### PR TITLE
Moar secrets

### DIFF
--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -6,7 +6,11 @@ import dj_database_url
 BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 DEBUG = TEMPLATE_DEBUG = True
 SITE_ID = 1
+<<<<<<< Updated upstream
 SECRET_KEY = 'hu9h&&%j*tcj2o9!k2w%ao=fcw&$0z$)la$&8vl+s$4y%r946h'
+=======
+SECRET_KEY = 'its-a-secret-to-everybody'
+>>>>>>> Stashed changes
 
 # Until Sentry works on Py3, do errors the old-fashioned way.
 ADMINS = [

--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -6,11 +6,7 @@ import dj_database_url
 BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 DEBUG = TEMPLATE_DEBUG = True
 SITE_ID = 1
-<<<<<<< Updated upstream
-SECRET_KEY = 'hu9h&&%j*tcj2o9!k2w%ao=fcw&$0z$)la$&8vl+s$4y%r946h'
-=======
 SECRET_KEY = 'its-a-secret-to-everybody'
->>>>>>> Stashed changes
 
 # Until Sentry works on Py3, do errors the old-fashioned way.
 ADMINS = [


### PR DESCRIPTION
The `SECRET_KEY` is replaced in production but we have to have some place holder so the Django test suite will run.
