### PR TITLE
Removed devfixture url unless the site is in DEBUG mode.

### DIFF
--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -50,7 +50,7 @@ urlpatterns = patterns('',
 
 if settings.DEBUG:
     # it's a secret to everyone
-    urlpatterns = patterns('',
+    urlpatterns += patterns('',
         url(r'^__secret/devfixture/$', 'pydotorg.views.get_dev_fixture', name='pydotorg-devfixture'),
     )
 

--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -44,12 +44,15 @@ urlpatterns = patterns('',
     # admin
     url(r'^admin/', include(admin.site.urls)),
 
-    # it's a secret to everyone
-    url(r'^__secret/devfixture/$', 'pydotorg.views.get_dev_fixture', name='pydotorg-devfixture'),
-
     # Fall back on CMS'd pages as the last resort.
     url(r'', include('pages.urls')),
 )
+
+if settings.DEBUG:
+    # it's a secret to everyone
+    urlpatterns = patterns('',
+        url(r'^__secret/devfixture/$', 'pydotorg.views.get_dev_fixture', name='pydotorg-devfixture'),
+    )
 
 urlpatterns += staticfiles_urlpatterns()
 


### PR DESCRIPTION
The devfixture url is useful in staging / dev but it's performance nightmare waiting to happen in production.
