### PR TITLE
Workaround for the test runner not resolving pytdotorg-devfixture url.

### DIFF
--- a/pydotorg/tests/test_views.py
+++ b/pydotorg/tests/test_views.py
@@ -1,11 +1,13 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.test.utils import override_settings
 
 
+@override_settings(DEBUG=True)
 class ViewTests(TestCase):
     urls = 'pydotorg.urls'
 
-    def test_sponsor_list(self):
+    def test_devfixture(self):
         url = reverse('pydotorg-devfixture')
         r = self.client.get(url)
         self.assertEqual(r.status_code, 200)

--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -44,15 +44,12 @@ urlpatterns = patterns('',
     # admin
     url(r'^admin/', include(admin.site.urls)),
 
+    # it's a secret to everyone
+    url(r'^__secret/devfixture/$', 'pydotorg.views.get_dev_fixture', name='pydotorg-devfixture'),
+
     # Fall back on CMS'd pages as the last resort.
     url(r'', include('pages.urls')),
 )
-
-if settings.DEBUG:
-    # it's a secret to everyone
-    urlpatterns += patterns('',
-        url(r'^__secret/devfixture/$', 'pydotorg.views.get_dev_fixture', name='pydotorg-devfixture'),
-    )
 
 urlpatterns += staticfiles_urlpatterns()
 

--- a/pydotorg/views.py
+++ b/pydotorg/views.py
@@ -2,17 +2,22 @@ import itertools
 
 from django.http import HttpResponse
 from django.core import serializers
-import sitetree.models
+from django.conf import settings
 
+import sitetree.models
 import boxes.models
 import feedbacks.models
 import pages.models
+
 
 def get_dev_fixture(request):
     response = HttpResponse(content_type='application/json')
     models = (sitetree.models.Tree, sitetree.models.TreeItem,
               boxes.models.Box, pages.models.Page,
               feedbacks.models.FeedbackCategory, feedbacks.models.IssueType)
-    objects = itertools.chain.from_iterable(M.objects.all() for M in models)
+    if settings.DEBUG:
+        objects = itertools.chain.from_iterable(M.objects.all() for M in models)
+    else:
+        objects = []
     serializers.serialize('json', objects, stream=response)
     return response


### PR DESCRIPTION
Workaround for the test runner not resolving pytdotorg-devfixture url.

Please wait until travis.ci gives this a :green_heart:
