### PR TITLE
don't crash if email=none in feedback form

### DIFF
--- a/feedbacks/forms.py
+++ b/feedbacks/forms.py
@@ -31,7 +31,7 @@ class FeedbackForm(ContentManageableModelForm):
         is_beta_tester = cleaned_data.get('is_beta_tester')
         email = cleaned_data.get('email')
 
-        if is_beta_tester and not len(email.strip()):
+        if is_beta_tester and (not email or not len(email.strip())):
             msg = 'An email address is required for beta testers.'
             self._errors['email'] = self.error_class([msg])
             del cleaned_data['email']


### PR DESCRIPTION
This fixes an error with validating the feedback form. I've received a couple of error emails with the following traceback:

```
Traceback (most recent call last):

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/core/handlers/base.py", line 115, in get_response
    response = callback(request, *callback_args, **callback_kwargs)

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/utils/decorators.py", line 25, in _wrapper
    return bound_func(*args, **kwargs)

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/views/decorators/csrf.py", line 77, in wrapped_view
    return view_func(*args, **kwargs)

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/utils/decorators.py", line 21, in bound_func
    return func(self, *args2, **kwargs2)

  File "/srv/redesign.python.org/releases/42188a649e88f71bdc7ddf1cc329f46a107eb628/feedbacks/views.py", line 26, in dispatch
    return super().dispatch(*args, **kwargs)

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/views/generic/base.py", line 86, in dispatch
    return handler(request, *args, **kwargs)

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/views/generic/edit.py", line 199, in post
    return super(BaseCreateView, self).post(request, *args, **kwargs)

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/views/generic/edit.py", line 164, in post
    if form.is_valid():

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/forms/forms.py", line 126, in is_valid
    return self.is_bound and not bool(self.errors)

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/forms/forms.py", line 117, in _get_errors
    self.full_clean()

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/forms/forms.py", line 273, in full_clean
    self._clean_form()

  File "/srv/redesign.python.org/shared/env/lib/python3.3/site-packages/django/forms/forms.py", line 299, in _clean_form
    self.cleaned_data = self.clean()

  File "/srv/redesign.python.org/releases/42188a649e88f71bdc7ddf1cc329f46a107eb628/feedbacks/forms.py", line 34, in clean
    if is_beta_tester and not len(email.strip()):

AttributeError: 'NoneType' object has no attribute 'strip'
```
