### PR TITLE
List upcoming events from the database on the homepage.

### DIFF
--- a/events/templatetags/events.py
+++ b/events/templatetags/events.py
@@ -1,0 +1,16 @@
+from django import template
+from django.utils import timezone
+
+from ..models import Event
+
+
+register = template.Library()
+
+
+@register.assignment_tag
+def get_events_upcoming(limit=5, only_featured=False):
+    qs = Event.objects.for_datetime(timezone.now()).order_by(
+        'occurring_rule__dt_start')
+    if only_featured:
+        qs.filter(featured=True)
+    return qs[:limit]

--- a/events/tests/test_views.py
+++ b/events/tests/test_views.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from ..models import Calendar, Event, EventCategory, EventLocation, RecurringRule
+from ..templatetags.events import get_events_upcoming
 
 
 class EventsViewsTests(TestCase):
@@ -131,3 +132,10 @@ class EventsViewsTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.event, response.context['object'])
+
+    def test_upcoming_tag(self):
+        self.assertEqual(len(get_events_upcoming()), 1)
+        self.rule.begin = self.now - datetime.timedelta(days=3)
+        self.rule.finish = self.now - datetime.timedelta(days=2)
+        self.rule.save()
+        self.assertEqual(len(get_events_upcoming()), 0)

--- a/templates/components/event-posts.html
+++ b/templates/components/event-posts.html
@@ -1,3 +1,4 @@
+{% load events %}
                         <div class="shrubbery">
                         
                             <h2 class="widget-title"><span aria-hidden="true" class="icon-calendar"></span>Upcoming Events</h2>
@@ -6,10 +7,11 @@
                             <!-- Need to hook these up and pull in 5 upcoming events -->
                             
                             <ul class="menu">
-                                <li><time datetime="">9/30<span class="say-no-more">/2012</span></time> <a href="#example">PyCon India 2012, PyCon UK 2012</a></li>
-                                <li><time datetime="">10/4<span class="say-no-more">/2012</span></time> <a href="#example">PyCon ZA 2012</a></li>
-                                <li><time datetime="">10/5<span class="say-no-more">/2012</span></time> <a href="#example">PyCon ZA 2012</a></li>
-                                <li><time datetime="">10/8<span class="say-no-more">/2012</span></time> <a href="#example">Plone Conference 2012, Plone Conference 2012</a></li>
-                                <li><time datetime="">10/30<span class="say-no-more">/2012</span></time> <a href="#example">Plone Conference 2012, Plone Conference 2012</a></li>
+                                {% get_events_upcoming limit=5 as events %}
+                                {% for event in events %}
+                                {% with event.next_time as next_time %}
+                                <li><time datetime="{{ next_time.dt_start|date:'c' }}">{{ next_time.dt_start|date:"SHORT_DATE_FORMAT"|slice:":5" }}<span class="say-no-more">/{{ next_time.dt_start|date:"Y" }}</span></time> <a href="{{ event.get_absolute_url }}">{{ event.title|striptags }}</a></li>
+                                {% endwith %}
+                                {% endfor %}
                             </ul>
                         </div>


### PR DESCRIPTION
There's a little bit of filter gymnastics to get SHORT_DATE_FORMAT to work with the say-no-more span, but it should display date/month order properly localized now.
