### PR TITLE
Never show non-published Releases on the /downloads/ pages.

### DIFF
--- a/downloads/managers.py
+++ b/downloads/managers.py
@@ -16,10 +16,10 @@ class ReleaseQuerySet(QuerySet):
             show_on_download_page=True).order_by('-release_date')
 
     def python2(self):
-        return self.filter(version=2)
+        return self.filter(version=2, is_published=True)
 
     def python3(self):
-        return self.filter(version=3)
+        return self.filter(version=3, is_published=True)
 
 
 class ReleaseManager(Manager):

--- a/downloads/tests/test_models.py
+++ b/downloads/tests/test_models.py
@@ -36,7 +36,7 @@ class DownloadModelTests(BaseDownloadTests):
 
     def test_python3(self):
         versions = Release.objects.python3()
-        self.assertEqual(len(versions), 2)
+        self.assertEqual(len(versions), 1)
         self.assertFalse(self.release_275 in versions)
-        self.assertTrue(self.draft_release in versions)
+        self.assertFalse(self.draft_release in versions)
         self.assertTrue(self.hidden_release in versions)


### PR DESCRIPTION
Fixes #162.
