### PR TITLE
order by companies by name, helps when viewing adding companies to jobs 

### DIFF
--- a/companies/models.py
+++ b/companies/models.py
@@ -19,3 +19,4 @@ class Company(NameSlugModel):
     class Meta:
         verbose_name = _('company')
         verbose_name_plural = _('companies')
+        ordering = ('name', )


### PR DESCRIPTION
Being able to view companies in order by name helps when entering a jobs to the new python site. 
