### PR TITLE
update form label for agency checkbox 

### DIFF
--- a/jobs/forms.py
+++ b/jobs/forms.py
@@ -37,7 +37,7 @@ class JobForm(ContentManageableModelForm):
         super().__init__(*args, **kwargs)
         self.fields['job_types'].help_text = None
         self.fields['telecommuting'].label = 'Is telecommuting allowed?'
-        self.fields['agencies'].label = 'Is job on behalf of an agency?'
+        self.fields['agencies'].label = 'Agencies are OK to contact?'
 
 
 class JobCommentForm(CommentForm):


### PR DESCRIPTION
As discussed on the jobs mailing list, the check box indicates whether an agency is ok to contact the poster in regards to the job, and not that it is on behalf of an agency.
