### PR TITLE
object.url is not being used for the href tag job link

### DIFF
--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -83,7 +83,7 @@
             <li><strong>E-mail contact</strong>: <a class="reference external" href="mailto:{{ object.email|urlencode }}">{{ object.email|render_email }}</a></li>
 
             {% if object.url %}
-            <li><strong>Web</strong>: <a class="reference external" href="{{ object.company.url }}">{{ object.url }}</a></li>
+            <li><strong>Web</strong>: <a class="reference external" href="{{ object.url }}">{{ object.url }}</a></li>
             {% endif %}
         </ul>
 


### PR DESCRIPTION
The company url is being used for the href tag, rather than the job link url.
