### PR TITLE
Job Board: amendments to submission form, admin and DB schema

### DIFF
--- a/jobs/admin.py
+++ b/jobs/admin.py
@@ -7,7 +7,7 @@ from cms.admin import NameSlugAdmin, ContentManageableModelAdmin
 class JobAdmin(ContentManageableModelAdmin):
     date_hierarchy = 'dt_start'
     filter_horizontal = ['job_types']
-    list_display = ['__str__', 'status', 'company']
+    list_display = ['__str__', 'status', 'company', 'company_name']
     list_filter = ['status', 'telecommuting']
     raw_id_fields = ['category', 'company']
 

--- a/jobs/forms.py
+++ b/jobs/forms.py
@@ -17,7 +17,7 @@ class JobForm(ContentManageableModelForm):
         fields = (
             'category',
             'job_types',
-            'company',
+            'company_name',
             'city',
             'region',
             'country',

--- a/jobs/forms.py
+++ b/jobs/forms.py
@@ -18,6 +18,7 @@ class JobForm(ContentManageableModelForm):
             'category',
             'job_types',
             'company_name',
+            'company_description',
             'city',
             'region',
             'country',

--- a/jobs/migrations/0010_auto__add_field_job_company_name__chg_field_job_company.py
+++ b/jobs/migrations/0010_auto__add_field_job_company_name__chg_field_job_company.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Job.company_name'
+        db.add_column('jobs_job', 'company_name',
+                      self.gf('django.db.models.fields.CharField')(blank=True, default='', max_length=100),
+                      keep_default=False)
+
+
+        # Changing field 'Job.company'
+        db.alter_column('jobs_job', 'company_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['companies.Company'], null=True))
+
+    def backwards(self, orm):
+        # Deleting field 'Job.company_name'
+        db.delete_column('jobs_job', 'company_name')
+
+
+        # User chose to not deal with backwards NULL issues for 'Job.company'
+        raise RuntimeError("Cannot reverse this migration. 'Job.company' and its values cannot be restored.")
+        
+        # The following code is provided here to aid in writing a correct migration
+        # Changing field 'Job.company'
+        db.alter_column('jobs_job', 'company_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['companies.Company']))
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'symmetrical': 'False', 'to': "orm['auth.Permission']"})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'companies.company': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Company'},
+            '_about_rendered': ('django.db.models.fields.TextField', [], {}),
+            'about': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'about_markup_type': ('django.db.models.fields.CharField', [], {'blank': 'True', 'default': "'restructuredtext'", 'max_length': '30'}),
+            'contact': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '100', 'null': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'blank': 'True', 'max_length': '75', 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'blank': 'True', 'max_length': '100', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'url': ('django.db.models.fields.URLField', [], {'blank': 'True', 'max_length': '200', 'null': 'True'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'jobs.job': {
+            'Meta': {'ordering': "('-created',)", 'object_name': 'Job'},
+            '_description_rendered': ('django.db.models.fields.TextField', [], {}),
+            '_requirements_rendered': ('django.db.models.fields.TextField', [], {}),
+            'agencies': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'jobs'", 'to': "orm['jobs.JobCategory']"}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['companies.Company']", 'blank': 'True', 'related_name': "'jobs'", 'null': 'True'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '100'}),
+            'contact': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '100', 'null': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '100'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.User']", 'blank': 'True', 'related_name': "'jobs_job_creator'", 'null': 'True'}),
+            'description': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'description_markup_type': ('django.db.models.fields.CharField', [], {'blank': 'True', 'default': "'restructuredtext'", 'max_length': '30'}),
+            'dt_end': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'null': 'True'}),
+            'dt_start': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'null': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_featured': ('django.db.models.fields.BooleanField', [], {'db_index': 'True', 'default': 'False'}),
+            'job_types': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['jobs.JobType']", 'blank': 'True', 'related_name': "'jobs'", 'symmetrical': 'False'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.User']", 'blank': 'True', 'related_name': "'jobs_job_modified'", 'null': 'True'}),
+            'location_slug': ('django.db.models.fields.SlugField', [], {'max_length': '350'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'requirements': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'requirements_markup_type': ('django.db.models.fields.CharField', [], {'blank': 'True', 'default': "'restructuredtext'", 'max_length': '30'}),
+            'status': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'default': "'draft'", 'max_length': '20'}),
+            'telecommuting': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'blank': 'True', 'max_length': '200', 'null': 'True'})
+        },
+        'jobs.jobcategory': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'JobCategory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'jobs.jobtype': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'JobType'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'users.user': {
+            'Meta': {'object_name': 'User'},
+            '_bio_rendered': ('django.db.models.fields.TextField', [], {}),
+            'bio': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'bio_markup_type': ('django.db.models.fields.CharField', [], {'blank': 'True', 'default': "'markdown'", 'max_length': '30'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'blank': 'True', 'max_length': '75'}),
+            'email_privacy': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'symmetrical': 'False', 'to': "orm['auth.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'search_visibility': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'symmetrical': 'False', 'to': "orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        }
+    }
+
+    complete_apps = ['jobs']

--- a/jobs/migrations/0011_auto__add_field_job_company_description__add_field_job_company_descrip.py
+++ b/jobs/migrations/0011_auto__add_field_job_company_description__add_field_job_company_descrip.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Job.company_description'
+        db.add_column('jobs_job', 'company_description',
+                      self.gf('markupfield.fields.MarkupField')(rendered_field=True, default='', blank=True),
+                      keep_default=False)
+
+        # Adding field 'Job.company_description_markup_type'
+        db.add_column('jobs_job', 'company_description_markup_type',
+                      self.gf('django.db.models.fields.CharField')(default='restructuredtext', max_length=30, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Job._company_description_rendered'
+        db.add_column('jobs_job', '_company_description_rendered',
+                      self.gf('django.db.models.fields.TextField')(default=''),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Job.company_description'
+        db.delete_column('jobs_job', 'company_description')
+
+        # Deleting field 'Job.company_description_markup_type'
+        db.delete_column('jobs_job', 'company_description_markup_type')
+
+        # Deleting field 'Job._company_description_rendered'
+        db.delete_column('jobs_job', '_company_description_rendered')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['auth.Permission']", 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'companies.company': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Company'},
+            '_about_rendered': ('django.db.models.fields.TextField', [], {}),
+            'about': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'about_markup_type': ('django.db.models.fields.CharField', [], {'default': "'restructuredtext'", 'max_length': '30', 'blank': 'True'}),
+            'contact': ('django.db.models.fields.CharField', [], {'null': 'True', 'max_length': '100', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'null': 'True', 'max_length': '75', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'null': 'True', 'max_length': '100', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'url': ('django.db.models.fields.URLField', [], {'null': 'True', 'max_length': '200', 'blank': 'True'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'jobs.job': {
+            'Meta': {'ordering': "('-created',)", 'object_name': 'Job'},
+            '_company_description_rendered': ('django.db.models.fields.TextField', [], {}),
+            '_description_rendered': ('django.db.models.fields.TextField', [], {}),
+            '_requirements_rendered': ('django.db.models.fields.TextField', [], {}),
+            'agencies': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'jobs'", 'to': "orm['jobs.JobCategory']"}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'jobs'", 'null': 'True', 'to': "orm['companies.Company']", 'blank': 'True'}),
+            'company_description': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'company_description_markup_type': ('django.db.models.fields.CharField', [], {'default': "'restructuredtext'", 'max_length': '30', 'blank': 'True'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'contact': ('django.db.models.fields.CharField', [], {'null': 'True', 'max_length': '100', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '100'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'jobs_job_creator'", 'null': 'True', 'to': "orm['users.User']", 'blank': 'True'}),
+            'description': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'description_markup_type': ('django.db.models.fields.CharField', [], {'default': "'restructuredtext'", 'max_length': '30', 'blank': 'True'}),
+            'dt_end': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'dt_start': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'job_types': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'jobs'", 'to': "orm['jobs.JobType']", 'symmetrical': 'False', 'blank': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'jobs_job_modified'", 'null': 'True', 'to': "orm['users.User']", 'blank': 'True'}),
+            'location_slug': ('django.db.models.fields.SlugField', [], {'max_length': '350'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'requirements': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'requirements_markup_type': ('django.db.models.fields.CharField', [], {'default': "'restructuredtext'", 'max_length': '30', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'draft'", 'db_index': 'True', 'max_length': '20'}),
+            'telecommuting': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'null': 'True', 'max_length': '200', 'blank': 'True'})
+        },
+        'jobs.jobcategory': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'JobCategory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'jobs.jobtype': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'JobType'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'users.user': {
+            'Meta': {'object_name': 'User'},
+            '_bio_rendered': ('django.db.models.fields.TextField', [], {}),
+            'bio': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'bio_markup_type': ('django.db.models.fields.CharField', [], {'default': "'markdown'", 'max_length': '30', 'blank': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'email_privacy': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['auth.Group']", 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'search_visibility': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['auth.Permission']", 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        }
+    }
+
+    complete_apps = ['jobs']

--- a/jobs/migrations/0012_auto__chg_field_job_company_description.py
+++ b/jobs/migrations/0012_auto__chg_field_job_company_description.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Job.company_description'
+        db.alter_column('jobs_job', 'company_description', self.gf('markupfield.fields.MarkupField')(null=True, rendered_field=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'Job.company_description'
+        db.alter_column('jobs_job', 'company_description', self.gf('markupfield.fields.MarkupField')(rendered_field=True, default=''))
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'to': "orm['auth.Permission']", 'symmetrical': 'False'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'companies.company': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Company'},
+            '_about_rendered': ('django.db.models.fields.TextField', [], {}),
+            'about': ('markupfield.fields.MarkupField', [], {'blank': 'True', 'rendered_field': 'True'}),
+            'about_markup_type': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30', 'default': "'restructuredtext'"}),
+            'contact': ('django.db.models.fields.CharField', [], {'null': 'True', 'blank': 'True', 'max_length': '100'}),
+            'email': ('django.db.models.fields.EmailField', [], {'null': 'True', 'blank': 'True', 'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'null': 'True', 'blank': 'True', 'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'url': ('django.db.models.fields.URLField', [], {'null': 'True', 'blank': 'True', 'max_length': '200'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'db_table': "'django_content_type'", 'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType'},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'jobs.job': {
+            'Meta': {'ordering': "('-created',)", 'object_name': 'Job'},
+            '_company_description_rendered': ('django.db.models.fields.TextField', [], {}),
+            '_description_rendered': ('django.db.models.fields.TextField', [], {}),
+            '_requirements_rendered': ('django.db.models.fields.TextField', [], {}),
+            'agencies': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'jobs'", 'to': "orm['jobs.JobCategory']"}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'jobs'", 'blank': 'True', 'null': 'True', 'to': "orm['companies.Company']"}),
+            'company_description': ('markupfield.fields.MarkupField', [], {'null': 'True', 'blank': 'True', 'rendered_field': 'True'}),
+            'company_description_markup_type': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30', 'default': "'restructuredtext'"}),
+            'company_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '100'}),
+            'contact': ('django.db.models.fields.CharField', [], {'null': 'True', 'blank': 'True', 'max_length': '100'}),
+            'country': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '100'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True', 'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'jobs_job_creator'", 'blank': 'True', 'null': 'True', 'to': "orm['users.User']"}),
+            'description': ('markupfield.fields.MarkupField', [], {'blank': 'True', 'rendered_field': 'True'}),
+            'description_markup_type': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30', 'default': "'restructuredtext'"}),
+            'dt_end': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'dt_start': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_featured': ('django.db.models.fields.BooleanField', [], {'db_index': 'True', 'default': 'False'}),
+            'job_types': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'jobs'", 'blank': 'True', 'to': "orm['jobs.JobType']", 'symmetrical': 'False'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'jobs_job_modified'", 'blank': 'True', 'null': 'True', 'to': "orm['users.User']"}),
+            'location_slug': ('django.db.models.fields.SlugField', [], {'max_length': '350'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'requirements': ('markupfield.fields.MarkupField', [], {'blank': 'True', 'rendered_field': 'True'}),
+            'requirements_markup_type': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30', 'default': "'restructuredtext'"}),
+            'status': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '20', 'default': "'draft'"}),
+            'telecommuting': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'null': 'True', 'blank': 'True', 'max_length': '200'})
+        },
+        'jobs.jobcategory': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'JobCategory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'jobs.jobtype': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'JobType'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'users.user': {
+            'Meta': {'object_name': 'User'},
+            '_bio_rendered': ('django.db.models.fields.TextField', [], {}),
+            'bio': ('markupfield.fields.MarkupField', [], {'blank': 'True', 'rendered_field': 'True'}),
+            'bio_markup_type': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30', 'default': "'markdown'"}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'blank': 'True', 'max_length': '75'}),
+            'email_privacy': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'to': "orm['auth.Group']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'search_visibility': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'to': "orm['auth.Permission']", 'symmetrical': 'False'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        }
+    }
+
+    complete_apps = ['jobs']

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -41,6 +41,7 @@ class Job(ContentManageable):
     company = models.ForeignKey('companies.Company', related_name='jobs', null=True, blank=True)
 
     company_name = models.CharField(max_length=100, blank=True)
+    company_description = MarkupField(blank=True, null=True, default_markup_type=DEFAULT_MARKUP_TYPE)
     city = models.CharField(max_length=100)
     region = models.CharField(max_length=100)
     country = models.CharField(max_length=100, db_index=True)
@@ -104,6 +105,11 @@ class Job(ContentManageable):
                 self.company = Company.objects.get(name=self.company_name)
             except Company.DoesNotExist:
                 self.company = None
+    
+        # If we didn't get some info in the company description and we have
+        # a company relation - store that on job now
+        if self.company and not self.company_description.raw.strip():
+            self.company_description.raw = self.company.about
 
         return super().save(**kwargs)
 

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -98,10 +98,12 @@ class Job(ContentManageable):
             self.dt_start = timezone.now()
             self.dt_end = timezone.now() + self.NEW_THRESHOLD
 
-        try:
-            self.company = Company.objects.get(name=self.company_name)
-        except Company.DoesNotExist:
-            self.company = None
+        # Try to get company relation on initial job creation
+        if self.pk is None:
+            try:
+                self.company = Company.objects.get(name=self.company_name)
+            except Company.DoesNotExist:
+                self.company = None
 
         return super().save(**kwargs)
 

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -37,8 +37,9 @@ class Job(ContentManageable):
 
     category = models.ForeignKey(JobCategory, related_name='jobs')
     job_types = models.ManyToManyField(JobType, related_name='jobs', blank=True)
-    company = models.ForeignKey('companies.Company', related_name='jobs')
+    company = models.ForeignKey('companies.Company', related_name='jobs', null=True, blank=True)
 
+    company_name = models.CharField(max_length=100, blank=True)
     city = models.CharField(max_length=100)
     region = models.CharField(max_length=100)
     country = models.CharField(max_length=100, db_index=True)

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -11,6 +11,7 @@ from markupfield.fields import MarkupField
 from .managers import JobManager
 from .listeners import on_comment_was_posted
 from cms.models import ContentManageable, NameSlugModel
+from companies.models import Company
 
 
 DEFAULT_MARKUP_TYPE = getattr(settings, 'DEFAULT_MARKUP_TYPE', 'restructuredtext')
@@ -96,6 +97,11 @@ class Job(ContentManageable):
         if not self.dt_start and self.status == self.STATUS_APPROVED:
             self.dt_start = timezone.now()
             self.dt_end = timezone.now() + self.NEW_THRESHOLD
+
+        try:
+            self.company = Company.objects.get(name=self.company_name)
+        except Company.DoesNotExist:
+            self.company = None
 
         return super().save(**kwargs)
 

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 from braces.views import LoginRequiredMixin, GroupRequiredMixin
 from django.contrib import messages
@@ -194,6 +195,11 @@ class JobCreate(JobMixin, CreateView):
         kwargs = super().get_form_kwargs()
         kwargs['request'] = self.request
         return kwargs
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['company_list'] = json.dumps(list(Company.objects.values_list('name', flat=True).order_by('name')))
+        return ctx
 
 
 class JobEdit(JobMixin, UpdateView):

--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -21,14 +21,13 @@
 {% block content %}
 {% load companies %}
 <article class="text">
-
 	<h1 class="listing-company">
         <span class="listing-company-name">
             {% if object.is_new %}<span class="listing-new">New</span>
             {% if user_can_edit %}<a href="{% url 'jobs:job_edit' pk=object.pk %}">Edit your listing</a>{% endif %}
-            {% endif %}<span class="company-name">{{ object.company.name }}</span>
+            {% endif %}<span class="company-name">{% firstof object.company.name object.company_name %}</span>
         </span>
-        <span class="listing-location"><a href="{% url 'jobs:job_list_location' slug=object.location_slug %}" title="More jobs in {{ object.city }}, {{ object.region }}">{{ object.city }}, {{ object.region }}, {{ object.country }}</a></span>
+        <span class="listing-location"><a href="{% if object.company %}{% url 'jobs:job_list_location' slug=object.location_slug %}{% else %}#{% endif %}" title="More jobs in {{ object.city }}, {{ object.region }}">{{ object.city }}, {{ object.region }}, {{ object.country }}</a></span>
     </h1>
 
     <!-- User input html/markup/rst/whatever -->
@@ -158,7 +157,7 @@
 
         <ul class="menu">
             {% for job in category_jobs %}
-            <li><a href="{% url 'jobs:job_list_company' slug=object.company.slug %}">{{ job.company.name }}, {{ job.city }}, {{ job.region }}, {{ job.country }}</a></li>
+            <li><a href="{% if object.company %}{% url 'jobs:job_list_company' slug=object.company.slug %}{% else %}#{% endif %}">{% firstof job.company.name job.company_name %}, {{ job.city }}, {{ job.region }}, {{ job.country }}</a></li>
             {% endfor %}
         </ul>
         {% endif %}

--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -25,7 +25,7 @@
         <span class="listing-company-name">
             {% if object.is_new %}<span class="listing-new">New</span>
             {% if user_can_edit %}<a href="{% url 'jobs:job_edit' pk=object.pk %}">Edit your listing</a>{% endif %}
-            {% endif %}<span class="company-name">{% firstof object.company.name object.company_name %}</span>
+            {% endif %}<span class="company-name">{% firstof object.company_name object.company.name %}</span>
         </span>
         <span class="listing-location"><a href="{% if object.company %}{% url 'jobs:job_list_location' slug=object.location_slug %}{% else %}#{% endif %}" title="More jobs in {{ object.city }}, {{ object.region }}">{{ object.city }}, {{ object.region }}, {{ object.country }}</a></span>
     </h1>
@@ -157,7 +157,7 @@
 
         <ul class="menu">
             {% for job in category_jobs %}
-            <li><a href="{% if object.company %}{% url 'jobs:job_list_company' slug=object.company.slug %}{% else %}#{% endif %}">{% firstof job.company.name job.company_name %}, {{ job.city }}, {{ job.region }}, {{ job.country }}</a></li>
+            <li><a href="{% if object.company %}{% url 'jobs:job_list_company' slug=object.company.slug %}{% else %}#{% endif %}">{% firstof job.company_name job.company.name %}, {{ job.city }}, {{ job.region }}, {{ job.country }}</a></li>
             {% endfor %}
         </ul>
         {% endif %}

--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load boxes %}
 
-{% block page_title %}Job Listing at {{ object.company.name }} | {{ SITE_INFO.site_name }}{% endblock %}
+{% block page_title %}Job Listing at {% firstof object.company_name object.company.name %} | {{ SITE_INFO.site_name }}{% endblock %}
 
 {% block body_attributes %}class="jobs default-page single-job"{% endblock %}
 
@@ -57,9 +57,9 @@
         {{ object.requirements }}
         {% endif %}
 
-        {% if object.company.about %}
+        {% if object.company_description %}
         <h2>About the Company</h2>
-        {{ object.company.about }}
+        {{ object.company_description }}
         {% endif %}
 
         {% if under_review or request.user == object.creator %}

--- a/templates/jobs/job_form.html
+++ b/templates/jobs/job_form.html
@@ -59,3 +59,14 @@
 
 </aside>
 {% endblock right_sidebar %}
+{% block javascript %}
+    {{ block.super }}
+    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
+    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+    <script>
+    $(function() {
+        var companyNames = {{ company_list|safe }}; 
+        $('#id_company_name').autocomplete({source: companyNames});
+    });
+    </script>
+{% endblock %}

--- a/templates/jobs/job_list.html
+++ b/templates/jobs/job_list.html
@@ -32,7 +32,7 @@
         <li>
             <h2 class="listing-company">
                 <span class="listing-company-name">
-                    {% if object.is_new %}<span class="listing-new">New</span> {% endif %}<a href="{{ object.get_absolute_url }}">{{ object.company.name }}</a>
+                    {% if object.is_new %}<span class="listing-new">New</span> {% endif %}<a href="{{ object.get_absolute_url }}">{% firstof object.company.name object.company_name %}</a>
                 </span>
                 <span class="listing-location"><a href="{% url 'jobs:job_list_location' slug=object.location_slug %}" title="More jobs in {{ object.city }}, {{ object.region }}">{{ object.city }}, {{ object.region }}, {{ object.country }}</a></span>
             </h2>

--- a/templates/jobs/job_list.html
+++ b/templates/jobs/job_list.html
@@ -32,11 +32,11 @@
         <li>
             <h2 class="listing-company">
                 <span class="listing-company-name">
-                    {% if object.is_new %}<span class="listing-new">New</span> {% endif %}<a href="{{ object.get_absolute_url }}">{% firstof object.company.name object.company_name %}</a>
+                    {% if object.is_new %}<span class="listing-new">New</span> {% endif %}<a href="{{ object.get_absolute_url }}">{% firstof object.company_name object.company.name %}</a>
                 </span>
                 <span class="listing-location"><a href="{% url 'jobs:job_list_location' slug=object.location_slug %}" title="More jobs in {{ object.city }}, {{ object.region }}">{{ object.city }}, {{ object.region }}, {{ object.country }}</a></span>
             </h2>
-            <span class="listing-job-type">{% for type in object.job_types.all %}<a href="{% url 'jobs:job_list_type' slug=type.slug %}" title="More Front-end Developer jobs">{{ type.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</span>
+            <span class="listing-job-type">{% for type in object.job_types.all %}<a href="{% url 'jobs:job_list_type' slug=type.slug %}" title="More {{ type.name }} jobs">{{ type.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</span>
             <span class="listing-posted"><time datetime="{{ object.created|date:"c" }}">{{ object.created|date:"d F Y" }}</time></span>
             <span class="listing-company-category"><a href="{% url 'jobs:job_list_category' slug=object.category.slug %}" title="More jobs in {{ object.category.name }}">{{ object.category.name }}</a></span>
         </li>


### PR DESCRIPTION
Enables job submission form to be usable without company being set up before hand by making dependencies on Company model optional... Adds company_name and company_description to Job model instead. Slight alterations to template to prioritise these fields over similar Company model fields.

Resolves most of https://github.com/python/pythondotorg/issues/246

Viewable at: http://pydotorg.sopython.com/newjobs and http://pydotorg.sopython.com/newjobs/create

Note: `./manage.py jobs migrate` is required...
