### PR TITLE
display property's for name and description with tests

### DIFF
--- a/jobs/admin.py
+++ b/jobs/admin.py
@@ -7,7 +7,7 @@ from cms.admin import NameSlugAdmin, ContentManageableModelAdmin
 class JobAdmin(ContentManageableModelAdmin):
     date_hierarchy = 'dt_start'
     filter_horizontal = ['job_types']
-    list_display = ['__str__', 'status', 'company']
+    list_display = ['__str__', 'status', 'company', 'company_name']
     list_filter = ['status', 'telecommuting']
     raw_id_fields = ['category', 'company']
 

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -72,7 +72,7 @@ class Job(ContentManageable):
         (STATUS_REMOVED, 'removed'),
         (STATUS_EXPIRED, 'expired'),
     )
-    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=STATUS_DRAFT, db_index=True)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=STATUS_REVIEW, db_index=True)
     dt_start = models.DateTimeField('Job start date', blank=True, null=True)
     dt_end = models.DateTimeField('Job end date', blank=True, null=True)
 
@@ -104,6 +104,16 @@ class Job(ContentManageable):
 
     def get_absolute_url(self):
         return reverse('jobs:job_detail', kwargs={'pk': self.pk})
+
+    @property
+    def display_name(self):
+        return self.company_name or getattr(self.company, 'name', '')
+
+    @property
+    def display_description(self):
+        if self.company_description.raw.strip():
+            return self.company_description
+        return getattr(self.company, 'about', '')
 
     @property
     def is_new(self):

--- a/jobs/tests/test_models.py
+++ b/jobs/tests/test_models.py
@@ -35,9 +35,9 @@ class JobsModelsTests(TestCase):
         self.assertEqual(Job.objects.archived().count(), 1)
 
     def test_draft_manager(self):
-        self.assertEqual(Job.objects.draft().count(), 1)
+        self.assertEqual(Job.objects.draft().count(), 0)
         factories.DraftJobFactory()
-        self.assertEqual(Job.objects.draft().count(), 2)
+        self.assertEqual(Job.objects.draft().count(), 1)
 
     def test_expired_manager(self):
         self.assertEqual(Job.objects.expired().count(), 0)
@@ -55,6 +55,6 @@ class JobsModelsTests(TestCase):
         self.assertEqual(Job.objects.removed().count(), 1)
 
     def test_review_manager(self):
-        self.assertEqual(Job.objects.review().count(), 0)
-        factories.ReviewJobFactory()
         self.assertEqual(Job.objects.review().count(), 1)
+        factories.ReviewJobFactory()
+        self.assertEqual(Job.objects.review().count(), 2)

--- a/jobs/tests/test_views.py
+++ b/jobs/tests/test_views.py
@@ -193,7 +193,7 @@ class JobsViewTests(TestCase):
         self.assertNotEqual(job.updated, None)
         self.assertEqual(job.creator, None)
 
-        self.assertEqual(job.status, 'draft')
+        self.assertEqual(job.status, 'review')
 
     def test_job_types(self):
         job_type2 = JobTypeFactory(
@@ -240,6 +240,24 @@ class JobsViewTests(TestCase):
         content = str(response.content)
         self.assertTrue('Memphis' in content)
         self.assertFalse('Lawrence' in content)
+
+    def test_job_display_name(self):
+        self.assertEqual(self.job.display_name, self.job.company.name)
+
+        self.job.company_name = 'ABC'
+        self.assertEqual(self.job.display_name, self.job.company_name)
+
+        self.job.company_name = ''
+        self.assertEqual(self.job.display_name, self.job.company.name)
+
+    def test_job_display_about(self):
+        self.assertEqual(self.job.display_description.raw, self.job.company.about.raw)
+
+        self.job.company_description.raw = 'XYZ'
+        self.assertEqual(self.job.display_description.raw, self.job.company_description.raw)
+
+        self.job.company_description = '     '
+        self.assertEqual(self.job.display_description.raw, self.job.company.about.raw)        
 
 
 class JobsReviewTests(TestCase):


### PR DESCRIPTION
~~**HOLD**  pending resolution of https://github.com/python/pythondotorg/issues/324~~
- Adds properties to Job model for choosing which company name/company about to display. 
- Additional tests relating to above
- Closes https://github.com/python/pythondotorg/issues/302
