### PR TITLE
Job Board: add country slug field

### DIFF
--- a/jobs/migrations/0014_auto__add_field_job_country_slug.py
+++ b/jobs/migrations/0014_auto__add_field_job_country_slug.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Job.country_slug'
+        db.add_column('jobs_job', 'country_slug',
+                      self.gf('django.db.models.fields.SlugField')(max_length=100, default=''),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Job.country_slug'
+        db.delete_column('jobs_job', 'country_slug')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'blank': 'True', 'to': "orm['auth.Permission']"})
+        },
+        'auth.permission': {
+            'Meta': {'object_name': 'Permission', 'unique_together': "(('content_type', 'codename'),)", 'ordering': "('content_type__app_label', 'content_type__model', 'codename')"},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'companies.company': {
+            'Meta': {'object_name': 'Company', 'ordering': "('name',)"},
+            '_about_rendered': ('django.db.models.fields.TextField', [], {}),
+            'about': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'about_markup_type': ('django.db.models.fields.CharField', [], {'max_length': '30', 'default': "'restructuredtext'", 'blank': 'True'}),
+            'contact': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True', 'null': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True', 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True', 'null': 'True'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'object_name': 'ContentType', 'unique_together': "(('app_label', 'model'),)", 'ordering': "('name',)", 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'jobs.job': {
+            'Meta': {'object_name': 'Job', 'ordering': "('-created',)"},
+            '_company_description_rendered': ('django.db.models.fields.TextField', [], {}),
+            '_description_rendered': ('django.db.models.fields.TextField', [], {}),
+            '_requirements_rendered': ('django.db.models.fields.TextField', [], {}),
+            'agencies': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'jobs'", 'to': "orm['jobs.JobCategory']"}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'company': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'jobs'", 'null': 'True', 'to': "orm['companies.Company']"}),
+            'company_description': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'company_description_markup_type': ('django.db.models.fields.CharField', [], {'max_length': '30', 'default': "'restructuredtext'", 'blank': 'True'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True', 'null': 'True'}),
+            'contact': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True', 'null': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '100'}),
+            'country_slug': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'jobs_job_creator'", 'null': 'True', 'to': "orm['users.User']"}),
+            'description': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'description_markup_type': ('django.db.models.fields.CharField', [], {'max_length': '30', 'default': "'restructuredtext'", 'blank': 'True'}),
+            'dt_end': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'null': 'True'}),
+            'dt_start': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'null': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_featured': ('django.db.models.fields.BooleanField', [], {'db_index': 'True', 'default': 'False'}),
+            'job_title': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True', 'null': 'True'}),
+            'job_types': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'jobs'", 'blank': 'True', 'symmetrical': 'False', 'to': "orm['jobs.JobType']"}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'jobs_job_modified'", 'null': 'True', 'to': "orm['users.User']"}),
+            'location_slug': ('django.db.models.fields.SlugField', [], {'max_length': '350'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'requirements': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'requirements_markup_type': ('django.db.models.fields.CharField', [], {'max_length': '30', 'default': "'restructuredtext'", 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '20', 'default': "'review'"}),
+            'telecommuting': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True', 'null': 'True'})
+        },
+        'jobs.jobcategory': {
+            'Meta': {'object_name': 'JobCategory', 'ordering': "('name',)"},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'jobs.jobtype': {
+            'Meta': {'object_name': 'JobType', 'ordering': "('name',)"},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'users.user': {
+            'Meta': {'object_name': 'User'},
+            '_bio_rendered': ('django.db.models.fields.TextField', [], {}),
+            'bio': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'bio_markup_type': ('django.db.models.fields.CharField', [], {'max_length': '30', 'default': "'markdown'", 'blank': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'email_privacy': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'blank': 'True', 'to': "orm['auth.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'search_visibility': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'blank': 'True', 'to': "orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        }
+    }
+
+    complete_apps = ['jobs']

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -47,6 +47,7 @@ class Job(ContentManageable):
     region = models.CharField(max_length=100)
     country = models.CharField(max_length=100, db_index=True)
     location_slug = models.SlugField(max_length=350, editable=False)
+    country_slug = models.SlugField(max_length=100, editable=False)
 
     description = MarkupField(blank=True, default_markup_type=DEFAULT_MARKUP_TYPE)
     requirements = MarkupField(blank=True, default_markup_type=DEFAULT_MARKUP_TYPE)
@@ -95,6 +96,7 @@ class Job(ContentManageable):
 
     def save(self, **kwargs):
         self.location_slug = slugify('%s %s %s' % (self.city, self.region, self.country))
+        self.country_slug = slugify(self.country)
 
         if not self.dt_start and self.status == self.STATUS_APPROVED:
             self.dt_start = timezone.now()


### PR DESCRIPTION
Adds new field to Job model to enable filtering and selection by country. City/Region/Country is far too specific for any practical purpose of filtering.

Note: **requires migration to be run**
