### PR TITLE
Get content from SVN if no local checkout

### DIFF
--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -2,7 +2,14 @@ from .base import *
 
 DEBUG = True
 TEMPLATE_DEBUG = True
-PYTHON_ORG_CONTENT_SVN_PATH='/Users/flavio/working_copies/beta.python.org/build/data'
+
+# If you have an existing SVN checkout locally, put the path below.
+#PYTHON_ORG_CONTENT_SVN_PATH=''
+
+PYTHON_ORG_CONTENT_SVN_URL='https://svn.python.org/www/trunk/beta.python.org'
+
+# Local path where the SVN checkout will be stored. Defaults to '/tmp'.
+#SVN_CHECKOUT_PATH=''
 
 HAYSTACK_CONNECTIONS = {
     'default': {


### PR DESCRIPTION
Replace PYTHON_ORG_CONTENT_SVN_PATH with commented-out empty string.
Add PYTHON_ORG_CONTENT_SVN_URL variable. Defaults to beta.python.org SVN
If no local path exists, default action is to checkout to /tmp and build

Fixes #369

I'm sure this breaks on Windows. Someone with Windows experience could improve it by adding a similar temporary directory there.
