### PR TITLE
Add head block to base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -114,7 +114,7 @@
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
     })();
     </script>
-
+    {% block head %}{% endblock %}
 </head>
 
 <body {% block body_attributes %}{% endblock %}>


### PR DESCRIPTION
Allow apps to extend the head tag further - for instance, the job board app utilises jquery autocomplete which requires a stylesheet and script inclusion. 

While the script can be added to the end of the required template, the link tag should be inside the head.
