### PR TITLE
Fix use of object.company in the jobs app

### DIFF
--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -26,7 +26,7 @@
         <span class="listing-company-name">
             {% if object.is_new %}<span class="listing-new">New</span>
             {% if user_can_edit %}<a href="{% url 'jobs:job_edit' pk=object.pk %}">Edit your listing</a>{% endif %}
-            {% endif %}<span class="company-name">{{ object.company.name }}</span>
+            {% endif %}<span class="company-name">{{ object.display_name }}</span>
         </span>
         <span class="listing-location"><a href="{% url 'jobs:job_list_location' slug=object.location_slug %}" title="More jobs in {{ object.city }}, {{ object.region }}">{{ object.city }}, {{ object.region }}, {{ object.country }}</a></span>
     </h1>
@@ -62,9 +62,9 @@
         {{ object.requirements }}
         {% endif %}
 
-        {% if object.company.about %}
+        {% if object.display_description %}
         <h2>About the Company</h2>
-        {{ object.company.about }}
+        {{ object.display_description }}
         {% endif %}
 
         {% if under_review or request.user == object.creator %}
@@ -115,7 +115,7 @@
     <div class="job-post-meta">
         <p class="job-meta">
             <!-- Company URL -->
-            {% if object.company.url %}
+            {% if object.company %}
             <span class="company-link"><a href="{{ object.company.url }}">{{ object.company.url }}</a></span>
             {% endif %}
 
@@ -143,7 +143,7 @@
         <a class="prev-button" href="{{ previous.get_absolute_url }}">
             <span class="prev-button-text"><span class="icon-arrow-left"><span>&larr;</span></span> Previous</span>
             <span class="prevnext-description">
-                <span class="company-name">{{ previous.company.name }}</span> in <span class="company-location">{{ previous.city }}, {{ previous.region }}, {{ previous.country }}</span>
+                <span class="company-name">{{ previous.display_name }}</span> in <span class="company-location">{{ previous.city }}, {{ previous.region }}, {{ previous.country }}</span>
             </span>
         </a>
         {% else %}
@@ -158,7 +158,7 @@
         <a class="next-button" href="{{ next.get_absolute_url }}">
             <span class="next-button-text">Next <span class="icon-arrow-right"><span>&rarr;</span></span></span>
             <span class="prevnext-description">
-                <span class="company-name">{{ next.company.name }}</span> in <span class="company-location">{{ next.city }}, {{ next.region }}, {{ next.country }}</span>
+                <span class="company-name">{{ next.display_name }}</span> in <span class="company-location">{{ next.city }}, {{ next.region }}, {{ next.country }}</span>
             </span>
         </a>
         {% else %}
@@ -180,7 +180,7 @@
 
         <ul class="menu">
             {% for job in category_jobs %}
-            <li><a href="{% url 'jobs:job_list_company' slug=object.company.slug %}">{{ job.company.name }}, {{ job.city }}, {{ job.region }}, {{ job.country }}</a></li>
+            <li><a href="{% url 'jobs:job_list_company' slug=object.company.slug %}">{{ job.display_name }}, {{ job.city }}, {{ job.region }}, {{ job.country }}</a></li>
             {% endfor %}
         </ul>
         {% endif %}

--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load boxes %}
 
-{% block page_title %}Job Listing at {{ object.company.name }} | {{ SITE_INFO.site_name }}{% endblock %}
+{% block page_title %}Job Listing at {{ object.display_name }} | {{ SITE_INFO.site_name }}{% endblock %}
 
 {% block body_attributes %}class="jobs default-page single-job"{% endblock %}
 
@@ -179,9 +179,11 @@
         <h3 class="widget-title">More jobs in <a href="{% url 'jobs:job_list_category' slug=object.category.slug %}">{{ object.category.name }}</a></h3>
 
         <ul class="menu">
-            {% for job in category_jobs %}
-            <li><a href="{% url 'jobs:job_list_company' slug=object.company.slug %}">{{ job.display_name }}, {{ job.city }}, {{ job.region }}, {{ job.country }}</a></li>
-            {% endfor %}
+            {% if object.company %}
+                {% for job in category_jobs %}
+                <li><a href="{% url 'jobs:job_list_company' slug=object.company.slug %}">{{ job.display_name }}, {{ job.city }}, {{ job.region }}, {{ job.country }}</a></li>
+                {% endfor %}
+            {% endif %}
         </ul>
         {% endif %}
     </div>

--- a/templates/jobs/job_list.html
+++ b/templates/jobs/job_list.html
@@ -32,7 +32,7 @@
         <li>
             <h2 class="listing-company">
                 <span class="listing-company-name">
-                    {% if object.is_new %}<span class="listing-new">New</span> {% endif %}<a href="{{ object.get_absolute_url }}">{{ object.company.name }}</a>
+                    {% if object.is_new %}<span class="listing-new">New</span> {% endif %}<a href="{{ object.get_absolute_url }}">{{ object.display_name }}</a>
                 </span>
                 <span class="listing-location"><a href="{% url 'jobs:job_list_location' slug=object.location_slug %}" title="More jobs in {{ object.city }}, {{ object.region }}">{{ object.city }}, {{ object.region }}, {{ object.country }}</a></span>
             </h2>

--- a/templates/jobs/job_review.html
+++ b/templates/jobs/job_review.html
@@ -26,8 +26,8 @@
     <tr>
         <td><a href="{% url 'jobs:job_detail_review' pk=object.pk %}">{{ object.pk }}</a></td>
         <td>
-            <p><strong>Company:</strong> {{ object.company.name }}</p>
-            {{ object.description|truncatewords:"50" }}
+            <p><strong>Company:</strong> {{ object.display_name }}</p>
+            {{ object.display_description|truncatewords:"50" }}
         </td>
         <td>{{ object.status }}</td>
         <td>

--- a/templates/jobs/job_review.html
+++ b/templates/jobs/job_review.html
@@ -27,7 +27,7 @@
         <td><a href="{% url 'jobs:job_detail_review' pk=object.pk %}">{{ object.pk }}</a></td>
         <td>
             <p><strong>Company:</strong> {{ object.display_name }}</p>
-            {{ object.display_description|truncatewords:"50" }}
+            {{ object.description|truncatewords:"50" }}
         </td>
         <td>{{ object.status }}</td>
         <td>


### PR DESCRIPTION
object.company can be None, so special care has to be taken when using it without testing for None. object.display_name and object.display_description provide a safe way to access the company name and description.
