### PR TITLE
Remove redundant numbered parameters in str.format() on Python 3.

### DIFF
--- a/blogs/admin.py
+++ b/blogs/admin.py
@@ -21,9 +21,9 @@ class ContributorAdmin(ContentManageableModelAdmin):
 
     def _display_name(self, obj):
         if obj.user.first_name or obj.user.last_name:
-            return "{0} {1}".format(obj.user.first_name, obj.user.last_name)
+            return "{} {}".format(obj.user.first_name, obj.user.last_name)
         else:
-            return "{0} (PK#{1})".format(obj.user.username, obj.user.pk)
+            return "{} (PK#{})".format(obj.user.username, obj.user.pk)
 
 admin.site.register(Contributor, ContributorAdmin)
 

--- a/blogs/models.py
+++ b/blogs/models.py
@@ -63,7 +63,7 @@ class Contributor(ContentManageable):
 
     def get_display_name(self):
         if self.user.first_name or self.user.last_name:
-            return """{0} {1}""".format(self.user.first_name, self.user.last_name)
+            return """{} {}""".format(self.user.first_name, self.user.last_name)
         else:
             return self.user.username
 

--- a/blogs/tests/test_parser.py
+++ b/blogs/tests/test_parser.py
@@ -8,7 +8,7 @@ class BlogParserTest(TestCase):
 
     def setUp(self):
         self.test_file_path = get_test_rss_path()
-        self.entries = get_all_entries("file://{0}".format(self.test_file_path))
+        self.entries = get_all_entries("file://{}".format(self.test_file_path))
 
     def test_entries(self):
         """ Make sure we can parse RSS entries """

--- a/community/models.py
+++ b/community/models.py
@@ -59,7 +59,7 @@ class Post(ContentManageable):
         ordering = ['-created']
 
     def __str__(self):
-        return 'Post {0} ({1})'.format(self.get_media_type_display(), self.pk)
+        return 'Post {} ({})'.format(self.get_media_type_display(), self.pk)
 
     def get_absolute_url(self):
         return reverse('community:post_detail', kwargs={'pk': self.pk})
@@ -76,7 +76,7 @@ class Link(ContentManageable):
         ordering = ['-created']
 
     def __str__(self):
-        return 'Link ({0})'.format(self.pk)
+        return 'Link ({})'.format(self.pk)
 
 
 class Photo(ContentManageable):
@@ -93,7 +93,7 @@ class Photo(ContentManageable):
         ordering = ['-created']
 
     def __str__(self):
-        return 'Photo ({0})'.format(self.pk)
+        return 'Photo ({})'.format(self.pk)
 
 
 class Video(ContentManageable):
@@ -110,4 +110,4 @@ class Video(ContentManageable):
         ordering = ['-created']
 
     def __str__(self):
-        return 'Video ({0})'.format(self.pk)
+        return 'Video ({})'.format(self.pk)

--- a/companies/factories.py
+++ b/companies/factories.py
@@ -11,5 +11,5 @@ class CompanyFactory(factory.DjangoModelFactory):
     FACTORY_FOR = Company
     FACTORY_DJANGO_GET_OR_CREATE = ('name',)
 
-    name = factory.Sequence(lambda n: 'Company {0}'.format(n))
-    email = factory.Sequence(lambda n: 'zombie_{0}@python.org'.format(n))
+    name = factory.Sequence(lambda n: 'Company {}'.format(n))
+    email = factory.Sequence(lambda n: 'zombie_{}@python.org'.format(n))

--- a/jobs/factories.py
+++ b/jobs/factories.py
@@ -8,14 +8,14 @@ class JobCategoryFactory(factory.DjangoModelFactory):
     FACTORY_FOR = JobCategory
     FACTORY_DJANGO_GET_OR_CREATE = ('name',)
 
-    name = factory.Sequence(lambda n: 'Job Category {0}'.format(n))
+    name = factory.Sequence(lambda n: 'Job Category {}'.format(n))
 
 
 class JobTypeFactory(factory.DjangoModelFactory):
     FACTORY_FOR = JobType
     FACTORY_DJANGO_GET_OR_CREATE = ('name',)
 
-    name = factory.Sequence(lambda n: 'Job Type {0}'.format(n))
+    name = factory.Sequence(lambda n: 'Job Type {}'.format(n))
 
 
 class JobFactory(factory.DjangoModelFactory):

--- a/jobs/listeners.py
+++ b/jobs/listeners.py
@@ -53,7 +53,7 @@ def send_job_review_message(job, user, subject_template_path,
     """
     subject_template = loader.get_template(subject_template_path)
     message_template = loader.get_template(message_template_path)
-    reviewer_name = '{0} {1}'.format(user.first_name, user.last_name)
+    reviewer_name = '{} {}'.format(user.first_name, user.last_name)
     message_context = Context({'addressee': job.contact,
                                'reviewer_name': reviewer_name,
                               })

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -94,7 +94,7 @@ class Job(ContentManageable):
         permissions = [('can_moderate_jobs', 'Can moderate Job listings')]
 
     def __str__(self):
-        return 'Job Listing #{0}'.format(self.pk)
+        return 'Job Listing #{}'.format(self.pk)
 
     def save(self, **kwargs):
         self.location_slug = slugify('%s %s %s' % (self.city, self.region, self.country))

--- a/pages/management/commands/import_pages_from_svn.py
+++ b/pages/management/commands/import_pages_from_svn.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
             try:
                 data = parse_page(os.path.dirname(match))
             except Exception as e:
-                print("Unable to parse {0}".format(match))
+                print("Unable to parse {}".format(match))
                 traceback.print_exc()
                 continue
 
@@ -108,6 +108,6 @@ class Command(BaseCommand):
                 page_obj, _ = Page.objects.get_or_create(path=path, defaults=defaults)
                 self.save_images(path, page_obj)
             except Exception as e:
-                print("Unable to create Page object for {0}".format(match))
+                print("Unable to create Page object for {}".format(match))
                 traceback.print_exc()
                 continue

--- a/pages/models.py
+++ b/pages/models.py
@@ -64,7 +64,7 @@ class Page(ContentManageable):
         return self.title
 
     def get_absolute_url(self):
-        return "/{0}/".format(self.path)
+        return "/{}/".format(self.path)
 
 
 def page_image_path(instance, filename):

--- a/peps/converters.py
+++ b/peps/converters.py
@@ -48,7 +48,7 @@ def convert_pep0():
         if not m:
             continue
 
-        b.attrs['href'] = '/dev/peps/pep-{0}/'.format(m.group(1))
+        b.attrs['href'] = '/dev/peps/pep-{}/'.format(m.group(1))
 
     return ''.join([header.prettify(), pep_content.prettify()])
 
@@ -109,7 +109,7 @@ def convert_pep_page(pep_number, content):
                 t.parent.extract()
 
         if not data['title']:
-            data['title'] = "PEP {0}".format(pep_number)
+            data['title'] = "PEP {}".format(pep_number)
 
         data['content'] = soup.prettify()
 
@@ -121,13 +121,13 @@ def get_pep_page(pep_number, commit=True):
     Given a pep_number retrieve original PEP source text, rst, or html.
     Get or create the associated Page and return it
     """
-    pep_path = os.path.join(settings.PEP_REPO_PATH, 'pep-{0}.html'.format(pep_number))
+    pep_path = os.path.join(settings.PEP_REPO_PATH, 'pep-{}.html'.format(pep_number))
     if not os.path.exists(pep_path):
-        print("PEP Path '{0}' does not exist, skipping".format(pep_path))
+        print("PEP Path '{}' does not exist, skipping".format(pep_path))
 
     pep_content = convert_pep_page(pep_number, open(pep_path).read())
 
-    pep_url = 'dev/peps/pep-{0}/'.format(pep_number)
+    pep_url = 'dev/peps/pep-{}/'.format(pep_number)
     pep_page, _ = Page.objects.get_or_create(path=pep_url)
 
     pep_page.title = pep_content['title']

--- a/peps/management/commands/generate_pep_pages.py
+++ b/peps/management/commands/generate_pep_pages.py
@@ -41,15 +41,15 @@ class Command(NoArgsCommand):
 
             # Skip files we aren't looking for
             if not f.startswith('pep-') or not f.endswith('.html'):
-                verbose("- Skipping non-PEP file '{0}'".format(f))
+                verbose("- Skipping non-PEP file '{}'".format(f))
                 continue
 
-            verbose("Generating PEP Page from '{0}'".format(f))
+            verbose("Generating PEP Page from '{}'".format(f))
             pep_match = pep_number_re.match(f)
             if pep_match:
                 pep_number = pep_match.groups(1)[0]
                 p = get_pep_page(pep_number)
             else:
-                verbose("- Skipping invalid {0}'".format(f))
+                verbose("- Skipping invalid {}'".format(f))
 
         verbose("== Finished")

--- a/successstories/models.py
+++ b/successstories/models.py
@@ -62,7 +62,7 @@ class Story(NameSlugModel, ContentManageable):
 
     def get_weight_display(self):
         """ Display more useful weight with percent sign in admin """
-        return "{0} %".format(self.weight)
+        return "{} %".format(self.weight)
     get_weight_display.short_description = 'Weight'
 
     def get_company_name(self):

--- a/users/factories.py
+++ b/users/factories.py
@@ -7,7 +7,7 @@ class UserFactory(factory.DjangoModelFactory):
     FACTORY_FOR = User
     FACTORY_DJANGO_GET_OR_CREATE = ('username',)
 
-    username = factory.Sequence(lambda n: 'zombie{0}'.format(n))
+    username = factory.Sequence(lambda n: 'zombie{}'.format(n))
     email = factory.Sequence(lambda n: "zombie%s@example.com" % n)
     #password = ?
     search_visibility = User.SEARCH_PUBLIC


### PR DESCRIPTION
This was only necessary on Python 2.6.
