### PR TITLE
Use Sqlite3 in development environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log
 *.pot
 *.pyc
+*.db
 __pycache__
 .vagrant
 build

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -15,3 +15,7 @@ HAYSTACK_CONNECTIONS = {
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 PEP_REPO_PATH = '/Users/frank/work/src/pythondotorg/tmp/peps'
+
+DATABASES = {
+    'default': dj_database_url.parse('sqlite:///pydotorg.db')
+}


### PR DESCRIPTION
This is more helpful for contributors, especially if they don't want to
install Vagrant.
