### PR TITLE
Consistent footnote number width.

### DIFF
--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1285,6 +1285,10 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
     border-bottom: 1px solid darken($grey-lighterest, 5%);
 }
 
+.footnote .label {
+    width: 4em;
+}
+
 /*dl*/ .info-key {
 
     dt, dd {


### PR DESCRIPTION
Fixes #499 

I'm not 100% sure I put this in the right spot, but it does fix the issue. Before / After screenshots below. Edited the html to show that there's plenty of room for larger numbers.
## Before

![screen shot 2014-11-27 at 6 16 35 pm](https://cloud.githubusercontent.com/assets/3853/5220157/8ebbc046-7661-11e4-9145-4267c23297ec.png)
## After

![screen shot 2014-11-27 at 6 16 19 pm](https://cloud.githubusercontent.com/assets/3853/5220158/8ec3813c-7661-11e4-86f6-bda261ad149a.png)
