### PR TITLE
Use the generated index for pep-0000 as well.

### DIFF
--- a/peps/converters.py
+++ b/peps/converters.py
@@ -64,18 +64,23 @@ def convert_pep0():
 def get_pep0_page(commit=True):
     """
     Using convert_pep0 above, create a CMS ready pep0 page and return it
+
+    pep0 is used as the directory index, but it's also an actual pep, so we
+    return both Page objects.
     """
     pep0_content = convert_pep0()
     pep0_page, _ = Page.objects.get_or_create(path='dev/peps/')
-    pep0_page.content = pep0_content
-    pep0_page.content_markup_type = 'html'
-    pep0_page.title = "PEP 0 -- Index of Python Enhancement Proposals (PEPs)"
-    pep0_page.template_name = PEP_TEMPLATE
+    pep0000_page, _ = Page.objects.get_or_create(path='dev/peps/pep-0000/')
+    for page in [pep0_page, pep0000_page]:
+        page.content = pep0_content
+        page.content_markup_type = 'html'
+        page.title = "PEP 0 -- Index of Python Enhancement Proposals (PEPs)"
+        page.template_name = PEP_TEMPLATE
 
-    if commit:
-        pep0_page.save()
+        if commit:
+            page.save()
 
-    return pep0_page
+    return pep0_page, pep0000_page
 
 
 def fix_headers(soup, data):

--- a/peps/management/commands/generate_pep_pages.py
+++ b/peps/management/commands/generate_pep_pages.py
@@ -34,7 +34,7 @@ class Command(NoArgsCommand):
         verbose("== Starting PEP page generation")
 
         verbose("Generating PEP0 index page")
-        pep0_page = get_pep0_page()
+        pep0_page, _ = get_pep0_page()
 
         # Find pep pages
         for f in os.listdir(settings.PEP_REPO_PATH):
@@ -42,6 +42,10 @@ class Command(NoArgsCommand):
             # Skip files we aren't looking for
             if not f.startswith('pep-') or not f.endswith('.html'):
                 verbose("- Skipping non-PEP file '{}'".format(f))
+                continue
+
+            if 'pep-0000.html' in f:
+                verbose("- Skipping duplicate PEP0 index")
                 continue
 
             verbose("Generating PEP Page from '{}'".format(f))

--- a/peps/tests/test_converters.py
+++ b/peps/tests/test_converters.py
@@ -15,3 +15,10 @@ class PEPConverterTests(TestCase):
 
         with self.assertRaises(ImproperlyConfigured):
             get_pep0_page()
+
+
+    def test_get_pep0_page__generates_both_pages(self):
+        index, pep0 = get_pep0_page()
+
+        self.assertEqual(index.path, "dev/peps/")
+        self.assertEqual(pep0.path, "dev/peps/pep-0000/")


### PR DESCRIPTION
Fixes #506 

We were previously generating the pep index page from pep0, but using the pep0 that came over from the peps repository. Instead, use the generated version with fixed links.
