### PR TITLE
Vagrant  migrations

### DIFF
--- a/chef/cookbooks/pythondotorg/recipes/project.rb
+++ b/chef/cookbooks/pythondotorg/recipes/project.rb
@@ -41,11 +41,10 @@ execute "#{manage_py} syncdb --noinput" do
   cwd "#{deploy_location}/pythondotorg/"
 end
 
-# Can't have migrations until South is in Python 3...
-# execute "#{manage_py} migrate" do
-#   user "#{user}"
-#   cwd "#{deploy_location}/pythondotorg/"
-# end
+execute "#{manage_py} migrate" do
+  user "#{user}"
+  cwd "#{deploy_location}/pythondotorg/"
+end
 
 execute "echo 'source #{deploy_location}/ENV/bin/activate' >> #{deploy_location}/.bash_profile" do
   not_if "grep ENV/bin/activate #{deploy_location}/.bash_profile"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ django-haystack==2.3.1
 elasticsearch==1.2.0
 pyelasticsearch==0.6.1
 Sphinx==1.2.2
-django-tastypie==0.12.1
+django-tastypie==0.11.1
 
 pytz==2013b
 python-dateutil==2.2


### PR DESCRIPTION
Fixes #399 

Migrations weren't being run on the chef provision. Migrations were broken due to this commit https://github.com/python/pythondotorg/commit/a14a7d482a633014277200936c5a0bb64d2a7d65  a few days ago. I'm not clear why that change was made, but maybe @gutworth can say?

It seems the 0.12 line of tastypie drops support for django's less than 1.7 as `django.db.migrations` doesn't exist on non-1.7 versions afaik. Offending exception originates from [this line](https://github.com/toastdriven/django-tastypie/blob/master/tastypie/migrations/0001_initial.py#L4) of tastypie.
