### PR TITLE
Actually install susy.

### DIFF
--- a/chef/cookbooks/pythondotorg/recipes/prereq.rb
+++ b/chef/cookbooks/pythondotorg/recipes/prereq.rb
@@ -52,13 +52,7 @@ package "libz-dev" do
   action :install
 end
 
-# Compass is used to compile sass files dynamically at deployment
-gem_package 'compass' do
-  version '0.11.7'
-  action :install
-end
-
-gem_package 'susy' do
-  version '1.0.rc.2'  # This is current the pre-release version
-  action :install
+bash "susy installation" do
+  code "sudo gem install susy --version 1.0.rc.2"
+  action :run
 end


### PR DESCRIPTION
Fixes #404

I ended up in a bit of a yak shave on getting `gem_package` to actually install things. Folks in #chef suggested I try `chef-shell`, but that didn't work. They noticed we're running chef 10, and that's 2 major version behind. They recommended upgrading. I took an initial stab at that, but to no avail. Someone with more chef knowledge will need to do that.

This PR does fix the issue, but likely not in the 'chef approved' way. It does fix the issue.

To validate:

```
vagrant destroy --force # This DELETES your existing vm!!
vagrant up
vagrant ssh
gem list
# validate susy is listed.
```
