### PR TITLE
Admin-editable dynamic content streams

### DIFF
--- a/blogs/admin.py
+++ b/blogs/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 
 from cms.admin import ContentManageableModelAdmin
 
-from .models import BlogEntry, Contributor, Translation
+from .models import BlogEntry, Contributor, Translation, Feed, FeedAggregate
 
 
 class TranslationAdmin(ContentManageableModelAdmin):
@@ -33,3 +33,11 @@ class BlogEntryAdmin(admin.ModelAdmin):
     date_hierarchy = 'pub_date'
 
 admin.site.register(BlogEntry, BlogEntryAdmin)
+
+class FeedAggregateAdmin(admin.ModelAdmin):
+    list_display = ['name', 'slug', 'description']
+    prepopulated_fields = {'slug': ('name',)}
+
+admin.site.register(FeedAggregate, FeedAggregateAdmin)
+
+admin.site.register(Feed)

--- a/blogs/management/commands/update_blogs.py
+++ b/blogs/management/commands/update_blogs.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.core.management.base import BaseCommand
 from django.conf import settings
 
@@ -31,6 +33,9 @@ class Command(BaseCommand):
                         url=entry['url'],
                         feed=feed,
                     )
+
+            feed.last_import = datetime.now()
+            feed.save()
 
         # Update the supernav box with the latest entry's info
         update_blog_supernav()

--- a/blogs/migrations/0001_initial.py
+++ b/blogs/migrations/0001_initial.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'BlogEntry'
+        db.create_table('blogs_blogentry', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('summary', self.gf('django.db.models.fields.TextField')(blank=True)),
+            ('pub_date', self.gf('django.db.models.fields.DateTimeField')()),
+            ('url', self.gf('django.db.models.fields.URLField')(max_length=200)),
+        ))
+        db.send_create_signal('blogs', ['BlogEntry'])
+
+        # Adding model 'Translation'
+        db.create_table('blogs_translation', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, db_index=True, blank=True)),
+            ('updated', self.gf('django.db.models.fields.DateTimeField')(blank=True)),
+            ('creator', self.gf('django.db.models.fields.related.ForeignKey')(null=True, blank=True, to=orm['users.User'], related_name='blogs_translation_creator')),
+            ('last_modified_by', self.gf('django.db.models.fields.related.ForeignKey')(null=True, blank=True, to=orm['users.User'], related_name='blogs_translation_modified')),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('url', self.gf('django.db.models.fields.URLField')(max_length=200)),
+        ))
+        db.send_create_signal('blogs', ['Translation'])
+
+        # Adding model 'Contributor'
+        db.create_table('blogs_contributor', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, db_index=True, blank=True)),
+            ('updated', self.gf('django.db.models.fields.DateTimeField')(blank=True)),
+            ('creator', self.gf('django.db.models.fields.related.ForeignKey')(null=True, blank=True, to=orm['users.User'], related_name='blogs_contributor_creator')),
+            ('last_modified_by', self.gf('django.db.models.fields.related.ForeignKey')(null=True, blank=True, to=orm['users.User'], related_name='blogs_contributor_modified')),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(related_name='blog_contributor', to=orm['users.User'])),
+        ))
+        db.send_create_signal('blogs', ['Contributor'])
+
+        # Adding model 'RelatedBlog'
+        db.create_table('blogs_relatedblog', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, db_index=True, blank=True)),
+            ('updated', self.gf('django.db.models.fields.DateTimeField')(blank=True)),
+            ('creator', self.gf('django.db.models.fields.related.ForeignKey')(null=True, blank=True, to=orm['users.User'], related_name='blogs_relatedblog_creator')),
+            ('last_modified_by', self.gf('django.db.models.fields.related.ForeignKey')(null=True, blank=True, to=orm['users.User'], related_name='blogs_relatedblog_modified')),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('feed_url', self.gf('django.db.models.fields.URLField')(max_length=200)),
+            ('blog_url', self.gf('django.db.models.fields.URLField')(max_length=200)),
+            ('blog_name', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('last_entry_published', self.gf('django.db.models.fields.DateTimeField')(db_index=True)),
+            ('last_entry_title', self.gf('django.db.models.fields.CharField')(max_length=500)),
+        ))
+        db.send_create_signal('blogs', ['RelatedBlog'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'BlogEntry'
+        db.delete_table('blogs_blogentry')
+
+        # Deleting model 'Translation'
+        db.delete_table('blogs_translation')
+
+        # Deleting model 'Contributor'
+        db.delete_table('blogs_contributor')
+
+        # Deleting model 'RelatedBlog'
+        db.delete_table('blogs_relatedblog')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80', 'unique': 'True'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'blank': 'True', 'to': "orm['auth.Permission']"})
+        },
+        'auth.permission': {
+            'Meta': {'unique_together': "(('content_type', 'codename'),)", 'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'blogs.blogentry': {
+            'Meta': {'object_name': 'BlogEntry'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pub_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'blogs.contributor': {
+            'Meta': {'ordering': "('user__last_name', 'user__first_name')", 'object_name': 'Contributor'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'null': 'True', 'blank': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_contributor_creator'"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'null': 'True', 'blank': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_contributor_modified'"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blog_contributor'", 'to': "orm['users.User']"})
+        },
+        'blogs.relatedblog': {
+            'Meta': {'object_name': 'RelatedBlog'},
+            'blog_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'blog_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'null': 'True', 'blank': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_relatedblog_creator'"}),
+            'feed_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_entry_published': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'last_entry_title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'null': 'True', 'blank': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_relatedblog_modified'"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'})
+        },
+        'blogs.translation': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Translation'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'null': 'True', 'blank': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_translation_creator'"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'null': 'True', 'blank': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_translation_modified'"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'unique_together': "(('app_label', 'model'),)", 'db_table': "'django_content_type'", 'ordering': "('name',)", 'object_name': 'ContentType'},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'users.user': {
+            'Meta': {'object_name': 'User'},
+            '_bio_rendered': ('django.db.models.fields.TextField', [], {}),
+            'bio': ('markupfield.fields.MarkupField', [], {'blank': 'True', 'rendered_field': 'True'}),
+            'bio_markup_type': ('django.db.models.fields.CharField', [], {'default': "'markdown'", 'max_length': '30', 'blank': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'email_privacy': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'blank': 'True', 'to': "orm['auth.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'search_visibility': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'blank': 'True', 'to': "orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '30', 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['blogs']

--- a/blogs/migrations/0002_auto__add_feedaggregate__add_feed.py
+++ b/blogs/migrations/0002_auto__add_feedaggregate__add_feed.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'FeedAggregate'
+        db.create_table('blogs_feedaggregate', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('slug', self.gf('django.db.models.fields.SlugField')(max_length=50, unique=True)),
+            ('description', self.gf('django.db.models.fields.TextField')()),
+        ))
+        db.send_create_signal('blogs', ['FeedAggregate'])
+
+        # Adding M2M table for field feeds on 'FeedAggregate'
+        m2m_table_name = db.shorten_name('blogs_feedaggregate_feeds')
+        db.create_table(m2m_table_name, (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('feedaggregate', models.ForeignKey(orm['blogs.feedaggregate'], null=False)),
+            ('feed', models.ForeignKey(orm['blogs.feed'], null=False))
+        ))
+        db.create_unique(m2m_table_name, ['feedaggregate_id', 'feed_id'])
+
+        # Adding model 'Feed'
+        db.create_table('blogs_feed', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('website_url', self.gf('django.db.models.fields.URLField')(max_length=200)),
+            ('feed_url', self.gf('django.db.models.fields.URLField')(max_length=200)),
+            ('last_import', self.gf('django.db.models.fields.DateTimeField')(blank=True, null=True)),
+        ))
+        db.send_create_signal('blogs', ['Feed'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'FeedAggregate'
+        db.delete_table('blogs_feedaggregate')
+
+        # Removing M2M table for field feeds on 'FeedAggregate'
+        db.delete_table(db.shorten_name('blogs_feedaggregate_feeds'))
+
+        # Deleting model 'Feed'
+        db.delete_table('blogs_feed')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80', 'unique': 'True'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'to': "orm['auth.Permission']", 'symmetrical': 'False'})
+        },
+        'auth.permission': {
+            'Meta': {'object_name': 'Permission', 'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)"},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'blogs.blogentry': {
+            'Meta': {'object_name': 'BlogEntry'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pub_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'blogs.contributor': {
+            'Meta': {'object_name': 'Contributor', 'ordering': "('user__last_name', 'user__first_name')"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'db_index': 'True', 'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'null': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_contributor_creator'"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'null': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_contributor_modified'"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.User']", 'related_name': "'blog_contributor'"})
+        },
+        'blogs.feed': {
+            'Meta': {'object_name': 'Feed'},
+            'feed_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_import': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'website_url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'blogs.feedaggregate': {
+            'Meta': {'object_name': 'FeedAggregate'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'feeds': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['blogs.Feed']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'unique': 'True'})
+        },
+        'blogs.relatedblog': {
+            'Meta': {'object_name': 'RelatedBlog'},
+            'blog_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'blog_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'db_index': 'True', 'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'null': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_relatedblog_creator'"}),
+            'feed_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_entry_published': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'last_entry_title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'null': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_relatedblog_modified'"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'})
+        },
+        'blogs.translation': {
+            'Meta': {'object_name': 'Translation', 'ordering': "('name',)"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'db_index': 'True', 'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'null': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_translation_creator'"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'null': 'True', 'to': "orm['users.User']", 'related_name': "'blogs_translation_modified'"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'object_name': 'ContentType', 'ordering': "('name',)", 'db_table': "'django_content_type'", 'unique_together': "(('app_label', 'model'),)"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'users.user': {
+            'Meta': {'object_name': 'User'},
+            '_bio_rendered': ('django.db.models.fields.TextField', [], {}),
+            'bio': ('markupfield.fields.MarkupField', [], {'blank': 'True', 'rendered_field': 'True'}),
+            'bio_markup_type': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30', 'default': "'markdown'"}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'blank': 'True', 'max_length': '75'}),
+            'email_privacy': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'to': "orm['auth.Group']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'search_visibility': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'to': "orm['auth.Permission']", 'symmetrical': 'False'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '30', 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['blogs']

--- a/blogs/migrations/0003_blog_python_org_feed.py
+++ b/blogs/migrations/0003_blog_python_org_feed.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+from django.conf import settings
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        orm['blogs.Feed'].objects.create(
+            name="Python Blogger Blog",
+            website_url=settings.PYTHON_BLOG_URL,
+            feed_url=settings.PYTHON_BLOG_FEED_URL
+        )
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+        orm['blogs.Feed'].objects.filter(
+            website_url=settings.PYTHON_BLOG_URL).delete()
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80', 'unique': 'True'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'to': "orm['auth.Permission']", 'symmetrical': 'False'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'object_name': 'Permission', 'unique_together': "(('content_type', 'codename'),)"},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'blogs.blogentry': {
+            'Meta': {'object_name': 'BlogEntry'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pub_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'blogs.contributor': {
+            'Meta': {'ordering': "('user__last_name', 'user__first_name')", 'object_name': 'Contributor'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_contributor_creator'", 'blank': 'True', 'to': "orm['users.User']", 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_contributor_modified'", 'blank': 'True', 'to': "orm['users.User']", 'null': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blog_contributor'", 'to': "orm['users.User']"})
+        },
+        'blogs.feed': {
+            'Meta': {'object_name': 'Feed'},
+            'feed_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_import': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'website_url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'blogs.feedaggregate': {
+            'Meta': {'object_name': 'FeedAggregate'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'feeds': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['blogs.Feed']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'unique': 'True'})
+        },
+        'blogs.relatedblog': {
+            'Meta': {'object_name': 'RelatedBlog'},
+            'blog_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'blog_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_relatedblog_creator'", 'blank': 'True', 'to': "orm['users.User']", 'null': 'True'}),
+            'feed_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_entry_published': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'last_entry_title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_relatedblog_modified'", 'blank': 'True', 'to': "orm['users.User']", 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'})
+        },
+        'blogs.translation': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Translation'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_translation_creator'", 'blank': 'True', 'to': "orm['users.User']", 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_translation_modified'", 'blank': 'True', 'to': "orm['users.User']", 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'object_name': 'ContentType', 'db_table': "'django_content_type'", 'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'users.user': {
+            'Meta': {'object_name': 'User'},
+            '_bio_rendered': ('django.db.models.fields.TextField', [], {}),
+            'bio': ('markupfield.fields.MarkupField', [], {'blank': 'True', 'rendered_field': 'True'}),
+            'bio_markup_type': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True', 'default': "'markdown'"}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'email_privacy': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'to': "orm['auth.Group']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'search_visibility': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'to': "orm['auth.Permission']", 'symmetrical': 'False'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '30', 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['blogs']
+    symmetrical = True

--- a/blogs/migrations/0004_auto__add_field_blogentry_feed.py
+++ b/blogs/migrations/0004_auto__add_field_blogentry_feed.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'BlogEntry.feed'
+        db.add_column('blogs_blogentry', 'feed',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=1, to=orm['blogs.Feed']),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'BlogEntry.feed'
+        db.delete_column('blogs_blogentry', 'feed_id')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'symmetrical': 'False', 'to': "orm['auth.Permission']"})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'object_name': 'Permission', 'unique_together': "(('content_type', 'codename'),)"},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'blogs.blogentry': {
+            'Meta': {'object_name': 'BlogEntry'},
+            'feed': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['blogs.Feed']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pub_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'blogs.contributor': {
+            'Meta': {'ordering': "('user__last_name', 'user__first_name')", 'object_name': 'Contributor'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'db_index': 'True', 'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_contributor_creator'", 'blank': 'True', 'null': 'True', 'to': "orm['users.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_contributor_modified'", 'blank': 'True', 'null': 'True', 'to': "orm['users.User']"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blog_contributor'", 'to': "orm['users.User']"})
+        },
+        'blogs.feed': {
+            'Meta': {'object_name': 'Feed'},
+            'feed_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_import': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'website_url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'blogs.feedaggregate': {
+            'Meta': {'object_name': 'FeedAggregate'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'feeds': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['blogs.Feed']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'blogs.relatedblog': {
+            'Meta': {'object_name': 'RelatedBlog'},
+            'blog_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'blog_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'db_index': 'True', 'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_relatedblog_creator'", 'blank': 'True', 'null': 'True', 'to': "orm['users.User']"}),
+            'feed_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_entry_published': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'last_entry_title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_relatedblog_modified'", 'blank': 'True', 'null': 'True', 'to': "orm['users.User']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'})
+        },
+        'blogs.translation': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Translation'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'db_index': 'True', 'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_translation_creator'", 'blank': 'True', 'null': 'True', 'to': "orm['users.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blogs_translation_modified'", 'blank': 'True', 'null': 'True', 'to': "orm['users.User']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'db_table': "'django_content_type'", 'ordering': "('name',)", 'object_name': 'ContentType', 'unique_together': "(('app_label', 'model'),)"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'users.user': {
+            'Meta': {'object_name': 'User'},
+            '_bio_rendered': ('django.db.models.fields.TextField', [], {}),
+            'bio': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'bio_markup_type': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True', 'default': "'markdown'"}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'blank': 'True', 'max_length': '75'}),
+            'email_privacy': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'symmetrical': 'False', 'to': "orm['auth.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'search_visibility': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'symmetrical': 'False', 'to': "orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        }
+    }
+
+    complete_apps = ['blogs']

--- a/blogs/migrations/0005_initial_feedaggregate.py
+++ b/blogs/migrations/0005_initial_feedaggregate.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName". 
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+        fa = orm['blogs.FeedAggregate'].objects.create(
+            name='PSF News',
+            slug='psf-news',
+            description="Bottom of PSF landing page",
+        )
+        fa.feeds.add(orm['blogs.Feed'].objects.get(pk=1))
+        
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'unique_together': "(('content_type', 'codename'),)", 'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'blogs.blogentry': {
+            'Meta': {'object_name': 'BlogEntry'},
+            'feed': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['blogs.Feed']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pub_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'summary': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'blogs.contributor': {
+            'Meta': {'ordering': "('user__last_name', 'user__first_name')", 'object_name': 'Contributor'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True', 'db_index': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.User']", 'blank': 'True', 'null': 'True', 'related_name': "'blogs_contributor_creator'"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.User']", 'blank': 'True', 'null': 'True', 'related_name': "'blogs_contributor_modified'"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.User']", 'related_name': "'blog_contributor'"})
+        },
+        'blogs.feed': {
+            'Meta': {'object_name': 'Feed'},
+            'feed_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_import': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'website_url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'blogs.feedaggregate': {
+            'Meta': {'object_name': 'FeedAggregate'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'feeds': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['blogs.Feed']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'blogs.relatedblog': {
+            'Meta': {'object_name': 'RelatedBlog'},
+            'blog_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'blog_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True', 'db_index': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.User']", 'blank': 'True', 'null': 'True', 'related_name': "'blogs_relatedblog_creator'"}),
+            'feed_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_entry_published': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'last_entry_title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.User']", 'blank': 'True', 'null': 'True', 'related_name': "'blogs_relatedblog_modified'"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'})
+        },
+        'blogs.translation': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Translation'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True', 'db_index': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.User']", 'blank': 'True', 'null': 'True', 'related_name': "'blogs_translation_creator'"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.User']", 'blank': 'True', 'null': 'True', 'related_name': "'blogs_translation_modified'"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'unique_together': "(('app_label', 'model'),)", 'db_table': "'django_content_type'", 'ordering': "('name',)", 'object_name': 'ContentType'},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'users.user': {
+            'Meta': {'object_name': 'User'},
+            '_bio_rendered': ('django.db.models.fields.TextField', [], {}),
+            'bio': ('markupfield.fields.MarkupField', [], {'blank': 'True', 'rendered_field': 'True'}),
+            'bio_markup_type': ('django.db.models.fields.CharField', [], {'default': "'markdown'", 'blank': 'True', 'max_length': '30'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'blank': 'True', 'max_length': '75'}),
+            'email_privacy': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'search_visibility': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        }
+    }
+
+    complete_apps = ['blogs']
+    symmetrical = True

--- a/blogs/models.py
+++ b/blogs/models.py
@@ -16,6 +16,7 @@ class BlogEntry(models.Model):
     summary = models.TextField(blank=True)
     pub_date = models.DateTimeField()
     url = models.URLField('URL')
+    feed = models.ForeignKey('Feed')
 
     class Meta:
         verbose_name = 'Blog Entry'
@@ -28,6 +29,33 @@ class BlogEntry(models.Model):
     def get_absolute_url(self):
         return self.url
 
+
+class Feed(models.Model):
+    """
+    An RSS feed to import.
+    """
+    name = models.CharField(max_length=200)
+    website_url = models.URLField()
+    feed_url = models.URLField()
+    last_import = models.DateTimeField(blank=True, null=True)
+
+    def __str__(self):
+        return self.name
+
+class FeedAggregate(models.Model):
+    """
+    An aggregate of RSS feeds.
+
+    These allow people to edit what are in feed-backed content blocks
+    without editing templates.
+    """
+    name = models.CharField(max_length=200)
+    slug = models.SlugField(unique=True)
+    description = models.TextField(help_text="Where this appears on the site")
+    feeds = models.ManyToManyField(Feed)
+
+    def __str__(self):
+        return self.name
 
 class Translation(ContentManageable):
     """ Model to store blog translation links """

--- a/blogs/parser.py
+++ b/blogs/parser.py
@@ -19,10 +19,11 @@ def get_all_entries(feed_url):
 
         entry = {
             'title': e['title'],
-            'summary': e['summary'],
+            'summary': e.get('summary', ''),
             'pub_date': published,
             'url': e['link'],
         }
+
         entries.append(entry)
 
     return entries
@@ -35,7 +36,7 @@ def _render_blog_supernav(entry):
 
 def update_blog_supernav():
     """Retrieve latest entry and update blog supernav item """
-    latest_entry = BlogEntry.objects.latest()
+    latest_entry = BlogEntry.objects.filter(feed_id=1).latest()
     rendered_box = _render_blog_supernav(latest_entry)
 
     box = Box.objects.get(label='supernav-python-blog')

--- a/blogs/templatetags/blogs.py
+++ b/blogs/templatetags/blogs.py
@@ -9,3 +9,18 @@ register = template.Library()
 def get_latest_blog_entries(limit=5):
     """ Return limit of latest blog entries """
     return BlogEntry.objects.order_by("-pub_date")[:limit]
+
+
+@register.assignment_tag
+def feed_list(slug, limit=10):
+    """
+    Returns a list of blog entries for the given FeedAggregate slug.
+
+    {% feed_list 'psf' as entries %}
+    {% for entry in entries %}
+      {{ entry }}
+    {% endfor %}
+    """
+    return BlogEntry.objects.filter(
+        feed__feedaggregate__slug=slug).order_by('-pub_date')[:limit]
+

--- a/blogs/tests/test_models.py
+++ b/blogs/tests/test_models.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.utils import timezone
 
-from ..models import Translation, BlogEntry
+from ..models import Translation, BlogEntry, Feed
 
 
 class BlogModelTest(TestCase):
@@ -22,6 +22,11 @@ class BlogModelTest(TestCase):
             summary='Test Summary',
             pub_date=now,
             url='http://www.revsys.com',
+            feed=Feed.objects.create(
+                name='psf blog',
+                website_url='psf.example.org',
+                feed_url='feed.psf.example.org',
+            )
         )
 
         self.assertEqual(str(b), b.title)

--- a/blogs/tests/test_templatetags.py
+++ b/blogs/tests/test_templatetags.py
@@ -1,11 +1,14 @@
+from datetime import datetime
+
 from django.core.management import call_command
 from django.test import TestCase
+from django.template import Template, Context
 
 from boxes.models import Box
 
 from ..templatetags.blogs import get_latest_blog_entries
 from ..parser import _render_blog_supernav
-from ..models import BlogEntry
+from ..models import BlogEntry, Feed, FeedAggregate
 from .utils import get_test_rss_path
 
 
@@ -22,12 +25,59 @@ class BlogTemplateTagTest(TestCase):
         Test our assignment tag, also ends up testing the update_blogs
         management command
         """
+        Feed.objects.create(
+            id=1, name='psf default', website_url='example.org',
+            feed_url=self.test_file_path)
         entries = None
-        with self.settings(PYTHON_BLOG_FEED_URL=self.test_file_path):
-            call_command('update_blogs')
-            entries = get_latest_blog_entries()
+        call_command('update_blogs')
+        entries = get_latest_blog_entries()
 
         self.assertEqual(len(entries), 5)
         b = Box.objects.get(label='supernav-python-blog')
         rendered_box = _render_blog_supernav(BlogEntry.objects.latest())
         self.assertEqual(b.content.raw, rendered_box)
+
+    def test_feed_list(self):
+        f1 = Feed.objects.create(
+            name='psf blog',
+            website_url='psf.example.org',
+            feed_url='feed.psf.example.org',
+        )
+        BlogEntry.objects.create(
+            title='test1',
+            summary='',
+            pub_date=datetime.now(),
+            url='path/to/foo',
+            feed=f1
+        )
+
+        f2 = Feed.objects.create(
+            name='django blog',
+            website_url='django.example.org',
+            feed_url='feed.django.example.org',
+        )
+        BlogEntry.objects.create(
+            title='test2',
+            summary='',
+            pub_date=datetime.now(),
+            url='path/to/foo',
+            feed=f1
+        )
+        fa = FeedAggregate.objects.create(
+            name='test',
+            slug='test',
+            description='testing',
+        )
+        fa.feeds.add(f1,f2)
+
+
+        t = Template("""
+        {% load blogs %}
+        {% feed_list 'test' as entries %}
+        {% for entry in entries %}
+        {{ entry.title }}
+        {% endfor %}
+        """)
+
+        rendered = t.render(Context())
+        self.assertEquals(rendered.strip().replace(' ', ''), 'test2\n\ntest1');

--- a/blogs/tests/test_views.py
+++ b/blogs/tests/test_views.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from boxes.models import Box
 
-from ..models import BlogEntry
+from ..models import BlogEntry, Feed
 
 from .utils import get_test_rss_path
 
@@ -22,8 +22,10 @@ class BlogViewTest(TestCase):
         Test our assignment tag, also ends up testing the update_blogs
         management command
         """
-        with self.settings(PYTHON_BLOG_FEED_URL=self.test_file_path):
-            call_command('update_blogs')
+        Feed.objects.create(
+            id=1, name='psf default', website_url='example.org',
+            feed_url=self.test_file_path)
+        call_command('update_blogs')
 
         resp = self.client.get(reverse('blog'))
         self.assertEqual(resp.status_code, 200)

--- a/templates/psf/index.html
+++ b/templates/psf/index.html
@@ -1,7 +1,7 @@
 {# ===== PSF LANDING PAGE ===== #}
 
 {% extends "base.html" %}
-{% load boxes sponsors %}
+{% load boxes sponsors blogs %}
 
 {% block page_title %}Python Software Foundation{% endblock %}
 
@@ -62,33 +62,17 @@
 
                     <div class="medium-widget news-wiki-widget last">
 
-                        {% comment %}
-                        There is some dynamic content needed in this box. Below is the markup/idea for the content.
-
                         <div class="split-widget-wrapper shrubbery">
                             <h2 class="widget-title">PSF News </h2>
-                            <p class="give-me-more"><a href="#" title="More PSF News">More</a></p>
-
-                            ** Dynamic:
+                            {% feed_list 'psf-news' as psf_entries %}
+                            {% if psf_entries %}
                             <ul class="menu">
-                                <li><a href="#">Simon Cross Awarded Community Service Award</a></li>
-                                <li><a href="#">Kenneth Gonsalves Posthumously Awarded Community Service Award</a></li>
-                                <li><a href="#">Announcing the 2012 Distinguished Service Award &ndash; John Hunter</a></li>
-                                <li><a href="#">Welcome New PSF Members!</a></li>
+                              {% for entry in psf_entries %}
+                              <li><a href="{{ entry.url }}">{{ entry.title }}</a></li>
+                              {% endfor %}
                             </ul>
-                            **
-
+                            {% endif %}
                         </div>
-                        <!--
-                        <div class="split-widget-wrapper shrubbery">
-                            <h2 class="widget-title">PSF Wiki </h2>
-                            <p class="give-me-more"><a href="#" title="Enter PSF Wiki">Enter</a></p>
-                            <p><strong class="uppercase">MEMBERS ONLY:</strong> The PSF Members&rsquo; Wiki is provided for collaboration amongst PSF members on internal projects. Become a member to see what exciting things we have in store for the Python family.</p>
-                        </div>
-                        -->
-                        {% endcomment %}
-
-                        {% box 'psf-news' %}
 
                     </div>
 


### PR DESCRIPTION
#### What's this PR do?

Adds support for dynamic content sections which are powered by RSS feeds.

The combination of these feeds is admin-controllable.
#### Where should the reviewer start?

`models.py`, then likely the changes to the `update_blog` management command, followed by the template tag.
#### How should this be manually tested?

Add a couple of feeds to the automatically created `psf-news` `FeedAggregate`. Run `./manage.py update_blogs`. You should see the contents of that feed at http://localhost:8000/psf-landing/ in date descending order.
#### What are the relevant tickets?

Fixes #476
#### Screenshots (if appropriate)

![screen shot 2014-12-13 at 1 11 32 pm](https://cloud.githubusercontent.com/assets/3853/5425390/95e5ca32-82c9-11e4-9010-0002b1d6d4a9.png)
#### What gif best describes this PR or how it makes you feel?

![](http://s.mlkshk-cdn.com/r/10XHJ.jpg)

(this is loosely formatted based on a [PR template that I use at work](http://quickleft.com/blog/pull-request-templates-make-code-review-easier))
