### PR TITLE
495 pep rss

### DIFF
--- a/pages/migrations/0008_auto__add_field_page_content_type.py
+++ b/pages/migrations/0008_auto__add_field_page_content_type.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Page.content_type'
+        db.add_column('pages_page', 'content_type',
+                      self.gf('django.db.models.fields.CharField')(max_length=150, default='text/html'),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Page.content_type'
+        db.delete_column('pages_page', 'content_type')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80', 'unique': 'True'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['auth.Permission']", 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'object_name': 'Permission', 'unique_together': "(('content_type', 'codename'),)", 'ordering': "('content_type__app_label', 'content_type__model', 'codename')"},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'object_name': 'ContentType', 'unique_together': "(('app_label', 'model'),)", 'db_table': "'django_content_type'", 'ordering': "('name',)"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'pages.image': {
+            'Meta': {'object_name': 'Image'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '400'}),
+            'page': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['pages.Page']"})
+        },
+        'pages.page': {
+            'Meta': {'object_name': 'Page', 'ordering': "['title', 'path']"},
+            '_content_rendered': ('django.db.models.fields.TextField', [], {}),
+            'content': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True'}),
+            'content_markup_type': ('django.db.models.fields.CharField', [], {'max_length': '30', 'default': "'restructuredtext'"}),
+            'content_type': ('django.db.models.fields.CharField', [], {'max_length': '150', 'default': "'text/html'"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pages_page_creator'", 'null': 'True', 'to': "orm['users.User']", 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_published': ('django.db.models.fields.BooleanField', [], {'db_index': 'True', 'default': 'True'}),
+            'keywords': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'}),
+            'last_modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pages_page_modified'", 'null': 'True', 'to': "orm['users.User']", 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'db_index': 'True'}),
+            'template_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'})
+        },
+        'users.user': {
+            'Meta': {'object_name': 'User'},
+            '_bio_rendered': ('django.db.models.fields.TextField', [], {}),
+            'bio': ('markupfield.fields.MarkupField', [], {'rendered_field': 'True', 'blank': 'True'}),
+            'bio_markup_type': ('django.db.models.fields.CharField', [], {'max_length': '30', 'default': "'markdown'", 'blank': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'email_privacy': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['auth.Group']", 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'search_visibility': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['auth.Permission']", 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '30', 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['pages']

--- a/pages/models.py
+++ b/pages/models.py
@@ -44,6 +44,7 @@ class Page(ContentManageable):
     path = models.CharField(max_length=500, validators=[is_valid_page_path], unique=True, db_index=True)
     content = MarkupField(default_markup_type=DEFAULT_MARKUP_TYPE)
     is_published = models.BooleanField(default=True, db_index=True)
+    content_type = models.CharField(max_length=150, default='text/html')
     template_name = models.CharField(
         max_length=100,
         blank=True,

--- a/pages/views.py
+++ b/pages/views.py
@@ -18,6 +18,10 @@ class PageView(DetailView):
         else:
             return Page.objects.published()
 
+    @property
+    def content_type(self):
+        return self.object.content_type
+
     def get_extra_context(self, *args, **kwargs):
         context = self.super().get_extra_context(*args, **kwargs)
         context['in_pages_app'] = True

--- a/peps/converters.py
+++ b/peps/converters.py
@@ -210,7 +210,7 @@ def add_pep_image(pep_number, path):
 def get_peps_rss():
     rss_feed = os.path.join(settings.PEP_REPO_PATH, 'peps.rss')
     if not os.path.exists(rss_feed):
-        print("Could not find generated RSS feed. Skipping.".format(rss_feed))
+        print("Could not find generated RSS feed. Skipping.")
         return
 
     page, _ = Page.objects.get_or_create(
@@ -218,9 +218,8 @@ def get_peps_rss():
         template_name="pages/raw.html",
     )
 
-    content = ""
     with open(rss_feed, "r") as rss_content:
-        content += rss_content.read()
+        content = rss_content.read()
 
     page.content = content
     page.is_published = True

--- a/peps/converters.py
+++ b/peps/converters.py
@@ -206,3 +206,25 @@ def add_pep_image(pep_number, path):
         page.save()
 
     return image
+
+def get_peps_rss():
+    rss_feed = os.path.join(settings.PEP_REPO_PATH, 'peps.rss')
+    if not os.path.exists(rss_feed):
+        print("Could not find generated RSS feed. Skipping.".format(rss_feed))
+        return
+
+    page, _ = Page.objects.get_or_create(
+        path="dev/peps/peps.rss",
+        template_name="pages/raw.html",
+    )
+
+    content = ""
+    with open(rss_feed, "r") as rss_content:
+        content += rss_content.read()
+
+    page.content = content
+    page.is_published = True
+    page.content_type = "application/rss+xml"
+    page.save()
+
+    return page

--- a/peps/management/commands/generate_pep_pages.py
+++ b/peps/management/commands/generate_pep_pages.py
@@ -4,7 +4,9 @@ import os
 from django.core.management.base import NoArgsCommand
 from django.conf import settings
 
-from peps.converters import get_pep0_page, get_pep_page, add_pep_image
+from peps.converters import (
+    get_pep0_page, get_pep_page, add_pep_image, get_peps_rss
+)
 
 pep_number_re = re.compile(r'pep-(\d+)')
 
@@ -39,6 +41,9 @@ class Command(NoArgsCommand):
                 print(msg)
 
         verbose("== Starting PEP page generation")
+
+        verbose("Generating RSS Feed")
+        get_peps_rss()
 
         verbose("Generating PEP0 index page")
         pep0_page, _ = get_pep0_page()

--- a/templates/pages/raw.html
+++ b/templates/pages/raw.html
@@ -1,0 +1,1 @@
+{{ page.content.raw|safe }}


### PR DESCRIPTION
#### What's this PR do?

Loads a `peps.rss` feed generated from the peps repo into a Page object.

Additionally, Pages have an optional content type used when serving the file.
#### Where should the reviewer start?

Import script, likely.
#### How should this be manually tested?

In the peps repo: `./pep2rss.py .`
In the pythondotorg repo: `./manage.py generate_pep_pages`
Visit http://localhost:8000/dev/peps/peps.rss
#### Any background context you want to provide?

Had to change the content type thing so we could serve the rss feed with the correct mime type.
#### What are the relevant tickets?

Fixes #495 
#### What gif best describes this PR or how it makes you feel?

![](http://s.mlkshk-cdn.com/r/11VNI.gif)
