### PR TITLE
Fix nav splits if there are only 6 items.

### DIFF
--- a/static/sass/_mixins.scss
+++ b/static/sass/_mixins.scss
@@ -353,7 +353,7 @@
             float: left; 
             width: 33.333333%;
             
-            &.element-6, &.element-7 { width: 16.6666665%; }
+            &.element-6:not(.unstacked), &.element-7:not(.unstacked) { width: 16.6666665%; }
             
             &.element-1 {
                 @include border-top-left-radius( 8px );

--- a/templates/sitetree/submenu.html
+++ b/templates/sitetree/submenu.html
@@ -1,12 +1,14 @@
 {% load sitetree %}
 <ul class="navigation menu" role="menubar" aria-label="Main Navigation">
+  {% with sitetree_items|length as total_length %}
     {% for item in sitetree_items %}
 
-    <li id="{{ item.title|slugify }}" class="tier-1 element-{{ forloop.counter }} {% if forloop.last %}last{% endif %}" aria-haspopup="true">
+    <li id="{{ item.title|slugify }}" class="tier-1 element-{{ forloop.counter }} {% if total_length == 6 and forloop.counter == 6 %}unstacked{% endif %} {% if forloop.last %}last{% endif %}" aria-haspopup="true">
         <a href="{% sitetree_url for item %}" title="{{ item.hint|default:'' }}" class="{{ item.is_current|yesno:' current_item selected,' }}{{ item.in_current_branch|yesno:' selected,' }}">{{ item.title_resolved }}</a>
         {% if item.has_children %}
             {% sitetree_children of item for menu template "sitetree/submenu_children.html" %}
         {% endif %}
     </li>
     {% endfor %}
+  {% endwith %}
 </ul>


### PR DESCRIPTION
#### What's this PR do?

Fixes an issue where if there were only 6 items in the nav, the last cell would only occupy 1/2 of it's space.
#### Where should the reviewer start?

css.
#### How should this be manually tested?

You can see it locally at http://localhost:8000/psf-landing/
#### Any background context you want to provide?

I'm unsure on what browser support looks like for this site. I think not selectors are only back to ie8 or so. I don't think this is possible as a CSS only change.
#### What are the relevant tickets?

Fixes #491 
#### Screenshots (if appropriate)

Links to prod version in #491 
Updated:
![screen shot 2014-12-14 at 3 42 19 pm](https://cloud.githubusercontent.com/assets/3853/5429637/dfe79bc2-83a7-11e4-9a30-d163d00cd634.png)
#### What gif best describes this PR or how it makes you feel?

![](http://s.mlkshk-cdn.com/r/11WCB.jpg)
