### PR TITLE
Set FIXTURE_DIRS to avoid typing "fixtures/" everytime.

### DIFF
--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -230,3 +230,9 @@ from .pipeline import (
     PIPELINE_SASS_BINARY, PIPELINE_SASS_ARGUMENTS,
     PIPELINE_CSS_COMPRESSOR, PIPELINE_JS_COMPRESSOR,
 )
+
+# Fixtures
+
+FIXTURE_DIRS = (
+    os.path.join(BASE, 'fixtures'),
+)


### PR DESCRIPTION
I'll update installation docs in a separate PR move it to `docs/`.
