### PR TITLE
Make success story widget visible on index (#544)

### DIFF
--- a/templates/components/success-story.html
+++ b/templates/components/success-story.html
@@ -7,7 +7,7 @@
                             <p class="give-me-more"><a href="{% url 'success_story_list' %}" title="More Success Stories">More</a></p>
 
                             {% for story in success_stories %}
-                            <div class="success-story-item" data-weight="{{ story.weight }}" id="success-story-{{ story.pk }}" style="display: none;">
+                            <div class="success-story-item" data-weight="{{ story.weight }}" id="success-story-{{ story.pk }}">
 
                             <blockquote>
                                 <a href="{{ story.get_absolute_url }}">{{ story.pull_quote }}</a>


### PR DESCRIPTION
This fixes #544. Cause was in 177d6d432c1dafc6fc5701486973fc772a0db819.
