### PR TITLE
Fix #24 (from python-jobs-board issues list)

### DIFF
--- a/templates/django_comments_xtd/email_job_added_comment.html
+++ b/templates/django_comments_xtd/email_job_added_comment.html
@@ -3,7 +3,7 @@
 <p>There is a new comment on your job posting.</p>
 
 <p>Sent by: {{ comment.name }}, {{ comment.submit_date|date:"SHORT_DATE_FORMAT" }}<br/>
-<a href="http://{{ site.domain }}{{ content_object.get_absolute_url }}">http://{{ site.domain }}{{ content_object.get_absolute_url }}</a></p>
+<a href="https://{{ site.domain }}{{ content_object.get_absolute_url }}">https://{{ site.domain }}{{ content_object.get_absolute_url }}</a></p>
 
 <p>The comment:<br/>
 <i>{{ comment.comment }}</i>

--- a/templates/django_comments_xtd/email_job_added_comment.txt
+++ b/templates/django_comments_xtd/email_job_added_comment.txt
@@ -4,7 +4,7 @@
 {% blocktrans %}There is a new comment on your job posting.{% endblocktrans %}
 
 Post: {{ content_object.title }}
-URL:  http://{{ site.domain }}{{ content_object.get_absolute_url }}
+URL:  https://{{ site.domain }}{{ content_object.get_absolute_url }}
 Sent by: {{ comment.name }}, {{ comment.submit_date|date:"SHORT_DATE_FORMAT" }}
 
 --- Comment: ---


### PR DESCRIPTION
Comment notification templates now properly use HTTPS links to python.org.
