### PR TITLE
Fix #579: Use job title as title in listings.

### DIFF
--- a/jobs/models.py
+++ b/jobs/models.py
@@ -132,7 +132,7 @@ class Job(ContentManageable):
 
     @property
     def display_name(self):
-        return self.company_name
+        return "%s, %s" % (self.job_title, self.company_name)
 
     @property
     def display_description(self):

--- a/jobs/tests/test_views.py
+++ b/jobs/tests/test_views.py
@@ -255,13 +255,16 @@ class JobsViewTests(TestCase):
         self.assertFalse('Lawrence' in content)
 
     def test_job_display_name(self):
-        self.assertEqual(self.job.display_name, self.job.company_name)
+        self.assertEqual(self.job.display_name, 
+            "%s, %s" % (self.job.job_title, self.job.company_name))
 
         self.job.company_name = 'ABC'
-        self.assertEqual(self.job.display_name, self.job.company_name)
+        self.assertEqual(self.job.display_name,
+            "%s, %s" % (self.job.job_title, self.job.company_name))
 
         self.job.company_name = ''
-        self.assertEqual(self.job.display_name, self.job.company_name)
+        self.assertEqual(self.job.display_name,
+            "%s, %s" % (self.job.job_title, self.job.company_name))
 
     def test_job_display_about(self):
         self.job.company_description.raw = 'XYZ'

--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load boxes %}
 
-{% block page_title %}Job Listing at {{ object.display_name }} | {{ SITE_INFO.site_name }}{% endblock %}
+{% block page_title %}{{ object.display_name }} | {{ SITE_INFO.site_name }}{% endblock %}
 
 {% block body_attributes %}class="jobs default-page single-job"{% endblock %}
 


### PR DESCRIPTION
This accomplishes the change by altering Job.display_name to
include the job title and company name.

This does cause some CSS class names to no longer be semantically
correct. This can be followed-up in a later commit.
