### PR TITLE
Use DummySASSCompiler in DEBUG mode to fix performance issues.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -83,6 +83,19 @@ Finally, start the development server::
     $ ./manage.py runserver
 
 
+Generating CSS files automatically
+----------------------------------
+
+Due to performance issues of django-pipeline_, we are using a dummy compiler
+``pydotorg.compilers.DummySASSCompiler`` in development mode. To generate CSS
+files, use ``sass`` itself in a separate terminal window::
+
+    $ cd static
+    $ sass --compass --scss -I $(dirname $(dirname $(gem which susy))) --trace --watch sass/style.scss:sass/style.css
+
+.. _django-pipeline: https://github.com/cyberdelia/django-pipeline/issues/313
+
+
 Running tests
 -------------
 

--- a/pydotorg/compilers.py
+++ b/pydotorg/compilers.py
@@ -1,0 +1,7 @@
+from pipeline.compilers import sass
+
+
+class DummySASSCompiler(sass.SASSCompiler):
+
+    def compile_file(self, infile, outfile, outdated=False, force=False):
+        pass

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -15,3 +15,7 @@ HAYSTACK_CONNECTIONS = {
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 PEP_REPO_PATH = '/Users/frank/work/src/pythondotorg/tmp/peps'
+
+PIPELINE_COMPILERS = (
+   'pydotorg.compilers.DummySASSCompiler',
+)


### PR DESCRIPTION
Currently, django-pipeline runs sass in every requests. Every
request took ~10 on my computer. Until https://github.com/cyberdelia/django-pipeline/issues/313
gets solved, use a dummy compiler class and run "sass --watch"
in a separate terminal.
