### PR TITLE
Deactivate JobType and JobCategories

### DIFF
--- a/jobs/admin.py
+++ b/jobs/admin.py
@@ -12,6 +12,19 @@ class JobAdmin(ContentManageableModelAdmin):
     raw_id_fields = ['category']
 
 
-admin.site.register(JobType, NameSlugAdmin)
-admin.site.register(JobCategory, NameSlugAdmin)
+class JobTypeAdmin(NameSlugAdmin):
+    list_display = ['__str__', 'active']
+    list_filter = ['active']
+    ordering = ('-active', 'name')
+
+admin.site.register(JobType, JobTypeAdmin)
+
+
+class JobCategoryAdmin(NameSlugAdmin):
+    list_display = ['__str__', 'active']
+    list_filter = ['active']
+    ordering = ('-active', 'name')
+
+admin.site.register(JobCategory, JobCategoryAdmin)
+
 admin.site.register(Job, JobAdmin)

--- a/jobs/forms.py
+++ b/jobs/forms.py
@@ -2,7 +2,6 @@ from django import forms
 from django.forms.widgets import CheckboxSelectMultiple
 from django.utils.translation import ugettext_lazy as _
 
-from django.conf import settings
 from django_comments_xtd.conf import settings as comments_settings
 from django_comments_xtd.forms import CommentForm
 from django_comments_xtd.models import TmpXtdComment

--- a/jobs/managers.py
+++ b/jobs/managers.py
@@ -5,10 +5,15 @@ from django.utils import timezone
 
 
 class JobTypeQuerySet(QuerySet):
-    def active_types(self):
+
+    def active(self):
+        """ active Job Types """
+        return self.filter(active=True)
+
+    def with_active_jobs(self):
         """ JobTypes with active jobs """
         now = timezone.now()
-        return self.filter(
+        return self.active().filter(
             jobs__status='approved',
             jobs__expires__gte=now,
         ).distinct()
@@ -20,13 +25,20 @@ class JobTypeManager(Manager):
     def get_queryset(self):
         return JobTypeQuerySet(self.model, using=self._db)
 
-    def active_types(self):
+    def active(self):
+        return self.get_queryset().active()
+
+    def with_active_jobs(self):
         """ Return all JobTypes that have active Jobs """
-        return self.get_queryset().active_types()
+        return self.get_queryset().with_active_jobs()
 
 
 class JobCategoryQuerySet(QuerySet):
-    def active_categories(self):
+
+    def active(self):
+        return self.filter(active=True)
+
+    def with_active_jobs(self):
         """ JobCategory with active jobs """
         now = timezone.now()
         return self.filter(
@@ -41,9 +53,12 @@ class JobCategoryManager(Manager):
     def get_queryset(self):
         return JobCategoryQuerySet(self.model, using=self._db)
 
-    def active_categories(self):
+    def active(self):
+        return self.get_queryset().active()
+
+    def with_active_jobs(self):
         """ Return all JobCategories that have active Jobs """
-        return self.get_queryset().active_categories()
+        return self.get_queryset().with_active_jobs()
 
 
 class JobQuerySet(QuerySet):

--- a/jobs/migrations/0008_auto_20150316_1205.py
+++ b/jobs/migrations/0008_auto_20150316_1205.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jobs', '0007_auto_20150227_2223'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='jobcategory',
+            name='active',
+            field=models.BooleanField(default=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='jobtype',
+            name='active',
+            field=models.BooleanField(default=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='job',
+            name='region',
+            field=models.CharField(blank=True, verbose_name='State, Province or Region', max_length=100, default=''),
+            preserve_default=False,
+        ),
+    ]

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -20,6 +20,7 @@ DEFAULT_MARKUP_TYPE = getattr(settings, 'DEFAULT_MARKUP_TYPE', 'restructuredtext
 
 
 class JobType(NameSlugModel):
+    active = models.BooleanField(default=True)
 
     objects = JobTypeManager()
 
@@ -30,6 +31,7 @@ class JobType(NameSlugModel):
 
 
 class JobCategory(NameSlugModel):
+    active = models.BooleanField(default=True)
 
     objects = JobCategoryManager()
 
@@ -42,8 +44,18 @@ class JobCategory(NameSlugModel):
 class Job(ContentManageable):
     NEW_THRESHOLD = datetime.timedelta(days=30)
 
-    category = models.ForeignKey(JobCategory, related_name='jobs')
-    job_types = models.ManyToManyField(JobType, related_name='jobs', blank=True, verbose_name='Job technologies')
+    category = models.ForeignKey(
+        JobCategory,
+        related_name='jobs',
+        limit_choices_to={'active': True},
+    )
+    job_types = models.ManyToManyField(
+        JobType,
+        related_name='jobs',
+        blank=True,
+        verbose_name='Job technologies',
+        limit_choices_to={'active': True},
+    )
     other_job_type = models.CharField(
         verbose_name='Other Job Technologies',
         max_length=100,
@@ -149,7 +161,7 @@ class Job(ContentManageable):
 
     @property
     def display_location(self):
-        location_parts = [part for part in (self.city, self.region, self.country) 
+        location_parts = [part for part in (self.city, self.region, self.country)
                             if part]
         location_str = ', '.join(location_parts)
         return location_str

--- a/jobs/tests/test_models.py
+++ b/jobs/tests/test_models.py
@@ -85,25 +85,25 @@ class JobsModelsTests(TestCase):
         self.assertFalse(j2 in visible)
         self.assertFalse(j3 in visible)
 
-    def test_job_type_active_types_manager(self):
+    def test_job_type_with_active_jobs_manager(self):
         t1 = factories.JobTypeFactory()
         t2 = factories.JobTypeFactory()
         j1 = factories.ApprovedJobFactory()
         j1.job_types.add(t1)
 
-        qs = JobType.objects.active_types()
+        qs = JobType.objects.with_active_jobs()
         self.assertEqual(len(qs), 1)
         self.assertTrue(t1 in qs)
         self.assertFalse(t2 in qs)
 
-    def test_job_type_active_categories_manager(self):
+    def test_job_category_with_active_jobs_manager(self):
         c1 = factories.JobCategoryFactory()
         c2 = factories.JobCategoryFactory()
         j1 = factories.ApprovedJobFactory()
         j1.category = c1
         j1.save()
 
-        qs = JobCategory.objects.active_categories()
+        qs = JobCategory.objects.with_active_jobs()
         self.assertEqual(len(qs), 1)
         self.assertTrue(c1 in qs)
         self.assertFalse(c2 in qs)
@@ -126,16 +126,16 @@ class JobsModelsTests(TestCase):
         self.assertEqual(job2.get_previous_listing(), job1)
 
     def test_region_optional(self):
-        job = self.create_job(region=None)
+        job = self.create_job(region='')
         self.assertEqual(job.city, "Memphis")
         self.assertEqual(job.country, "USA")
-        self.assertIsNone(job.region)
+        self.assertFalse(job.region)
 
     def test_display_location(self):
         job1 = self.create_job()
         self.assertEqual(job1.display_location, 'Memphis, TN, USA')
 
-        job2 = self.create_job(region=None)
+        job2 = self.create_job(region='')
         self.assertEqual(job2.display_location, 'Memphis, USA')
 
     def test_email_on_submit(self):

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -26,8 +26,8 @@ class JobMixin(object):
 
         context.update({
             'jobs_count': Job.objects.visible().count(),
-            'active_types': JobType.objects.active_types(),
-            'active_categories': JobCategory.objects.active_categories(),
+            'active_types': JobType.objects.with_active_jobs(),
+            'active_categories': JobCategory.objects.with_active_jobs(),
             'active_locations': active_locations,
         })
 
@@ -106,14 +106,14 @@ class JobListLocation(JobLocationMenu, JobList):
 class JobTypes(JobTypeMenu, JobMixin, ListView):
     """ View to simply list JobType instances that have current jobs """
     template_name = "jobs/job_types.html"
-    queryset = JobType.objects.active_types().order_by('name')
+    queryset = JobType.objects.with_active_jobs().order_by('name')
     context_object_name = 'types'
 
 
 class JobCategories(JobCategoryMenu, JobMixin, ListView):
     """ View to simply list JobCategory instances that have current jobs """
     template_name = "jobs/job_categories.html"
-    queryset = JobCategory.objects.active_categories().order_by('name')
+    queryset = JobCategory.objects.with_active_jobs().order_by('name')
     context_object_name = 'categories'
 
 


### PR DESCRIPTION
```
- Added active flag to models
- Adjusted managers and Job model to only show active Types and
  Categories
- Removed unused settings import in forms
- Fixes #631
```
