### PR TITLE
Clear the job technologies instead of deleteing them

### DIFF
--- a/jobs/views.py
+++ b/jobs/views.py
@@ -211,8 +211,9 @@ class JobCreateEditMixin(object):
 
     def form_valid(self, form):
         self.object = form.save()
-        # Delete existing
-        self.object.job_types.all().delete()
+        
+        # Clear existing job types
+        self.object.job_types.clear()
 
         # Add all of the chosen ones
         for t in form.cleaned_data['job_types']:


### PR DESCRIPTION
This is an attempt to solve the issue #637, where selected
job technologies get deleted when editing job entries through
the job edit form.
