### PR TITLE
Fix #656: Only send email when a job post created.

### DIFF
--- a/jobs/__init__.py
+++ b/jobs/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'jobs.apps.JobsAppConfig'

--- a/jobs/apps.py
+++ b/jobs/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class JobsAppConfig(AppConfig):
+
+    name = 'jobs'
+    verbose_name = 'Jobs Application'
+
+    def ready(self):
+        import jobs.listeners

--- a/jobs/forms.py
+++ b/jobs/forms.py
@@ -41,6 +41,15 @@ class JobForm(ContentManageableModelForm):
         super().__init__(*args, **kwargs)
         self.fields['job_types'].help_text = None
 
+    def save(self, commit=True):
+        obj = super().save()
+        obj.job_types.clear()
+        for t in self.cleaned_data['job_types']:
+            obj.job_types.add(t)
+        if commit:
+            obj.save()
+        return obj
+
 
 class JobCommentForm(CommentForm):
     reply_to = forms.IntegerField(required=True, initial=0, widget=forms.HiddenInput())

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -1,19 +1,17 @@
 import datetime
 
 from django.conf import settings
-from django.contrib.comments.signals import comment_was_posted
 from django.core.urlresolvers import reverse
 from django.db import models
-from django.db.models.signals import post_save
 from django.template.defaultfilters import slugify
 from django.utils import timezone
+
 from markupfield.fields import MarkupField
 
-from .managers import JobManager, JobTypeManager, JobCategoryManager
-from .listeners import (on_comment_was_posted, on_job_was_approved,
-                        on_job_was_rejected, on_job_was_submitted)
-from .signals import job_was_approved, job_was_rejected
 from cms.models import ContentManageable, NameSlugModel
+
+from .managers import JobManager, JobTypeManager, JobCategoryManager
+from .signals import job_was_approved, job_was_rejected
 
 
 DEFAULT_MARKUP_TYPE = getattr(settings, 'DEFAULT_MARKUP_TYPE', 'restructuredtext')
@@ -221,9 +219,3 @@ class Job(ContentManageable):
 
     def get_next_listing(self):
         return self.get_next_by_created(status=self.STATUS_APPROVED)
-
-comment_was_posted.connect(on_comment_was_posted)
-job_was_approved.connect(on_job_was_approved)
-job_was_rejected.connect(on_job_was_rejected)
-post_save.connect(on_job_was_submitted, sender=Job)
-

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -210,22 +210,7 @@ class JobDetailReview(LoginRequiredMixin, JobBoardAdminRequiredMixin, JobDetail)
         return ctx
 
 
-class JobCreateEditMixin(object):
-
-    def form_valid(self, form):
-        self.object = form.save()
-        
-        # Clear existing job types
-        self.object.job_types.clear()
-
-        # Add all of the chosen ones
-        for t in form.cleaned_data['job_types']:
-            self.object.job_types.add(t)
-
-        return super().form_valid(form)
-
-
-class JobCreate(JobMixin, JobCreateEditMixin, CreateView):
+class JobCreate(JobMixin, CreateView):
     model = Job
     form_class = JobForm
 
@@ -251,7 +236,7 @@ class JobCreate(JobMixin, JobCreateEditMixin, CreateView):
         return form
 
 
-class JobEdit(JobMixin, JobCreateEditMixin, UpdateView):
+class JobEdit(JobMixin, UpdateView):
     model = Job
     form_class = JobForm
 
@@ -264,11 +249,8 @@ class JobEdit(JobMixin, JobCreateEditMixin, UpdateView):
 
     def form_valid(self, form):
         """ set last_modified_by to the current user """
-        form = super().form_valid(form)
-        self.object.last_modified_by = self.request.user
-        self.object.save()
-
-        return form
+        form.instance.last_modified_by = self.request.user
+        return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(


### PR DESCRIPTION
Use AppConfig.ready() to register signals.
