### PR TITLE
Update job board email texts

### DIFF
--- a/jobs/listeners.py
+++ b/jobs/listeners.py
@@ -1,17 +1,17 @@
 from django.db import models
+from django.dispatch import receiver
+from django.contrib.comments.signals import comment_was_posted
 from django.contrib.sites.models import Site
 from django.template import loader, Context
 from django.utils.translation import ugettext_lazy as _
 from django_comments_xtd.conf import settings
 from django_comments_xtd.utils import send_mail
 
-### Globals
+from .models import Job
+from .signals import job_was_approved, job_was_rejected
 
-# Python job board team email address
-EMAIL_JOBS_BOARD = 'jobs@python.org'
 
-###
-
+@receiver(comment_was_posted)
 def on_comment_was_posted(sender, comment, request, **kwargs):
     """
     Notify the author of the post when the first comment has been posted.
@@ -20,19 +20,22 @@ def on_comment_was_posted(sender, comment, request, **kwargs):
     `.forms.JobCommentForm` forces `follow_up` to `True` and Django-comments-xtd
     will already notify followers.
     """
+    Job = models.get_model('jobs', 'Job')
+
     # Skip if this is not a 'first comment'
     if comment.level > 0 or comment.order > 1:
         return False
 
-    # Skip if we're not commenting on a Job
-    Job = models.get_model('jobs', 'Job')
+    # RSkip if we're not commenting on a Job
     model = comment.content_type.model_class()
     if model != Job:
         return False
 
     job = model._default_manager.get(pk=comment.object_pk)
+
     email = job.email
     name = job.contact
+
 
     subject = _("new comment posted")
     text_message_template = loader.get_template("django_comments_xtd/email_job_added_comment.txt")
@@ -44,8 +47,7 @@ def on_comment_was_posted(sender, comment, request, **kwargs):
                                 'site': Site.objects.get_current() })
     text_message = text_message_template.render(message_context)
     html_message = html_message_template.render(message_context)
-    send_mail(subject, text_message, settings.DEFAULT_FROM_EMAIL,
-              [email], html=html_message)
+    send_mail(subject, text_message, settings.DEFAULT_FROM_EMAIL, [ email, ], html=html_message)
 
 
 def send_job_review_message(job, user, subject_template_path,
@@ -64,10 +66,10 @@ def send_job_review_message(job, user, subject_template_path,
     # subject can't contain newlines, thus strip() call
     subject = subject_template.render(message_context).strip()
     message = message_template.render(message_context)
-    send_mail(subject, message, settings.DEFAULT_FROM_EMAIL,
-              [job.email])
+    send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [job.email])
 
 
+@receiver(job_was_approved)
 def on_job_was_approved(sender, job, approving_user, **kwargs):
     """Handle approving job offer. Currently an email should be sent to the
     person that sent the offer.
@@ -77,6 +79,7 @@ def on_job_was_approved(sender, job, approving_user, **kwargs):
                             'jobs/email/job_was_approved.txt')
 
 
+@receiver(job_was_rejected)
 def on_job_was_rejected(sender, job, rejecting_user, **kwargs):
     """Handle rejecting job offer. Currently an email should be sent to the
     person that sent the offer.
@@ -86,16 +89,12 @@ def on_job_was_rejected(sender, job, rejecting_user, **kwargs):
                             'jobs/email/job_was_rejected.txt')
 
 
-def on_job_was_submitted(sender, instance, created=False, **kwargs):
+@receiver(models.signals.post_save, sender=Job, dispatch_uid="job_was_submitted")
+def on_job_was_submitted(sender, instance, **kwargs):
     """
     Notify the jobs board when a new job has been submitted for approval
 
     """
-    # Only send emails for newly created Jobs
-    if not created:
-        return
-
-    # Only new Jobs in review status should trigger the email
     Job = models.get_model('jobs', 'Job')
     if instance.status != Job.STATUS_REVIEW:
         return
@@ -108,5 +107,4 @@ def on_job_was_submitted(sender, instance, created=False, **kwargs):
     subject = subject_template.render(message_context)
     message = message_template.render(message_context)
 
-    send_mail(subject, message, settings.DEFAULT_FROM_EMAIL,
-              [EMAIL_JOBS_BOARD])
+    send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, ['jobs@python.org'])

--- a/templates/jobs/email/job_was_approved.txt
+++ b/templates/jobs/email/job_was_approved.txt
@@ -1,10 +1,10 @@
 Dear {{ addressee }},
 
-Thank you for choosing to list your vacancy on python.org's Job Board.
+Thank you for choosing to list your vacancy on the PSF Python Job Board.
 
 Your listing is now active and is available to view at {{ job_link }}. If
 you notice any errors in the listing, please notify the Job Board team as
-soon as possible.
+soon as possible at jobs@python.org.
 
 To keep the job board fresh and active for job seekers, we'd appreciate if
 you'd let us know as soon as possible when the position is filled so we can

--- a/templates/jobs/email/job_was_rejected.txt
+++ b/templates/jobs/email/job_was_rejected.txt
@@ -1,10 +1,12 @@
 Dear {{ addressee }},
 
-Thank you for choosing to list your vacancy on python.org's Job Board.
+Thank you for choosing to list your vacancy on the PSF Python Job Board.
 
 Unfortunately, your listing does not comply to our Job Board listing
 guidelines (see https://www.python.org/community/jobs/howto/). If possible,
 please update your listing and resubmit the request.
+
+If you have questions, please contact the Job Board Team at jobs@python.org.
 
 Many thanks,
 {{ reviewer_name }}


### PR DESCRIPTION
Include the jobs@python.org email address.

Use PSF Python Job Board instead of python.org's Job Board.

Fixes #683.
