### PR TITLE
Do not show docutils error messages for now.

### DIFF
--- a/docutils.conf
+++ b/docutils.conf
@@ -1,0 +1,3 @@
+[general]
+halt_level=5
+report_level=5


### PR DESCRIPTION
This is a temporary workaround for #652.

Another option would be override the warning_stream option: http://docutils.sourceforge.net/docs/user/config.html#warning-stream
