### PR TITLE
admin.autodiscover() call is not necessary anymore.

### DIFF
--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -9,8 +9,6 @@ from cms.views import custom_404
 from . import views
 from .urls_api import v1_api
 
-admin.autodiscover()
-
 handler404 = custom_404
 
 urlpatterns = [


### PR DESCRIPTION
AdminConfig calls autodiscover when Django starts.

https://docs.djangoproject.com/en/1.7/ref/contrib/admin/#django.contrib.admin.autodiscover
