### PR TITLE
Fix "Not a gzipped file" error in generate_dev_fixtures command.

### DIFF
--- a/cms/management/commands/generate_dev_fixtures.py
+++ b/cms/management/commands/generate_dev_fixtures.py
@@ -63,7 +63,6 @@ class Command(BaseCommand):
                     continue
                 try:
                     model = app_config.get_model(model_label)
-                    print(model)
                 except LookupError:
                     raise CommandError("Unknown model: %s.%s" % (app_label, model_label))
 
@@ -114,6 +113,5 @@ class Command(BaseCommand):
         )
 
         data = bytes(data, 'utf-8')
-        out = open(outputfile, 'wb')
-        out.write(gzip.compress(data))
-        out.close()
+        with gzip.open(outputfile, 'wb') as out:
+            out.write(data)


### PR DESCRIPTION
Here is the traceback:

```
$ ./manage.py load_dev_fixtures
/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/contrib/comments/__init__.py:13: RemovedInDjango18Warning: django.contrib.comments is deprecated and will be removed before Django 1.8.
  warnings.warn("django.contrib.comments is deprecated and will be removed before Django 1.8.", RemovedInDjango18Warning)

You have requested to load the python.org development fixtures.
This will IRREVERSIBLY DESTROY all data currently in your local database.
Are you sure you want to do this?

    Type 'yes' to continue, or 'no' to cancel:  yes

Beginning download, note this can take a couple of minutes...
Unable to download file: Received status code 404
Download complete, loading fixtures
Traceback (most recent call last):
  File "./manage.py", line 8, in <module>
    execute_from_command_line(sys.argv)
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/management/__init__.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/management/base.py", line 533, in handle
    return self.handle_noargs(**options)
  File "/home/berker/projects/pythondotorg/cms/management/commands/load_dev_fixtures.py", line 38, in handle_noargs
    call_command('loaddata', '/tmp/dev-fixtures.json')
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/management/commands/loaddata.py", line 61, in handle
    self.loaddata(fixture_labels)
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/management/commands/loaddata.py", line 91, in loaddata
    self.load_label(fixture_label)
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/management/commands/loaddata.py", line 142, in load_label
    for obj in objects:
  File "/home/berker/projects/pythondotorg/venv/lib/python3.3/site-packages/django/core/serializers/json.py", line 70, in Deserializer
    stream_or_string = stream_or_string.read()
  File "/usr/local/lib/python3.3/gzip.py", line 360, in read
    self._read(readsize)
  File "/usr/local/lib/python3.3/gzip.py", line 441, in _read
    self._read_gzip_header()
  File "/usr/local/lib/python3.3/gzip.py", line 290, in _read_gzip_header
    raise IOError('Not a gzipped file')
OSError: Problem installing fixture '/tmp/dev-fixtures.json.gz': Not a gzipped file
```
