### PR TITLE
Clarify setup choice in the 'Installing' guide.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,8 +1,10 @@
 Installing
 ==========
 
-Using Vagrant
--------------
+Here are two ways to hack on python.org:
+
+a. Easy setup using Vagrant
+---------------------------
 
 You can ignore the below instructions by using Vagrant::
 
@@ -16,7 +18,7 @@ activated upon login.
 .. note:: You will need to run ``./manage.py createsuperuser`` to use the admin.
 
 
-Getting started
+b. Manual setup
 ---------------
 
 First, clone the repository::


### PR DESCRIPTION
Formerly there was 'Vagrant', followed by 'Getting Started', which left me puzzled and wondering if/why I should do both. Does this make more sense?
