### PR TITLE
Fix #225 - Add some useful help to the 404 page.

### DIFF
--- a/cms/tests.py
+++ b/cms/tests.py
@@ -5,6 +5,7 @@ from django.template import Template, Context
 from django.test import TestCase
 
 from .admin import ContentManageableModelAdmin
+from .views import legacy_path
 import datetime
 
 
@@ -74,6 +75,9 @@ class TemplateTagsTest(unittest.TestCase):
 
 
 class Test404(TestCase):
+    def test_legacy_path(self):
+        self.assertEqual(legacy_path('/any/thing'), 'http://legacy.python.org/any/thing')
+
     def test_custom_404(self):
         """ Ensure custom 404 is set to 5 minutes """
         response = self.client.get('/foo-bar/baz/9876')

--- a/cms/views.py
+++ b/cms/views.py
@@ -1,10 +1,25 @@
+from django.core.urlresolvers import reverse
 from django.shortcuts import render
+from urllib.parse import urljoin
+
+LEGACY_PYTHON_DOMAIN = 'http://legacy.python.org'
+PYPI_URL = 'https://pypi.python.org/'
+
+
+def legacy_path(path):
+    """Build a path to the same path under the legacy.python.org domain."""
+    return urljoin(LEGACY_PYTHON_DOMAIN, path)
 
 
 def custom_404(request, template_name='404.html'):
     """ Custom 404 handler to only cache 404s for 5 mintues """
 
-    response = render(request, template_name)
+    response = render(request, template_name,
+                      {'legacy_path': legacy_path(request.path),
+                       'download_path': reverse('download:download'),
+                       'doc_path': reverse('documentation'),
+                       'pypi_path': PYPI_URL
+                       })
     response['Cache-Control'] = 'max-age=300'
     response.status_code = 404
 

--- a/templates/404.html
+++ b/templates/404.html
@@ -8,7 +8,13 @@
             
         <h1 class="giga">Error 404: File not Found</h1>
         
-        <p>We couldn&rsquo;t find what you were looking for. This error has been reported and we will look into it shortly.</p>
+        <p>We couldn&rsquo;t find what you were looking for. This error has been reported and we will look into it shortly. For now,</p>
+
+        <ul>
+            <li>Try using the search box.</li>
+            <li>Python.org went through a redesign and you may have followed a broken link. Sorry for that, see if <a href="{{ legacy_path }}">the same page on the legacy website</a> works.</li>
+            <li>Lost in an exotic function call? Read <a href="{{ doc_path }}">the docs</a>. Looking for a package? Check the <a href="{{ pypi_path }}">Package Index</a>. Need a specific version of Python? The <a href="{{ download_path }}">Downloads section</a> has it.</li>
+        </ul>
         
     </article>
     


### PR DESCRIPTION
- Provide a direct link to the legacy version of the same path.
- Mention the search box.
- List some high level entry points: documentation, pypi, downloads.
