### PR TITLE
Add og:title for each page

### DIFF
--- a/templates/blogs/index.html
+++ b/templates/blogs/index.html
@@ -2,6 +2,7 @@
 {% load boxes %}
 
 {% block page_title %}Our Blogs | {{ SITE_INFO.site_name }}{% endblock %}
+{% block og_title %}Our Blogs{% endblock %}
 
 {% block body_attributes %}class="python blog"{% endblock %}
 

--- a/templates/community/post_detail.html
+++ b/templates/community/post_detail.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block page_title %}{{ object.title }} | {{ SITE_INFO.site_name }}{% endblock %}
+{% block og_title %}{{ object.title }}{% endblock %}
 
 {% block body_attributes %}class="python community default-page"{% endblock %}
 

--- a/templates/community/post_list.html
+++ b/templates/community/post_list.html
@@ -3,6 +3,7 @@
 {% load community %}
 
 {% block page_title %}Our Community | {{ SITE_INFO.site_name }}{% endblock %}
+{% block og_title %}Our Community{% endblock %}
 
 {% block body_attributes %}class="python community"{% endblock %}
 

--- a/templates/downloads/full_os_list.html
+++ b/templates/downloads/full_os_list.html
@@ -11,6 +11,7 @@
 
 
 {% block page_title %}Python Operating Systems List | {{ SITE_INFO.site_name }}{% endblock %}
+{% block og_title %}Python Operating Systems List{% endblock %}
 
 
 {% block content %}

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -2,6 +2,7 @@
 {% load boxes %}
 
 {% block page_title %}Download Python | {{ SITE_INFO.site_name }}{% endblock %}
+{% block og_title %}Download Python{% endblock %}
 
 {% block body_attributes %}class="python download"{% endblock %}
 

--- a/templates/downloads/os_list.html
+++ b/templates/downloads/os_list.html
@@ -15,6 +15,8 @@
 {% if os.slug == 'source' %}Python Source Releases{% else %}Python Releases for {{ os.name }}{% endif %} | {{ SITE_INFO.site_name }}
 {% endblock %}
 
+{% block og_title %}Python{% if os.slug == 'source' %} Source{% endif %} Releases for {{ os.name }}{% endblock %}
+
 
 {% block content %}
     <article class="text">

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -12,6 +12,7 @@
 
 
 {% block page_title %}Python Release {{ release.name }} | {{ SITE_INFO.site_name }}{% endblock %}
+{% block og_title %}Python Release {{ release.name }}{% endblock %}
 
 
 {% block content %}

--- a/templates/events/calendar_list.html
+++ b/templates/events/calendar_list.html
@@ -2,6 +2,7 @@
 {% load boxes %}
 
 {% block page_title %}Python Calendars | {{ SITE_INFO.site_name }}{% endblock %}
+{% block og_title %}Python Calendars{% endblock %}
 
 {% block body_attributes %}class="python events list-calendars default-page"{% endblock %}
 

--- a/templates/events/event_detail.html
+++ b/templates/events/event_detail.html
@@ -2,6 +2,7 @@
 
 
 {% block page_title %}{{ object.title|striptags }} | {{ SITE_INFO.site_name }}{% endblock %}
+{% block og_title %}{{ object.title|striptags }}{% endblock %}
 
 {% block body_attributes %}class="python default-page single-event"{% endblock %}
 

--- a/templates/events/event_list.html
+++ b/templates/events/event_list.html
@@ -2,6 +2,7 @@
 {% load boxes %}
 
 {% block page_title %}Our Events | {{ SITE_INFO.site_name }}{% endblock %}
+{% block og_title %}Our Events{% endblock %}
 
 {% block body_attributes %}class="python events{% if not featured %} default-page{% endif %}"{% endblock %}
 

--- a/templates/events/event_list_past.html
+++ b/templates/events/event_list_past.html
@@ -2,6 +2,7 @@
 {% load boxes %}
 
 {% block page_title %}Our Events | {{ SITE_INFO.site_name }}{% endblock %}
+{% block og_title %}Our Past Events{% endblock %}
 
 {% block body_attributes %}class="python events{% if not featured %} default-page{% endif %}"{% endblock %}
 


### PR DESCRIPTION
Currently every page is using the same `og:title="Welcome to Python.org"`, which is not better than nothing.

I am planing to add `og:title` and `og:description` for every page. Here are some pages that I've modified. It seems that the `{% block page_title %}` shares the pattern **og_title + site_name**. I think it is better to write a macro to render them together.
