### PR TITLE
Add status badge for RTD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # python.org
 
 [![Build Status](https://travis-ci.org/python/pythondotorg.png?branch=master)](https://travis-ci.org/python/pythondotorg)
+[![Documentation Status](https://readthedocs.org/projects/pythondotorg/badge/?version=latest)](http://pythondotorg.readthedocs.org/?badge=latest)
 
 ### General information
 


### PR DESCRIPTION
Add status badge from Read The Docs build to README.

@berkerpeksag Small change. Let me know if you want me to open a corresponding issue.
