### PR TITLE
Edit documentation on pep generation

### DIFF
--- a/docs/source/pep_generation.rst
+++ b/docs/source/pep_generation.rst
@@ -7,22 +7,17 @@ Process Overview
 ----------------
 
 We are generating the PEP pages by lightly parsing the HTML output from the
-`PEP Mercurial Repository <http://hg.python.org/peps/>`_ and then cleaning up
-some post-parsing formatting.
+`PEP Repository`_ and then cleaning up some post-parsing formatting.
 
 The PEP Page Generation process is as follows:
 
-1. Clone and/or update the PEP repo located in ``settings.PEP_REPO_PATH`` to
-   the latest revision.
+1. Set ``PEP_REPO_PATH`` in ``pydotorg/settings/local.py`` to the location
+   of the `PEP Repository`_.
 2. Run ``pep2html.py``
 3. Run ``genpepindex.py``
 4. After all PEP pages are generated into HTML, run::
 
-   ./manage.py generate_pep_pages
-
-.. caution:: Steps 2 and 3 must be run using **Python 2**.
-             Python 3, which builds the rest of Python.org, may not be used
-             at this time.
+   $ ./manage.py generate_pep_pages
 
 This process runs periodically via cron to keep the PEP pages up to date.
 
@@ -35,11 +30,11 @@ generate_pep_pages
 This Django management command generates ``pages.Page`` objects from the output
 of the existing PEP repository generation process. You run it like::
 
-    ./manage.py generate_pep_pages
+    $ ./manage.py generate_pep_pages
 
 To get verbose output run it like::
 
-    ./manage.py generate_pep_pages --verbosity=2
+    $ ./manage.py generate_pep_pages --verbosity=2
 
 It uses the conversion code in the ``peps.converters`` module in an attempt to
 normalize the formatting for display purposes.
@@ -47,7 +42,7 @@ normalize the formatting for display purposes.
 dump_pep_pages
 ^^^^^^^^^^^^^^
 
-This simply dumps our PEP related pages as JSON like ``dumpdata`` would do
-with a ``--pks options`` if the site was using Django 1.6 or newer. The
-``dumpdata`` content is written to ``stdout`` just like a normal ``dumpdata``
-command.
+This simply dumps our PEP related pages as JSON. The ``dumpdata`` content is
+written to ``stdout`` just like a normal ``dumpdata`` command.
+
+.. _PEP Repository: https://hg.python.org/peps/

--- a/docs/source/pep_generation.rst
+++ b/docs/source/pep_generation.rst
@@ -6,18 +6,25 @@ PEP Page Generation
 Process Overview
 ----------------
 
-We are generating the PEP pages by lightly parsing and cleaning up the HTML output from the `PEP Mercurial Repository <http://hg.python.org/peps/>`_.
+We are generating the PEP pages by lightly parsing the HTML output from the
+`PEP Mercurial Repository <http://hg.python.org/peps/>`_ and then cleaning up
+some post-parsing formatting.
 
-The process is as follows:
+The PEP Page Generation process is as follows:
 
-1. Clone and/or update the PEP repo located in `settings.PEP_REPO_PATH` to the latest revision.
-2. Run `pep2html.py`
-3. Run `genpepindex.py`
-4. Once all PEP HTML pages are generated, run `./manage.py generate_pep_pages`
+1. Clone and/or update the PEP repo located in ``settings.PEP_REPO_PATH`` to
+   the latest revision.
+2. Run ``pep2html.py``
+3. Run ``genpepindex.py``
+4. After all PEP pages are generated into HTML, run::
 
-.. note:: Steps 2 and 3 currently must be run using Python 2 and **NOT** Python 3 like the rest of Python.org
+   ./manage.py generate_pep_pages
 
-This process will be run periodically via cron to keep the PEP pages up to date.
+.. caution:: Steps 2 and 3 must be run using **Python 2**.
+             Python 3, which builds the rest of Python.org, may not be used
+             at this time.
+
+This process runs periodically via cron to keep the PEP pages up to date.
 
 Management Commands
 -------------------
@@ -25,8 +32,8 @@ Management Commands
 generate_pep_pages
 ^^^^^^^^^^^^^^^^^^
 
-This Django management command generates `pages.Page` objects based on the output of the existing PEP repository
-generation process. You run it like::
+This Django management command generates ``pages.Page`` objects from the output
+of the existing PEP repository generation process. You run it like::
 
     ./manage.py generate_pep_pages
 
@@ -34,11 +41,13 @@ To get verbose output run it like::
 
     ./manage.py generate_pep_pages --verbosity=2
 
-It uses the conversion code in the `peps.converters` module in an attempt to normalize the formatting for display
-purposes.
+It uses the conversion code in the ``peps.converters`` module in an attempt to
+normalize the formatting for display purposes.
 
 dump_pep_pages
 ^^^^^^^^^^^^^^
 
-This simply dumps our PEP related pages as JSON like dumpdata would do with a --pks options if the site was using
-Django 1.6 or newer. The dumpdata content is written to stdout just like a normal dumpdata command.
+This simply dumps our PEP related pages as JSON like ``dumpdata`` would do
+with a ``--pks options`` if the site was using Django 1.6 or newer. The
+``dumpdata`` content is written to ``stdout`` just like a normal ``dumpdata``
+command.

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -4,7 +4,9 @@ DEBUG = TEMPLATE_DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
-PYTHON_ORG_CONTENT_SVN_PATH='/Users/flavio/working_copies/beta.python.org/build/data'
+# Set the path to the location of the content files for python org
+# For example, PYTHON_ORG_CONTENT_SVN_PATH='/Users/flavio/working_copies/beta.python.org/build/data'
+PYTHON_ORG_CONTENT_SVN_PATH=''
 
 DATABASES = {
     'default': dj_database_url.config(default='postgres:///pythondotorg')
@@ -20,7 +22,9 @@ HAYSTACK_CONNECTIONS = {
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-PEP_REPO_PATH = '/Users/frank/work/src/pythondotorg/tmp/peps'
+# Set the path to where the pep repo's html source files are located
+# For example, PEP_REPO_PATH = '/Users/frank/work/src/pythondotorg/tmp/peps'
+PEP_REPO_PATH = ''
 
 # Use Dummy SASS compiler to avoid performance issues and remove the need to
 # have a sass compiler installed at all during local development if you aren't


### PR DESCRIPTION
Cleaned up the developer documentation of how peps are generated for rendering on pythondotog. This is a first step to addressing #825.
- Edited formatting
- Reflowed text for line length
- Switched note box to a caution box
