### PR TITLE
Update download supernav to indicate that WinXP is not supported on W…

### DIFF
--- a/templates/downloads/supernav.html
+++ b/templates/downloads/supernav.html
@@ -12,7 +12,7 @@
             <a class="button" href="{{ data.python2.url }}">{{ data.python2.release.name }}</a>
         </p>
         <p>{{navigator.appVersion}}</p>
-        {% if data.os.slug == 'windows' and data.python3.release.name >= 'Python 3.5' %}<p><b>NB Python 3.5+ <i>cannot</i> be used on WinXP or earlier</b></p>{% endif %}
+        {% if data.os.slug == 'windows' and data.python3.release.name >= 'Python 3.5' %}<p><strong>NB Python 3.5+ <em>cannot</em> be used on WinXP or earlier</strong></p>{% endif %}
         <p>Not the OS you are looking for? Python can be used on many operating systems and environments. <a href="{% url 'download:download' %}">View the full list of downloads</a>.</p>
     </div>
     {% endfor %}
@@ -20,7 +20,7 @@
         <h4>Download Python for Any OS</h4>
         <p>Python can be used on many operating systems and environments.</p>
         <p>
-            <a class="button" href="{% url 'download:download_full_os_list' %}">View the Full List of downloads</a>
+            <a class="button" href="{% url 'download:download_full_os_list' %}">View the full list of downloads</a>
         </p>
     </div>
 </li>

--- a/templates/downloads/supernav.html
+++ b/templates/downloads/supernav.html
@@ -11,14 +11,16 @@
             <a class="button" href="{{ data.python3.url }}">{{ data.python3.release.name }}</a>
             <a class="button" href="{{ data.python2.url }}">{{ data.python2.release.name }}</a>
         </p>
-        <p>Not the OS you are looking for? Python can be used on 21 different operating systems and environments. <a href="{% url 'download:download' %}">View the full list</a>.</p>
+        <p>{{navigator.appVersion}}</p>
+        {% if data.os.slug == 'windows' and data.python3.release.name >= 'Python 3.5' %}<p><b>NB Python 3.5+ <i>cannot</i> be used on WinXP or earlier</b></p>{% endif %}
+        <p>Not the OS you are looking for? Python can be used on many operating systems and environments. <a href="{% url 'download:download' %}">View the full list of downloads</a>.</p>
     </div>
     {% endfor %}
     <div class="download-unknown">
         <h4>Download Python for Any OS</h4>
-        <p>Python can be used on 21 different operating systems and environments.</p>
+        <p>Python can be used on many operating systems and environments.</p>
         <p>
-            <a class="button" href="{% url 'download:download_full_os_list' %}">View the Full List</a>
+            <a class="button" href="{% url 'download:download_full_os_list' %}">View the Full List of downloads</a>
         </p>
     </div>
 </li>


### PR DESCRIPTION
…indows for 3.5 or later

This addresses the principal issue raised in #867:
- The "21 platforms" text is made more general
- If the browser is detected as Windows and the latest 3.x version is 3.5 or greater, an additional warning is issued indicating the WinXP is not supported
