### PR TITLE
Explain the codebase of python.org website

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,10 @@
 * Mailing list: [pydotorg-www](https://mail.python.org/mailman/listinfo/pydotorg-www)
 * IRC: `#pydotorg` on Freenode
 * Staging site: https://staging.python.org/ (`master` branch)
-* License: Apache License
+* License: Apache 2.0 License
+
+python.org is a **Django** based web site, which uses several `applications` for different parts of site. The main entry point is the [pydotorg](https://github.com/python/pythondotorg/tree/master/pydotorg) application, which contains [root URL mapping](https://github.com/python/pythondotorg/blob/master/pydotorg/urls.py). Applications are contained in their own directories at repository root, and maintain their own URL maps (in `urls.py` file), data models (`models.py`) and view (request processing logic in `views.py`).
+
+Jobs application relies on **specific features of PostgreSQL** database (#911). Site stylesheets are compiled using [compass](http://compass-style.org/), which in turn requires **Ruby**.
+
+Site management is done with standard Django **manage.py** script located in the root of this repository.


### PR DESCRIPTION
Closes #907. Addresses #911.
