### PR TITLE
Google code is no longer supported

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ psycopg2==2.6
 python3-openid==3.0.5
 lxml==3.4.4
 cssselect==0.9.1
-git+https://code.google.com/p/feedparser/@dc3bd29bfc1b#egg=feedparser
+git+https://github.com/kurtmckee/feedparser.git@dc3bd29bfc1b#egg=feedparser
 beautifulsoup4==4.3.2
 icalendar==3.8.4
 chardet2==2.0.3


### PR DESCRIPTION
Google code is no longer supported

pip install -r requirements.txt

```
Collecting feedparser from git+https://code.google.com/p/feedparser/@dc3bd29bfc1b#egg=feedparser (from -r requirements.txt (line 16))
  Cloning https://code.google.com/p/feedparser/ (to dc3bd29bfc1b) to /private/var/folders/yd/9m7ngvrs65g4n7b4zv8txhvw0000gn/T/pip-build-njebreiy/feedparser
fatal: repository 'https://code.google.com/p/feedparser/' not found
Command "git clone -q https://code.google.com/p/feedparser/ /private/var/folders/yd/9m7ngvrs65g4n7b4zv8txhvw0000gn/T/pip-build-njebreiy/feedparser" failed with error code 128 in None
```
