### PR TITLE
Redirect python.org/blog to blogs.python.org

### DIFF
--- a/blogs/tests/test_views.py
+++ b/blogs/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.core.management import call_command
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.conf import settings
 
 from boxes.models import Box
 
@@ -32,3 +33,12 @@ class BlogViewTest(TestCase):
 
         latest = BlogEntry.objects.latest()
         self.assertEqual(resp.context['latest_entry'], latest)
+
+    def test_blog_redirects(self):
+        """
+        Test that when '/blog/' is hit, it redirects to blog.python.org
+        """
+        response = self.client.get('/blog/', follow=True)
+        self.assertRedirects(response,
+                             settings.PYTHON_BLOG_URL,
+                             status_code=301)

--- a/blogs/tests/test_views.py
+++ b/blogs/tests/test_views.py
@@ -1,7 +1,6 @@
 from django.core.management import call_command
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from django.conf import settings
 
 from boxes.models import Box
 
@@ -36,9 +35,9 @@ class BlogViewTest(TestCase):
 
     def test_blog_redirects(self):
         """
-        Test that when '/blog/' is hit, it redirects to blog.python.org
+        Test that when '/blog/' is hit, it redirects '/blogs/'
         """
-        response = self.client.get('/blog/', follow=True)
+        response = self.client.get('/blog/')
         self.assertRedirects(response,
-                             settings.PYTHON_BLOG_URL,
+                             '/blogs/',
                              status_code=301)

--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
     url(r'^downloads/', include('downloads.urls', namespace='download')),
     url(r'^doc/$', TemplateView.as_view(template_name="python/documentation.html"), name='documentation'),
     #url(r'^community/$', TemplateView.as_view(template_name="python/community.html"), name='community'),
-    url(r'^blog/$', RedirectView.as_view(url=settings.PYTHON_BLOG_URL)),
+    url(r'^blog/$', RedirectView.as_view(url='/blogs/', permanent=True)),
     url(r'^blogs/$', include('blogs.urls')),
     url(r'^inner/$', TemplateView.as_view(template_name="python/inner.html"), name='inner'),
 

--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
     url(r'^downloads/', include('downloads.urls', namespace='download')),
     url(r'^doc/$', TemplateView.as_view(template_name="python/documentation.html"), name='documentation'),
     #url(r'^community/$', TemplateView.as_view(template_name="python/community.html"), name='community'),
-    url(r'^blog/$', TemplateView.as_view(template_name="python/blog.html"), name='blog'),
+    url(r'^blog/$', RedirectView.as_view(url=settings.PYTHON_BLOG_URL)),
     url(r'^blogs/$', include('blogs.urls')),
     url(r'^inner/$', TemplateView.as_view(template_name="python/inner.html"), name='inner'),
 


### PR DESCRIPTION
For #1002 
