### PR TITLE
Remove lengthy text in job info box

### DIFF
--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -14,8 +14,7 @@
 
     {% if request.user.is_staff %}
     <p class="user-feedback level-notice">
-        This job is in <strong>{{ object.status }}</strong> mode. You're able
-        to see this because you're in the staff or super user group.
+        This job is in <strong>{{ object.status }}</strong> mode.
     </p>
     {% endif %}
 


### PR DESCRIPTION
Based on discussion in https://github.com/python/pythondotorg/pull/672

Keeping the text inside job info box short.
