### PR TITLE
Improve documentation for generating PEP pages.

### DIFF
--- a/docs/source/pep_generation.rst
+++ b/docs/source/pep_generation.rst
@@ -11,11 +11,20 @@ We are generating the PEP pages by lightly parsing the HTML output from the
 
 The PEP Page Generation process is as follows:
 
-1. Set ``PEP_REPO_PATH`` in ``pydotorg/settings/local.py`` to the location
-   of the `PEP Repository`_.
-2. Run ``pep2html.py``
-3. Run ``genpepindex.py``
-4. After all PEP pages are generated into HTML, run::
+1. Check out PEP Repository, if you have not done so::
+
+      $ hg clone https://hg.python.org/peps/
+
+2. From cloned PEP Repository, run::
+
+
+      $ pep2html.py
+      $ genpepindex.py
+
+3. Set ``PEP_REPO_PATH`` in ``pydotorg/settings/local.py`` to the location
+   of the cloned PEP Repository
+
+5. After all PEP pages are generated into HTML, run in pythondotorg repository::
 
    $ ./manage.py generate_pep_pages
 

--- a/docs/source/pep_generation.rst
+++ b/docs/source/pep_generation.rst
@@ -11,20 +11,18 @@ We are generating the PEP pages by lightly parsing the HTML output from the
 
 The PEP Page Generation process is as follows:
 
-1. Check out PEP Repository, if you have not done so::
+1. Clone the PEP Repository, if you have not already done so::
 
-      $ hg clone https://hg.python.org/peps/
+      $ git clone https://github.com/python/peps.git
 
-2. From cloned PEP Repository, run::
+2. From the cloned PEP Repository, run::
 
-
-      $ pep2html.py
-      $ genpepindex.py
+      $ make -j
 
 3. Set ``PEP_REPO_PATH`` in ``pydotorg/settings/local.py`` to the location
    of the cloned PEP Repository
 
-4. After all PEP pages are generated into HTML, run in pythondotorg repository::
+4. Run in your ``pythondotorg`` repository::
 
    $ ./manage.py generate_pep_pages
 
@@ -54,4 +52,4 @@ dump_pep_pages
 This simply dumps our PEP related pages as JSON. The ``dumpdata`` content is
 written to ``stdout`` just like a normal ``dumpdata`` command.
 
-.. _PEP Repository: https://hg.python.org/peps/
+.. _PEP Repository: https://github.com/python/peps.git

--- a/docs/source/pep_generation.rst
+++ b/docs/source/pep_generation.rst
@@ -24,7 +24,7 @@ The PEP Page Generation process is as follows:
 3. Set ``PEP_REPO_PATH`` in ``pydotorg/settings/local.py`` to the location
    of the cloned PEP Repository
 
-5. After all PEP pages are generated into HTML, run in pythondotorg repository::
+4. After all PEP pages are generated into HTML, run in pythondotorg repository::
 
    $ ./manage.py generate_pep_pages
 


### PR DESCRIPTION
Add instruction on how to clone PEP repo.
Also be more specific of where pep2html.py and genpepindex.py should be run from.
