### PR TITLE
Add styling to admonitions

### DIFF
--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -2949,10 +2949,10 @@ p.quote-by-organization {
 div.note {
   background-color: #eee;
   border: 1px solid #cccccc;
-  padding: 5px 10px; }
+  padding: 0.3125em 0.625em; }
 
 p.admonition-title {
-  margin: 0px 10px 5px 0px;
+  margin-bottom: 0.3125em;
   font-weight: bold; }
 
 /* ! ===== Slideshow requirements ===== */

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -187,7 +187,7 @@
   color: #4d4d4d !important;
   font-weight: normal;
   margin-bottom: 0.4375em;
-  padding: .4em .75em .35em;
+  padding: 0.4em 0.75em 0.35em;
   text-align: left;
   white-space: nowrap;
   text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.3);
@@ -211,11 +211,11 @@
   -webkit-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05), inset 0 0 5px rgba(255, 255, 255, 0.5);
   -moz-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05), inset 0 0 5px rgba(255, 255, 255, 0.5);
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05), inset 0 0 5px rgba(255, 255, 255, 0.5); }
-  .search-button:hover, #dive-into-python .flex-control-paging a:hover, .text form button:hover, .text form input[type=submit]:hover,
+  .header-banner .button:hover, .header-banner a.button:hover, .search-button:hover, #dive-into-python .flex-control-paging a:hover, .text form button:hover, .text form input[type=submit]:hover,
   .sidebar-widget form button:hover,
-  .sidebar-widget form input[type=submit]:hover, input[type=submit]:hover, input[type=reset]:hover, button:hover, .button:hover, .search-button:focus, #dive-into-python .flex-control-paging a:focus, .text form button:focus, .text form input[type=submit]:focus,
+  .sidebar-widget form input[type=submit]:hover, input[type=submit]:hover, input[type=reset]:hover, button:hover, .button:hover, .header-banner .button:focus, .header-banner a.button:focus, .search-button:focus, #dive-into-python .flex-control-paging a:focus, .text form button:focus, .text form input[type=submit]:focus,
   .sidebar-widget form button:focus,
-  .sidebar-widget form input[type=submit]:focus, input[type=submit]:focus, input[type=reset]:focus, button:focus, .button:focus, .search-button:active, #dive-into-python .flex-control-paging a:active, .text form button:active, .text form input[type=submit]:active,
+  .sidebar-widget form input[type=submit]:focus, input[type=submit]:focus, input[type=reset]:focus, button:focus, .button:focus, .header-banner .button:active, .header-banner a.button:active, .search-button:active, #dive-into-python .flex-control-paging a:active, .text form button:active, .text form input[type=submit]:active,
   .sidebar-widget form button:active,
   .sidebar-widget form input[type=submit]:active, input[type=submit]:active, input[type=reset]:active, button:active, .button:active {
     color: #1a1a1a !important;
@@ -241,7 +241,7 @@
   border-right: 1px solid #dca900;
   border-bottom: 1px solid #dca900;
   border-left: 1px solid #dca900; }
-  .psf-widget .button:hover, .python-needs-you-widget .button:hover, .header-banner .button:hover, .psf-widget .button:active, .python-needs-you-widget .button:active, .header-banner .button:active {
+  .psf-widget .button:hover, .python-needs-you-widget .button:hover, .header-banner .button:hover, .header-banner a.button:hover, .psf-widget .button:active, .python-needs-you-widget .button:active, .header-banner .button:active, .header-banner a.button:active {
     background-color: inherit;
     background-color: #ffd343;
     *zoom: 1;
@@ -314,7 +314,7 @@ button[type=submit], .search-button, #dive-into-python .flex-control-paging a, .
   /* Used in the pagination UL anchors, and in the Previous Next pattern */
   display: block;
   color: #999999;
-  padding: .5em .75em .4em;
+  padding: 0.5em 0.75em 0.4em;
   border: 1px solid #caccce;
   background-color: transparent; }
 
@@ -462,8 +462,8 @@ ins {
 
 mark {
   display: inline-block;
-  padding: 0 .25em;
-  margin: 0 -.125em;
+  padding: 0 0.25em;
+  margin: 0 -0.125em;
   background-color: #ffb;
   /* light yellow */ }
 
@@ -562,7 +562,7 @@ sub {
   bottom: -0.25em; }
 
 pre, code, kbd, samp, var {
-  font-family: Consolas, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Courier New', monospace, sans-serif; }
+  font-family: Consolas, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, sans-serif; }
 
 pre {
   /* Get spaces to display for PRE tags but dont let long lines break out of containers */
@@ -997,7 +997,7 @@ h2.not-column {
     color: #999999;
     background: transparent;
     text-align: center;
-    padding: .5em .75em .4em;
+    padding: 0.5em 0.75em 0.4em;
     font-size: 1em;
     line-height: 1.75em;
     /* no fallback for .no-generatedcontent. This is a progressive enhancement */ }
@@ -1046,10 +1046,10 @@ h2.not-column {
 /* Used in both the main-header and the header-banner */
 .main-header {
   border-top: 1px solid #191919;
-  border-bottom: 1px solid #444; }
+  border-bottom: 1px solid #444444; }
   .main-header .container {
     text-align: center;
-    padding: .75em 1em; }
+    padding: 0.75em 1em; }
 
 /*h1*/
 .site-headline {
@@ -1135,15 +1135,15 @@ input#s,
 .menu-icon {
   display: inline-block;
   font-size: 1.25em;
-  margin: -.125em -.125em 0 0; }
+  margin: -0.125em -0.125em 0 0; }
 
 /*form*/
 .search-the-site {
   text-align: left;
-  padding: .35em .2em .3em; }
+  padding: 0.35em 0.2em 0.3em; }
   .search-the-site .icon-search:before {
     font-size: 1.75em;
-    margin: 0 .125em 0 .25em; }
+    margin: 0 0.125em 0 0.25em; }
   .search-the-site .no-touch {
     border-left: 0; }
 
@@ -1154,8 +1154,8 @@ input#s,
   color: #bbbbbb;
   background-color: transparent;
   border: none;
-  margin: .125em 0;
-  padding: .4em 0 .3em;
+  margin: 0.125em 0;
+  padding: 0.4em 0 0.3em;
   -webkit-border-radius: 0px;
   -moz-border-radius: 0px;
   -ms-border-radius: 0px;
@@ -1170,7 +1170,7 @@ input#s,
   .search-field:focus {
     background-color: white;
     color: #444444;
-    padding: .4em .5em .3em;
+    padding: 0.4em 0.5em 0.3em;
     /* removed this line because it was making the height fluctuate on focus:
     @include pe-border( $color-top: darken( $darkerblue, 12% ), $color-bottom: lighten( $darkerblue, 8% ) ); */ }
   .search-field:blur {
@@ -1233,7 +1233,7 @@ input#s,
     .account-signin .tier-1 > a,
     .account-signin .tier-2 > a {
       display: block;
-      padding: .5em 1.5em .4em 1em;
+      padding: 0.5em 1.5em 0.4em 1em;
       position: relative; }
   .adjust-font-size .tier-1,
   .winkwink-nudgenudge .tier-1,
@@ -1268,15 +1268,25 @@ input#s,
   .account-signin .sidebar-widget form label + ul,
   .sidebar-widget form .account-signin label + ul {
     *zoom: 1; }
-    .adjust-font-size .menu:after, .adjust-font-size form ul:after, form .adjust-font-size ul:after, .adjust-font-size .errorlist:after,
+    .adjust-font-size .menu:after, .adjust-font-size form ul:after, form .adjust-font-size ul:after, .adjust-font-size .errorlist:after, .adjust-font-size .text form label + ul:after, .text form .adjust-font-size label + ul:after,
+    .adjust-font-size .sidebar-widget form label + ul:after,
+    .sidebar-widget form .adjust-font-size label + ul:after,
     .winkwink-nudgenudge .menu:after,
     .winkwink-nudgenudge form ul:after,
     form .winkwink-nudgenudge ul:after,
     .winkwink-nudgenudge .errorlist:after,
+    .winkwink-nudgenudge .text form label + ul:after,
+    .text form .winkwink-nudgenudge label + ul:after,
+    .winkwink-nudgenudge .sidebar-widget form label + ul:after,
+    .sidebar-widget form .winkwink-nudgenudge label + ul:after,
     .account-signin .menu:after,
     .account-signin form ul:after,
     form .account-signin ul:after,
-    .account-signin .errorlist:after {
+    .account-signin .errorlist:after,
+    .account-signin .text form label + ul:after,
+    .text form .account-signin label + ul:after,
+    .account-signin .sidebar-widget form label + ul:after,
+    .sidebar-widget form .account-signin label + ul:after {
       content: "";
       display: table;
       clear: both; }
@@ -1528,7 +1538,7 @@ input#s,
 .adjust-font-size .tier-1 > a,
 .winkwink-nudgenudge .tier-1 > a,
 .account-signin .tier-1 > a {
-  padding: 1em 1em .875em; }
+  padding: 1em 1em 0.875em; }
 
 /* ! ===== Main navigation – In _layout.scss and _mixins.scss, as we don't display it here ===== */
 .main-navigation {
@@ -1791,7 +1801,7 @@ input#s,
     .sidebar-widget form button,
     .sidebar-widget form input[type=submit] {
       font-size: 1.125em;
-      padding: .4em 1em .35em; }
+      padding: 0.4em 1em 0.35em; }
   .text a:not(.button),
   .sidebar-widget a:not(.button) {
     display: inline;
@@ -1803,14 +1813,23 @@ input#s,
         color: $grey-light;
         margin-right: .5em;
     } */ }
-  .text nav a, .text .menu a, .text form ul a, form .text ul a, .text .errorlist a, .text input[type=submit], .text input[type=reset], .text input[type=button], .text button, .text .prompt, .text .readmore:before, .text .give-me-more a:before, .give-me-more .text a:before,
-  .text nav a:hover, .text .menu a:hover, .text form ul a:hover, form .text ul a:hover, .text .errorlist a:hover, .text input[type=submit]:hover, .text input[type=reset]:hover, .text input[type=button]:hover, .text .prompt:hover, .text .readmore:hover:before, .text .give-me-more a:hover:before, .give-me-more .text a:hover:before,
-  .text nav a:focus, .text .menu a:focus, .text form ul a:focus, form .text ul a:focus, .text .errorlist a:focus, .text input[type=submit]:focus, .text input[type=reset]:focus, .text input[type=button]:focus, .text .prompt:focus, .text .readmore:focus:before, .text .give-me-more a:focus:before, .give-me-more .text a:focus:before,
+  .text nav a, .text .menu a, .text form ul a, form .text ul a, .text .errorlist a, .text form label + ul a,
+  .text .sidebar-widget form label + ul a,
+  .sidebar-widget form .text label + ul a, .text input[type=submit], .text input[type=reset], .text input[type=button], .text button, .text .prompt, .text .readmore:before, .text .give-me-more a:before, .give-me-more .text a:before,
+  .text nav a:hover, .text .menu a:hover, .text form ul a:hover, form .text ul a:hover, .text .errorlist a:hover, .text form label + ul a:hover,
+  .text .sidebar-widget form label + ul a:hover,
+  .sidebar-widget form .text label + ul a:hover, .text input[type=submit]:hover, .text input[type=reset]:hover, .text input[type=button]:hover, .text .prompt:hover, .text .readmore:hover:before, .text .give-me-more a:hover:before, .give-me-more .text a:hover:before,
+  .text nav a:focus, .text .menu a:focus, .text form ul a:focus, form .text ul a:focus, .text .errorlist a:focus, .text form label + ul a:focus,
+  .text .sidebar-widget form label + ul a:focus,
+  .sidebar-widget form .text label + ul a:focus, .text input[type=submit]:focus, .text input[type=reset]:focus, .text input[type=button]:focus, .text .prompt:focus, .text .readmore:focus:before, .text .give-me-more a:focus:before, .give-me-more .text a:focus:before,
   .sidebar-widget nav a,
   .sidebar-widget .menu a,
   .sidebar-widget form ul a,
   form .sidebar-widget ul a,
   .sidebar-widget .errorlist a,
+  .sidebar-widget .text form label + ul a,
+  .text form .sidebar-widget label + ul a,
+  .sidebar-widget form label + ul a,
   .sidebar-widget input[type=submit],
   .sidebar-widget input[type=reset],
   .sidebar-widget input[type=button],
@@ -1824,6 +1843,9 @@ input#s,
   .sidebar-widget form ul a:hover,
   form .sidebar-widget ul a:hover,
   .sidebar-widget .errorlist a:hover,
+  .sidebar-widget .text form label + ul a:hover,
+  .text form .sidebar-widget label + ul a:hover,
+  .sidebar-widget form label + ul a:hover,
   .sidebar-widget input[type=submit]:hover,
   .sidebar-widget input[type=reset]:hover,
   .sidebar-widget input[type=button]:hover,
@@ -1836,6 +1858,9 @@ input#s,
   .sidebar-widget form ul a:focus,
   form .sidebar-widget ul a:focus,
   .sidebar-widget .errorlist a:focus,
+  .sidebar-widget .text form label + ul a:focus,
+  .text form .sidebar-widget label + ul a:focus,
+  .sidebar-widget form label + ul a:focus,
   .sidebar-widget input[type=submit]:focus,
   .sidebar-widget input[type=reset]:focus,
   .sidebar-widget input[type=button]:focus,
@@ -1876,13 +1901,13 @@ input#s,
   .sidebar-widget samp {
     border-bottom: 1px solid #caccce;
     background-color: #e6e8ea;
-    padding: .125em .375em 0;
-    margin: 0 .25em; }
+    padding: 0.125em 0.375em 0;
+    margin: 0 0.25em; }
   .text code, .text kbd,
   .sidebar-widget code,
   .sidebar-widget kbd {
-    padding: .125em .375em 0;
-    margin: 0 -.0625em;
+    padding: 0.125em 0.375em 0;
+    margin: 0 -0.0625em;
     background: #e6e8ea;
     background: rgba(230, 232, 234, 0.5);
     -webkit-box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset;
@@ -1936,7 +1961,7 @@ table tr {
 table tr:nth-of-type(even), table tr.even {
   background-color: #f0f0f0; }
 table th, table td {
-  padding: .25em .5em .2em;
+  padding: 0.25em 0.5em 0.2em;
   border-left: 2px solid white; }
   table th:first-child, table td:first-child {
     border-left: none; }
@@ -2144,7 +2169,7 @@ table tfoot {
   .applications-widget ul {
     border-top: 1px solid #caccce; }
   .applications-widget li {
-    padding: .5em 0 .4em;
+    padding: 0.5em 0 0.4em;
     border-bottom: 1px solid #caccce; }
 
 .shrubbery {
@@ -2198,7 +2223,7 @@ table tfoot {
       color: #3776ab;
       background-color: #f2f4f6;
       border-bottom: 1px solid #e6eaee;
-      padding: .6em .75em .5em; }
+      padding: 0.6em 0.75em 0.5em; }
       .pep-list li a:hover, .pep-list li a:focus, .pep-list li a:active {
         color: #222222;
         background-color: #fefefe; }
@@ -2243,7 +2268,7 @@ table tfoot {
       color: #222222; }
 
 .pep-type, .pep-num, .pep-title, .pep-owner {
-  padding: .5em .5em .4em;
+  padding: 0.5em 0.5em 0.4em;
   border-bottom: 1px solid #e3e7ec; }
 
 .footnote .label {
@@ -2253,7 +2278,7 @@ table tfoot {
 .info-key dt, .info-key dd {
   display: block;
   float: left;
-  padding: .5em .5em .4em; }
+  padding: 0.5em 0.5em 0.4em; }
 .info-key dt {
   width: 25%; }
 .info-key dd {
@@ -2271,14 +2296,14 @@ table tfoot {
         </li>
     </ul> */
 .pep-owner-header {
-  margin: 0 -.5em;
+  margin: 0 -0.5em;
   overflow: hidden;
   *zoom: 1; }
   .pep-owner-header .label {
     font-family: SourceSansProBold, Arial, sans-serif;
     float: left;
     width: 50%;
-    padding: .25em .5em .2em; }
+    padding: 0.25em 0.5em 0.2em; }
 
 .pep-owner-list li {
   background-color: #f2f4f6;
@@ -2290,12 +2315,12 @@ table tfoot {
 .pep-owner-list .owner-name, .pep-owner-list .owner-email {
   float: left;
   width: 50%;
-  padding: .5em .5em .4em; }
+  padding: 0.5em 0.5em 0.4em; }
 
 /* ! ===== Success Stories landing page ===== */
 .featured-success-story {
   padding: 1.3125em 0;
-  background: center -230px no-repeat url('../img/success-glow2.png?1412817243') transparent;
+  background: center -230px no-repeat url('../img/success-glow2.png?1471664877') transparent;
   /*blockquote*/ }
   .featured-success-story img {
     padding: 10px 30px; }
@@ -2404,7 +2429,7 @@ p.quote-by-organization {
   /* resets as this is an H3 element and it behaves differently */
   margin-top: .75em;
   margin-bottom: 1.25em;
-  padding: .5em .75em; }
+  padding: 0.5em 0.75em; }
 
 .event-description {
   padding: 1.3125em 0; }
@@ -2427,7 +2452,7 @@ p.quote-by-organization {
   -ms-border-radius: 0 0 8px 8px;
   -o-border-radius: 0 0 8px 8px;
   border-radius: 0 0 8px 8px;
-  padding: .75em 1em; }
+  padding: 0.75em 1em; }
 
 /*ul*/
 .twitter-stream li {
@@ -2458,7 +2483,7 @@ p.quote-by-organization {
     color: #666666;
     font-size: 0.875em;
     vertical-align: baseline;
-    padding: .2em .4em .1em;
+    padding: 0.2em 0.4em 0.1em;
     background-color: #e6e8ea;
     border-top: 1px solid #f2f4f6;
     border-bottom: 1px solid #caccce; }
@@ -2481,13 +2506,13 @@ p.quote-by-organization {
 /* ! ===== Stylized lists of items, used on Downloads and others ===== */
 .list-row-headings {
   font-family: SourceSansProBold, Arial, sans-serif;
-  padding: .5em .5em .4em .75em;
+  padding: 0.5em 0.5em 0.4em 0.75em;
   margin-right: 1.25em; }
 
 .list-row-container {
   border: 1px solid #caccce; }
   .list-row-container li {
-    padding: .5em .5em .4em .75em;
+    padding: 0.5em 0.5em 0.4em 0.75em;
     margin-right: 0; }
     .list-row-container li:nth-child(odd) {
       background-color: #f2f4f6; }
@@ -2552,7 +2577,7 @@ p.quote-by-organization {
   .previous-next .prev-button,
   .previous-next .next-button {
     display: block;
-    padding: .5em .75em .4em;
+    padding: 0.5em 0.75em 0.4em;
     margin-bottom: 0.875em; }
     .previous-next .prev-button:not(.disabled):hover, .previous-next .prev-button:not(.disabled):focus,
     .previous-next .next-button:not(.disabled):hover,
@@ -2620,7 +2645,7 @@ p.quote-by-organization {
         <p role="alert">Can’t find what you’re looking for? <a href="#">Try our comprehensive Help section</a></p>
     </div>*/
 .user-feedback {
-  padding: .75em 1em .65em;
+  padding: 0.75em 1em 0.65em;
   margin-bottom: 1.3125em;
   -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
@@ -2685,7 +2710,7 @@ p.quote-by-organization {
   font-size: 0.58333em;
   text-transform: uppercase;
   letter-spacing: .0625em;
-  padding: .45em .5em 0;
+  padding: 0.45em 0.5em 0;
   margin-right: .25em; }
 .listing-company .listing-location a {
   color: #999999; }
@@ -2714,7 +2739,7 @@ p.quote-by-organization {
 
 /* ! ===== Inner pages ===== */
 .breadcrumbs {
-  padding: .5em 0;
+  padding: 0.5em 0;
   border-bottom: 1px solid #caccce;
   white-space: nowrap; }
   .breadcrumbs li {
@@ -2739,7 +2764,7 @@ p.quote-by-organization {
 
 .section-nav a {
   display: block;
-  padding: .3em 0 .2em; }
+  padding: 0.3em 0 0.2em; }
 
 .psf-sidebar-widget {
   color: #f2f4f6;
@@ -2793,7 +2818,7 @@ p.quote-by-organization {
 
 .psf-codeofconduct {
   font-size: 0.875em;
-  padding: .5em 1em;
+  padding: 0.5em 1em;
   margin-bottom: 1em;
   background-color: white;
   -webkit-box-shadow: 0.25em 0.25em 0.75em rgba(0, 0, 0, 0.15);
@@ -2820,7 +2845,7 @@ p.quote-by-organization {
 .main-footer .jump-link, .sitemap a, .footer-links a {
   display: block;
   text-align: center;
-  padding: .5em .75em .4em; }
+  padding: 0.5em 0.75em 0.4em; }
 
 .main-footer {
   clear: both;
@@ -2828,7 +2853,7 @@ p.quote-by-organization {
   background-color: #e6e8ea;
   border-top: 1px solid #d8dbde; }
   .main-footer .container {
-    padding: 0 .75em .75em; }
+    padding: 0 0.75em 0.75em; }
   .main-footer a {
     color: #666666; }
     .main-footer a:hover, .main-footer a:focus {
@@ -2836,7 +2861,7 @@ p.quote-by-organization {
   .main-footer .jump-link {
     background-color: #e0e3e5; }
   .main-footer a.jump-link {
-    margin: .75em 0;
+    margin: 0.75em 0;
     border-top: 1px solid #e6e8ea;
     border-bottom: 1px solid #dbdee1; }
     .main-footer a.jump-link:hover, .main-footer a.jump-link:focus {
@@ -2850,7 +2875,7 @@ p.quote-by-organization {
     margin-bottom: 1.3125em; }
     .sitemap .tier-1 > a {
       color: #3776ab;
-      padding: .4em .5em .3em;
+      padding: 0.4em 0.5em 0.3em;
       font-family: Flux-Bold, SourceSansProBold, Arial, sans-serif;
       font-size: 1.25em;
       margin-top: 0.875em;
@@ -2869,7 +2894,7 @@ p.quote-by-organization {
       background-color: #ecedef; }
 
 .site-base {
-  border-top: 1px solid #111; }
+  border-top: 1px solid #111111; }
   .site-base .container {
     padding: 1em; }
 
@@ -2920,6 +2945,17 @@ p.quote-by-organization {
 
 .python-status-indicator-default {
   background-color: #808080; }
+
+div.note {
+  background-color: #eee;
+  border: 1px solid #cccccc; }
+
+.note code {
+  background: #d6d6d6; }
+
+p.admonition-title {
+  margin: 0px 10px 5px 0px;
+  font-weight: bold; }
 
 /* ! ===== Slideshow requirements ===== */
 .flex-slideshow {
@@ -2994,7 +3030,7 @@ p.quote-by-organization {
     background-color: white; }
   .touch .flex-control-nav a {
     /* Larger touch target */
-    padding: .5em .75em; }
+    padding: 0.5em 0.75em; }
 
 /*<ul class="flex-direction-nav">
     <li>
@@ -3046,7 +3082,7 @@ p.quote-by-organization {
     display: none; } }
 /* ! ==== No JS warning message... more of a suggestion, really ==== */
 #nojs, #oldie-warning {
-  padding: .75em .75em .65em;
+  padding: 0.75em 0.75em 0.65em;
   text-align: center;
   background-color: #c33; }
   #nojs p, #oldie-warning p {
@@ -3115,7 +3151,7 @@ p.quote-by-organization {
 @media print {
   *, *:before, *:after {
     background: transparent !important;
-    color: #000 !important;
+    color: black !important;
     /* Black prints faster: h5bp.com/s */
     box-shadow: none !important;
     text-shadow: none !important; }
@@ -3139,7 +3175,7 @@ p.quote-by-organization {
     content: ""; }
 
   pre, blockquote {
-    border: 1px solid #999;
+    border: 1px solid #999999;
     page-break-inside: avoid; }
 
   thead {
@@ -3187,11 +3223,11 @@ p.quote-by-organization {
     .python .site-headline a:before {
       width: 290px;
       height: 82px;
-      content: url('../img/python-logo_print.png?1412817243'); }
+      content: url('../img/python-logo_print.png?1471664877'); }
     .psf .site-headline a:before {
       width: 334px;
       height: 82px;
-      content: url('../img/psf-logo_print.png?1412817243'); } }
+      content: url('../img/psf-logo_print.png?1471664877'); } }
 /*
  * When we want to review the markup for W3 and similar errors, turn some of these on
  * Uses :not selectors a bunch, so only modern browsers will support them
@@ -3319,7 +3355,7 @@ p.quote-by-organization {
 .icon-arrow-left:before {
   content: "\e61c"; }
 
-.icon-arrow-down:before, .errorlist:before {
+.icon-arrow-down:before, .errorlist:before:before {
   content: "\e61d"; }
 
 .icon-freenode:before {
@@ -3360,14 +3396,14 @@ p.quote-by-organization {
 /*modernizr*/
 .no-fontface .icon-megaphone, .no-fontface .icon-python-alt, .no-fontface .icon-pypi, .no-fontface .icon-news, .no-fontface .icon-moderate, .no-fontface .icon-mercurial, .no-fontface .icon-jobs, .no-fontface .icon-help, .no-fontface .icon-google-plus, .no-fontface .icon-download, .no-fontface .icon-documentation, .no-fontface .icon-community, .no-fontface .icon-code, .no-fontface .icon-close, .no-fontface .icon-calendar, .no-fontface .icon-beginner, .no-fontface .icon-advanced, .no-fontface .icon-sitemap, .no-fontface .icon-search, .no-fontface .icon-search-alt, .no-fontface .icon-python, .no-fontface .icon-github, .no-fontface .icon-get-started, .no-fontface .icon-feed, .no-fontface .icon-facebook, .no-fontface .icon-email, .no-fontface .icon-arrow-up, .no-fontface .icon-arrow-right, .no-fontface .icon-arrow-left, .no-fontface .icon-arrow-down, .no-fontface .errorlist:before, .no-fontface .icon-freenode, .no-fontface .icon-alert, .no-fontface .icon-versions, .no-fontface .icon-twitter, .no-fontface .icon-thumbs-up, .no-fontface .icon-thumbs-down, .no-fontface .icon-text-resize, .no-fontface .icon-success-stories, .no-fontface .icon-statistics, .no-fontface .icon-stack-overflow, .no-svg .icon-megaphone, .no-svg .icon-python-alt, .no-svg .icon-pypi, .no-svg .icon-news, .no-svg .icon-moderate, .no-svg .icon-mercurial, .no-svg .icon-jobs, .no-svg .icon-help, .no-svg .icon-google-plus, .no-svg .icon-download, .no-svg .icon-documentation, .no-svg .icon-community, .no-svg .icon-code, .no-svg .icon-close, .no-svg .icon-calendar, .no-svg .icon-beginner, .no-svg .icon-advanced, .no-svg .icon-sitemap, .no-svg .icon-search, .no-svg .icon-search-alt, .no-svg .icon-python, .no-svg .icon-github, .no-svg .icon-get-started, .no-svg .icon-feed, .no-svg .icon-facebook, .no-svg .icon-email, .no-svg .icon-arrow-up, .no-svg .icon-arrow-right, .no-svg .icon-arrow-left, .no-svg .icon-arrow-down, .no-svg .errorlist:before, .no-svg .icon-freenode, .no-svg .icon-alert, .no-svg .icon-versions, .no-svg .icon-twitter, .no-svg .icon-thumbs-up, .no-svg .icon-thumbs-down, .no-svg .icon-text-resize, .no-svg .icon-success-stories, .no-svg .icon-statistics, .no-svg .icon-stack-overflow, .no-generatedcontent .icon-megaphone, .no-generatedcontent .icon-python-alt, .no-generatedcontent .icon-pypi, .no-generatedcontent .icon-news, .no-generatedcontent .icon-moderate, .no-generatedcontent .icon-mercurial, .no-generatedcontent .icon-jobs, .no-generatedcontent .icon-help, .no-generatedcontent .icon-google-plus, .no-generatedcontent .icon-download, .no-generatedcontent .icon-documentation, .no-generatedcontent .icon-community, .no-generatedcontent .icon-code, .no-generatedcontent .icon-close, .no-generatedcontent .icon-calendar, .no-generatedcontent .icon-beginner, .no-generatedcontent .icon-advanced, .no-generatedcontent .icon-sitemap, .no-generatedcontent .icon-search, .no-generatedcontent .icon-search-alt, .no-generatedcontent .icon-python, .no-generatedcontent .icon-github, .no-generatedcontent .icon-get-started, .no-generatedcontent .icon-feed, .no-generatedcontent .icon-facebook, .no-generatedcontent .icon-email, .no-generatedcontent .icon-arrow-up, .no-generatedcontent .icon-arrow-right, .no-generatedcontent .icon-arrow-left, .no-generatedcontent .icon-arrow-down, .no-generatedcontent .errorlist:before, .no-generatedcontent .icon-freenode, .no-generatedcontent .icon-alert, .no-generatedcontent .icon-versions, .no-generatedcontent .icon-twitter, .no-generatedcontent .icon-thumbs-up, .no-generatedcontent .icon-thumbs-down, .no-generatedcontent .icon-text-resize, .no-generatedcontent .icon-success-stories, .no-generatedcontent .icon-statistics, .no-generatedcontent .icon-stack-overflow {
   /* Show a unicode character back up if it exists */ }
-  .no-fontface .icon-megaphone:before, .no-fontface .icon-python-alt:before, .no-fontface .icon-pypi:before, .no-fontface .icon-news:before, .no-fontface .icon-moderate:before, .no-fontface .icon-mercurial:before, .no-fontface .icon-jobs:before, .no-fontface .icon-help:before, .no-fontface .icon-google-plus:before, .no-fontface .icon-download:before, .no-fontface .icon-documentation:before, .no-fontface .icon-community:before, .no-fontface .icon-code:before, .no-fontface .icon-close:before, .no-fontface .icon-calendar:before, .no-fontface .icon-beginner:before, .no-fontface .icon-advanced:before, .no-fontface .icon-sitemap:before, .no-fontface .icon-search:before, .no-fontface .icon-search-alt:before, .no-fontface .icon-python:before, .no-fontface .icon-github:before, .no-fontface .icon-get-started:before, .no-fontface .icon-feed:before, .no-fontface .icon-facebook:before, .no-fontface .icon-email:before, .no-fontface .icon-arrow-up:before, .no-fontface .icon-arrow-right:before, .no-fontface .icon-arrow-left:before, .no-fontface .icon-arrow-down:before, .no-fontface .errorlist:before, .no-fontface .icon-freenode:before, .no-fontface .icon-alert:before, .no-fontface .icon-versions:before, .no-fontface .icon-twitter:before, .no-fontface .icon-thumbs-up:before, .no-fontface .icon-thumbs-down:before, .no-fontface .icon-text-resize:before, .no-fontface .icon-success-stories:before, .no-fontface .icon-statistics:before, .no-fontface .icon-stack-overflow:before, .no-svg .icon-megaphone:before, .no-svg .icon-python-alt:before, .no-svg .icon-pypi:before, .no-svg .icon-news:before, .no-svg .icon-moderate:before, .no-svg .icon-mercurial:before, .no-svg .icon-jobs:before, .no-svg .icon-help:before, .no-svg .icon-google-plus:before, .no-svg .icon-download:before, .no-svg .icon-documentation:before, .no-svg .icon-community:before, .no-svg .icon-code:before, .no-svg .icon-close:before, .no-svg .icon-calendar:before, .no-svg .icon-beginner:before, .no-svg .icon-advanced:before, .no-svg .icon-sitemap:before, .no-svg .icon-search:before, .no-svg .icon-search-alt:before, .no-svg .icon-python:before, .no-svg .icon-github:before, .no-svg .icon-get-started:before, .no-svg .icon-feed:before, .no-svg .icon-facebook:before, .no-svg .icon-email:before, .no-svg .icon-arrow-up:before, .no-svg .icon-arrow-right:before, .no-svg .icon-arrow-left:before, .no-svg .icon-arrow-down:before, .no-svg .errorlist:before, .no-svg .icon-freenode:before, .no-svg .icon-alert:before, .no-svg .icon-versions:before, .no-svg .icon-twitter:before, .no-svg .icon-thumbs-up:before, .no-svg .icon-thumbs-down:before, .no-svg .icon-text-resize:before, .no-svg .icon-success-stories:before, .no-svg .icon-statistics:before, .no-svg .icon-stack-overflow:before, .no-generatedcontent .icon-megaphone:before, .no-generatedcontent .icon-python-alt:before, .no-generatedcontent .icon-pypi:before, .no-generatedcontent .icon-news:before, .no-generatedcontent .icon-moderate:before, .no-generatedcontent .icon-mercurial:before, .no-generatedcontent .icon-jobs:before, .no-generatedcontent .icon-help:before, .no-generatedcontent .icon-google-plus:before, .no-generatedcontent .icon-download:before, .no-generatedcontent .icon-documentation:before, .no-generatedcontent .icon-community:before, .no-generatedcontent .icon-code:before, .no-generatedcontent .icon-close:before, .no-generatedcontent .icon-calendar:before, .no-generatedcontent .icon-beginner:before, .no-generatedcontent .icon-advanced:before, .no-generatedcontent .icon-sitemap:before, .no-generatedcontent .icon-search:before, .no-generatedcontent .icon-search-alt:before, .no-generatedcontent .icon-python:before, .no-generatedcontent .icon-github:before, .no-generatedcontent .icon-get-started:before, .no-generatedcontent .icon-feed:before, .no-generatedcontent .icon-facebook:before, .no-generatedcontent .icon-email:before, .no-generatedcontent .icon-arrow-up:before, .no-generatedcontent .icon-arrow-right:before, .no-generatedcontent .icon-arrow-left:before, .no-generatedcontent .icon-arrow-down:before, .no-generatedcontent .errorlist:before, .no-generatedcontent .icon-freenode:before, .no-generatedcontent .icon-alert:before, .no-generatedcontent .icon-versions:before, .no-generatedcontent .icon-twitter:before, .no-generatedcontent .icon-thumbs-up:before, .no-generatedcontent .icon-thumbs-down:before, .no-generatedcontent .icon-text-resize:before, .no-generatedcontent .icon-success-stories:before, .no-generatedcontent .icon-statistics:before, .no-generatedcontent .icon-stack-overflow:before {
+  .no-fontface .icon-megaphone:before, .no-fontface .icon-python-alt:before, .no-fontface .icon-pypi:before, .no-fontface .icon-news:before, .no-fontface .icon-moderate:before, .no-fontface .icon-mercurial:before, .no-fontface .icon-jobs:before, .no-fontface .icon-help:before, .no-fontface .icon-google-plus:before, .no-fontface .icon-download:before, .no-fontface .icon-documentation:before, .no-fontface .icon-community:before, .no-fontface .icon-code:before, .no-fontface .icon-close:before, .no-fontface .icon-calendar:before, .no-fontface .icon-beginner:before, .no-fontface .icon-advanced:before, .no-fontface .icon-sitemap:before, .no-fontface .icon-search:before, .no-fontface .icon-search-alt:before, .no-fontface .icon-python:before, .no-fontface .icon-github:before, .no-fontface .icon-get-started:before, .no-fontface .icon-feed:before, .no-fontface .icon-facebook:before, .no-fontface .icon-email:before, .no-fontface .icon-arrow-up:before, .no-fontface .icon-arrow-right:before, .no-fontface .icon-arrow-left:before, .no-fontface .icon-arrow-down:before, .no-fontface .errorlist:before:before, .no-fontface .icon-freenode:before, .no-fontface .icon-alert:before, .no-fontface .icon-versions:before, .no-fontface .icon-twitter:before, .no-fontface .icon-thumbs-up:before, .no-fontface .icon-thumbs-down:before, .no-fontface .icon-text-resize:before, .no-fontface .icon-success-stories:before, .no-fontface .icon-statistics:before, .no-fontface .icon-stack-overflow:before, .no-svg .icon-megaphone:before, .no-svg .icon-python-alt:before, .no-svg .icon-pypi:before, .no-svg .icon-news:before, .no-svg .icon-moderate:before, .no-svg .icon-mercurial:before, .no-svg .icon-jobs:before, .no-svg .icon-help:before, .no-svg .icon-google-plus:before, .no-svg .icon-download:before, .no-svg .icon-documentation:before, .no-svg .icon-community:before, .no-svg .icon-code:before, .no-svg .icon-close:before, .no-svg .icon-calendar:before, .no-svg .icon-beginner:before, .no-svg .icon-advanced:before, .no-svg .icon-sitemap:before, .no-svg .icon-search:before, .no-svg .icon-search-alt:before, .no-svg .icon-python:before, .no-svg .icon-github:before, .no-svg .icon-get-started:before, .no-svg .icon-feed:before, .no-svg .icon-facebook:before, .no-svg .icon-email:before, .no-svg .icon-arrow-up:before, .no-svg .icon-arrow-right:before, .no-svg .icon-arrow-left:before, .no-svg .icon-arrow-down:before, .no-svg .errorlist:before:before, .no-svg .icon-freenode:before, .no-svg .icon-alert:before, .no-svg .icon-versions:before, .no-svg .icon-twitter:before, .no-svg .icon-thumbs-up:before, .no-svg .icon-thumbs-down:before, .no-svg .icon-text-resize:before, .no-svg .icon-success-stories:before, .no-svg .icon-statistics:before, .no-svg .icon-stack-overflow:before, .no-generatedcontent .icon-megaphone:before, .no-generatedcontent .icon-python-alt:before, .no-generatedcontent .icon-pypi:before, .no-generatedcontent .icon-news:before, .no-generatedcontent .icon-moderate:before, .no-generatedcontent .icon-mercurial:before, .no-generatedcontent .icon-jobs:before, .no-generatedcontent .icon-help:before, .no-generatedcontent .icon-google-plus:before, .no-generatedcontent .icon-download:before, .no-generatedcontent .icon-documentation:before, .no-generatedcontent .icon-community:before, .no-generatedcontent .icon-code:before, .no-generatedcontent .icon-close:before, .no-generatedcontent .icon-calendar:before, .no-generatedcontent .icon-beginner:before, .no-generatedcontent .icon-advanced:before, .no-generatedcontent .icon-sitemap:before, .no-generatedcontent .icon-search:before, .no-generatedcontent .icon-search-alt:before, .no-generatedcontent .icon-python:before, .no-generatedcontent .icon-github:before, .no-generatedcontent .icon-get-started:before, .no-generatedcontent .icon-feed:before, .no-generatedcontent .icon-facebook:before, .no-generatedcontent .icon-email:before, .no-generatedcontent .icon-arrow-up:before, .no-generatedcontent .icon-arrow-right:before, .no-generatedcontent .icon-arrow-left:before, .no-generatedcontent .icon-arrow-down:before, .no-generatedcontent .errorlist:before:before, .no-generatedcontent .icon-freenode:before, .no-generatedcontent .icon-alert:before, .no-generatedcontent .icon-versions:before, .no-generatedcontent .icon-twitter:before, .no-generatedcontent .icon-thumbs-up:before, .no-generatedcontent .icon-thumbs-down:before, .no-generatedcontent .icon-text-resize:before, .no-generatedcontent .icon-success-stories:before, .no-generatedcontent .icon-statistics:before, .no-generatedcontent .icon-stack-overflow:before {
     display: none;
     margin-right: 0; }
   .no-fontface .icon-megaphone span, .no-fontface .icon-python-alt span, .no-fontface .icon-pypi span, .no-fontface .icon-news span, .no-fontface .icon-moderate span, .no-fontface .icon-mercurial span, .no-fontface .icon-jobs span, .no-fontface .icon-help span, .no-fontface .icon-google-plus span, .no-fontface .icon-download span, .no-fontface .icon-documentation span, .no-fontface .icon-community span, .no-fontface .icon-code span, .no-fontface .icon-close span, .no-fontface .icon-calendar span, .no-fontface .icon-beginner span, .no-fontface .icon-advanced span, .no-fontface .icon-sitemap span, .no-fontface .icon-search span, .no-fontface .icon-search-alt span, .no-fontface .icon-python span, .no-fontface .icon-github span, .no-fontface .icon-get-started span, .no-fontface .icon-feed span, .no-fontface .icon-facebook span, .no-fontface .icon-email span, .no-fontface .icon-arrow-up span, .no-fontface .icon-arrow-right span, .no-fontface .icon-arrow-left span, .no-fontface .icon-arrow-down span, .no-fontface .errorlist:before span, .no-fontface .icon-freenode span, .no-fontface .icon-alert span, .no-fontface .icon-versions span, .no-fontface .icon-twitter span, .no-fontface .icon-thumbs-up span, .no-fontface .icon-thumbs-down span, .no-fontface .icon-text-resize span, .no-fontface .icon-success-stories span, .no-fontface .icon-statistics span, .no-fontface .icon-stack-overflow span, .no-svg .icon-megaphone span, .no-svg .icon-python-alt span, .no-svg .icon-pypi span, .no-svg .icon-news span, .no-svg .icon-moderate span, .no-svg .icon-mercurial span, .no-svg .icon-jobs span, .no-svg .icon-help span, .no-svg .icon-google-plus span, .no-svg .icon-download span, .no-svg .icon-documentation span, .no-svg .icon-community span, .no-svg .icon-code span, .no-svg .icon-close span, .no-svg .icon-calendar span, .no-svg .icon-beginner span, .no-svg .icon-advanced span, .no-svg .icon-sitemap span, .no-svg .icon-search span, .no-svg .icon-search-alt span, .no-svg .icon-python span, .no-svg .icon-github span, .no-svg .icon-get-started span, .no-svg .icon-feed span, .no-svg .icon-facebook span, .no-svg .icon-email span, .no-svg .icon-arrow-up span, .no-svg .icon-arrow-right span, .no-svg .icon-arrow-left span, .no-svg .icon-arrow-down span, .no-svg .errorlist:before span, .no-svg .icon-freenode span, .no-svg .icon-alert span, .no-svg .icon-versions span, .no-svg .icon-twitter span, .no-svg .icon-thumbs-up span, .no-svg .icon-thumbs-down span, .no-svg .icon-text-resize span, .no-svg .icon-success-stories span, .no-svg .icon-statistics span, .no-svg .icon-stack-overflow span, .no-generatedcontent .icon-megaphone span, .no-generatedcontent .icon-python-alt span, .no-generatedcontent .icon-pypi span, .no-generatedcontent .icon-news span, .no-generatedcontent .icon-moderate span, .no-generatedcontent .icon-mercurial span, .no-generatedcontent .icon-jobs span, .no-generatedcontent .icon-help span, .no-generatedcontent .icon-google-plus span, .no-generatedcontent .icon-download span, .no-generatedcontent .icon-documentation span, .no-generatedcontent .icon-community span, .no-generatedcontent .icon-code span, .no-generatedcontent .icon-close span, .no-generatedcontent .icon-calendar span, .no-generatedcontent .icon-beginner span, .no-generatedcontent .icon-advanced span, .no-generatedcontent .icon-sitemap span, .no-generatedcontent .icon-search span, .no-generatedcontent .icon-search-alt span, .no-generatedcontent .icon-python span, .no-generatedcontent .icon-github span, .no-generatedcontent .icon-get-started span, .no-generatedcontent .icon-feed span, .no-generatedcontent .icon-facebook span, .no-generatedcontent .icon-email span, .no-generatedcontent .icon-arrow-up span, .no-generatedcontent .icon-arrow-right span, .no-generatedcontent .icon-arrow-left span, .no-generatedcontent .icon-arrow-down span, .no-generatedcontent .errorlist:before span, .no-generatedcontent .icon-freenode span, .no-generatedcontent .icon-alert span, .no-generatedcontent .icon-versions span, .no-generatedcontent .icon-twitter span, .no-generatedcontent .icon-thumbs-up span, .no-generatedcontent .icon-thumbs-down span, .no-generatedcontent .icon-text-resize span, .no-generatedcontent .icon-success-stories span, .no-generatedcontent .icon-statistics span, .no-generatedcontent .icon-stack-overflow span {
     display: inline; }
 
 /* Show in IE8: supports FontFace (eot) but not SVG. */
-.ie8 .icon-megaphone:before, .ie8 .icon-python-alt:before, .ie8 .icon-pypi:before, .ie8 .icon-news:before, .ie8 .icon-moderate:before, .ie8 .icon-mercurial:before, .ie8 .icon-jobs:before, .ie8 .icon-help:before, .ie8 .icon-google-plus:before, .ie8 .icon-download:before, .ie8 .icon-documentation:before, .ie8 .icon-community:before, .ie8 .icon-code:before, .ie8 .icon-close:before, .ie8 .icon-calendar:before, .ie8 .icon-beginner:before, .ie8 .icon-advanced:before, .ie8 .icon-sitemap:before, .ie8 .icon-search:before, .ie8 .icon-search-alt:before, .ie8 .icon-python:before, .ie8 .icon-github:before, .ie8 .icon-get-started:before, .ie8 .icon-feed:before, .ie8 .icon-facebook:before, .ie8 .icon-email:before, .ie8 .icon-arrow-up:before, .ie8 .icon-arrow-right:before, .ie8 .icon-arrow-left:before, .ie8 .icon-arrow-down:before, .ie8 .errorlist:before, .ie8 .icon-freenode:before, .ie8 .icon-alert:before, .ie8 .icon-versions:before, .ie8 .icon-twitter:before, .ie8 .icon-thumbs-up:before, .ie8 .icon-thumbs-down:before, .ie8 .icon-text-resize:before, .ie8 .icon-success-stories:before, .ie8 .icon-statistics:before, .ie8 .icon-stack-overflow:before {
+.ie8 .icon-megaphone:before, .ie8 .icon-python-alt:before, .ie8 .icon-pypi:before, .ie8 .icon-news:before, .ie8 .icon-moderate:before, .ie8 .icon-mercurial:before, .ie8 .icon-jobs:before, .ie8 .icon-help:before, .ie8 .icon-google-plus:before, .ie8 .icon-download:before, .ie8 .icon-documentation:before, .ie8 .icon-community:before, .ie8 .icon-code:before, .ie8 .icon-close:before, .ie8 .icon-calendar:before, .ie8 .icon-beginner:before, .ie8 .icon-advanced:before, .ie8 .icon-sitemap:before, .ie8 .icon-search:before, .ie8 .icon-search-alt:before, .ie8 .icon-python:before, .ie8 .icon-github:before, .ie8 .icon-get-started:before, .ie8 .icon-feed:before, .ie8 .icon-facebook:before, .ie8 .icon-email:before, .ie8 .icon-arrow-up:before, .ie8 .icon-arrow-right:before, .ie8 .icon-arrow-left:before, .ie8 .icon-arrow-down:before, .ie8 .errorlist:before:before, .ie8 .icon-freenode:before, .ie8 .icon-alert:before, .ie8 .icon-versions:before, .ie8 .icon-twitter:before, .ie8 .icon-thumbs-up:before, .ie8 .icon-thumbs-down:before, .ie8 .icon-text-resize:before, .ie8 .icon-success-stories:before, .ie8 .icon-statistics:before, .ie8 .icon-stack-overflow:before {
   display: inline; }
 .ie8 .icon-megaphone span, .ie8 .icon-python-alt span, .ie8 .icon-pypi span, .ie8 .icon-news span, .ie8 .icon-moderate span, .ie8 .icon-mercurial span, .ie8 .icon-jobs span, .ie8 .icon-help span, .ie8 .icon-google-plus span, .ie8 .icon-download span, .ie8 .icon-documentation span, .ie8 .icon-community span, .ie8 .icon-code span, .ie8 .icon-close span, .ie8 .icon-calendar span, .ie8 .icon-beginner span, .ie8 .icon-advanced span, .ie8 .icon-sitemap span, .ie8 .icon-search span, .ie8 .icon-search-alt span, .ie8 .icon-python span, .ie8 .icon-github span, .ie8 .icon-get-started span, .ie8 .icon-feed span, .ie8 .icon-facebook span, .ie8 .icon-email span, .ie8 .icon-arrow-up span, .ie8 .icon-arrow-right span, .ie8 .icon-arrow-left span, .ie8 .icon-arrow-down span, .ie8 .errorlist:before span, .ie8 .icon-freenode span, .ie8 .icon-alert span, .ie8 .icon-versions span, .ie8 .icon-twitter span, .ie8 .icon-thumbs-up span, .ie8 .icon-thumbs-down span, .ie8 .icon-text-resize span, .ie8 .icon-success-stories span, .ie8 .icon-statistics span, .ie8 .icon-stack-overflow span {
   display: none; }

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -2950,9 +2950,10 @@ div.note {
   background-color: #eee;
   border: 1px solid #cccccc;
   padding: 0.3125em 0.625em; }
+  div.note > p {
+    margin-bottom: 0; }
 
 p.admonition-title {
-  margin-bottom: 0.3125em;
   font-weight: bold; }
 
 /* ! ===== Slideshow requirements ===== */

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -2948,10 +2948,8 @@ p.quote-by-organization {
 
 div.note {
   background-color: #eee;
-  border: 1px solid #cccccc; }
-
-.note code {
-  background: #d6d6d6; }
+  border: 1px solid #cccccc;
+  padding: 5px 10px; }
 
 p.admonition-title {
   margin: 0px 10px 5px 0px;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2164,11 +2164,11 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
 div.note {
     background-color: #eee;
     border: 1px solid #ccc;
-    padding: 5px 10px;
+    padding: px2em( 5px ) px2em( 10px );
 }
 
 p.admonition-title {
-    margin: 0px 10px 5px 0px;
+    margin-bottom: px2em( 5px );
     font-weight: bold;
 }
 

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2161,6 +2161,15 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
     background-color: #808080;
 }
 
+div.note {
+    background-color: #eee;
+    border: 1px solid #ccc;
+}
+
+p.admonition-title {
+    margin: 0px 10px 5px 0px;
+    font-weight: bold;
+}
 
 /* ! ===== Slideshow requirements ===== */
 .flex-slideshow {

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2165,10 +2165,12 @@ div.note {
     background-color: #eee;
     border: 1px solid #ccc;
     padding: px2em( 5px ) px2em( 10px );
+    > p {
+      margin-bottom: 0;
+    }
 }
 
 p.admonition-title {
-    margin-bottom: px2em( 5px );
     font-weight: bold;
 }
 

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2164,6 +2164,7 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
 div.note {
     background-color: #eee;
     border: 1px solid #ccc;
+    padding: 5px 10px;
 }
 
 p.admonition-title {


### PR DESCRIPTION
- added box border and background color

This is to address #428 and python/peps#109

If `.. Note::` directive is used in page, then it will be rendered in a box

example screenshots:
for code of conduct page
<img width="700" alt="screen shot 2016-09-26 at 9 24 48 pm" src="https://cloud.githubusercontent.com/assets/5844587/18860247/705ce808-8430-11e6-803f-f5325a89daea.png">

for pep 339
<img width="818" alt="screen shot 2016-09-26 at 9 23 07 pm" src="https://cloud.githubusercontent.com/assets/5844587/18860246/7059cd80-8430-11e6-8b0b-12f916a8511b.png">
