### PR TITLE
use bold font for h1, and regular for h2 element

### DIFF
--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -749,13 +749,14 @@ img, embed, object, video {
 
 h1, .alpha {
   color: #3776ab;
+  font-family: SourceSansProBold, Arial, sans-serif;
   line-height: 1em;
   font-size: 1.75em;
   margin-bottom: 0.4375em; }
 
 h2, .beta {
   color: #999999;
-  font-family: SourceSansProBold, Arial, sans-serif;
+  font-family: SourceSansProRegular, Arial, sans-serif;
   font-size: 1.5em;
   margin-top: 1.3125em;
   margin-bottom: 0.32813em; }

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -88,7 +88,7 @@ img, embed, object, video { max-width: 100% }
 
 h1, .alpha {
     color: $blue;
-    //font-family: $default-font;
+    font-family: $default-font-bold;
     line-height: 1em;
     font-size: px2em( $headerone );
     @include trailer(.25);
@@ -97,7 +97,7 @@ h1, .alpha {
 
 h2, .beta {
     color: $grey-light;
-    font-family: $default-font-bold;
+    font-family: $default-font;
     font-size: px2em( $headertwo );
     @include leader(.75);
     @include trailer(.1875);


### PR DESCRIPTION
to address issue #498 

The site was using bold font for h2 elements, and regular font for h1 elements.
I changed the css so that h1 is bold, and h2 is regular.

This is how it looks like on live page PEP 442: (https://www.python.org/dev/peps/pep-0442/#id9)
<img width="425" alt="screen shot 2016-09-27 at 8 51 56 pm" src="https://cloud.githubusercontent.com/assets/5844587/18900264/bfdc8612-84f4-11e6-8b97-c249ea5e4131.png">

After style change:
<img width="456" alt="screen shot 2016-09-27 at 8 52 12 pm" src="https://cloud.githubusercontent.com/assets/5844587/18900265/bfdef834-84f4-11e6-8d4f-112279ec0d10.png">
