### PR TITLE
Get latest release information dynamically

### DIFF
--- a/downloads/templatetags/download_tags.py
+++ b/downloads/templatetags/download_tags.py
@@ -12,3 +12,8 @@ def os_release_files(release, os_slug):
         'release': release,
         'files': release.files_for_os(os_slug),
     }
+
+
+@register.filter
+def strip_minor_version(version):
+    return '.'.join(version.split('.')[:2])

--- a/pydotorg/tests/test_views.py
+++ b/pydotorg/tests/test_views.py
@@ -1,0 +1,41 @@
+from django.core.urlresolvers import reverse
+from django.db.models import signals
+from django.test import TestCase
+
+import factory
+
+from downloads.models import Release
+
+
+class ViewsTests(TestCase):
+
+    @factory.django.mute_signals(signals.post_save)
+    def test_download_index_without_release(self):
+        url = reverse('documentation')
+        response = self.client.get(url)
+        latest_python3 = response.context['latest_python3']
+        self.assertIsNone(latest_python3)
+        # We included the link because there two instances of the
+        # "Browse Current Documentation" link.
+        self.assertContains(
+            response,
+            '<a href="https://docs.python.org/3/">Browse Current Documentation</a>'
+        )
+        self.assertContains(response, 'What\'s new in Python 3')
+
+    @factory.django.mute_signals(signals.post_save)
+    def test_download_index(self):
+        release = Release.objects.create(
+            name='Python 3.6.0',
+            is_latest=True,
+            is_published=True,
+        )
+        url = reverse('documentation')
+        response = self.client.get(url)
+        latest_python3 = response.context['latest_python3']
+        self.assertIsNotNone(latest_python3)
+        self.assertEqual(latest_python3.name, release.name)
+        self.assertEqual(latest_python3.get_version(), release.get_version())
+        self.assertContains(response, 'Browse Python 3.6.0 Documentation')
+        self.assertContains(response, 'https://docs.python.org/3/whatsnew/3.6.html')
+        self.assertContains(response, 'What\'s new in Python 3.6')

--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     # https://github.com/python/pythondotorg/issues/427 for more info.
     url(r'^getit/', include('downloads.urls', namespace='getit')),
     url(r'^downloads/', include('downloads.urls', namespace='download')),
-    url(r'^doc/$', TemplateView.as_view(template_name="python/documentation.html"), name='documentation'),
+    url(r'^doc/$', views.DocumentationIndexView.as_view(), name='documentation'),
     url(r'^blog/$', RedirectView.as_view(url='/blogs/', permanent=True)),
     url(r'^blogs/$', include('blogs.urls')),
     url(r'^inner/$', TemplateView.as_view(template_name="python/inner.html"), name='inner'),

--- a/pydotorg/views.py
+++ b/pydotorg/views.py
@@ -1,6 +1,7 @@
 from django.views.generic.base import TemplateView
 
 from codesamples.models import CodeSample
+from downloads.models import Release
 
 
 class IndexView(TemplateView):
@@ -11,5 +12,17 @@ class IndexView(TemplateView):
 
         context.update({
             'code_samples': CodeSample.objects.published()[:5],
+        })
+        return context
+
+
+class DocumentationIndexView(TemplateView):
+    template_name = 'python/documentation.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update({
+            'latest_python2': Release.objects.latest_python2(),
+            'latest_python3': Release.objects.latest_python3(),
         })
         return context

--- a/templates/python/documentation.html
+++ b/templates/python/documentation.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load boxes %}
+{% load strip_minor_version from download_tags %}
 
 {% block page_title %}Our Documentation | {{ SITE_INFO.site_name }}{% endblock %}
 
@@ -43,13 +44,23 @@
 
                     <div id="docs-by-version" class="medium-widget">
 
-                        {# These need to be dynamically driven somehow, or are they going to edit these manually? #}
-
                         <h2 class="widget-title"><span aria-hidden="true" class="icon-versions"></span>Python 3.x Resources</h2>
                         <ul>
-                            <li><a href="https://docs.python.org/3/">Browse Current Python 3 Documentation</a> - <a href="http://docs.python.org/3/py-modindex.html">(Module Index)</a>
+                            <li>
+                                {% if latest_python3 %}
+                                <a href="https://docs.python.org/3/">Browse Python {{ latest_python3.get_version }} Documentation</a>
+                                {% else %}
+                                <a href="https://docs.python.org/3/">Browse Current Documentation</a>
+                                {% endif %}
+                                - <a href="http://docs.python.org/3/py-modindex.html">(Module Index)</a>
                                 <ul>
-                                    <li><a href="https://docs.python.org/3/whatsnew/index.html">What's new in Python 3</a></li>
+                                    <li>
+                                        {% if latest_python3 %}
+                                        <a href="https://docs.python.org/3/whatsnew/{{ latest_python3.get_version|strip_minor_version }}.html">What's new in Python {{ latest_python3.get_version|strip_minor_version }}</a>
+                                        {% else %}
+                                        <a href="https://docs.python.org/3/whatsnew/index.html">What's new in Python 3</a>
+                                        {% endif %}
+                                    </li>
                                     <li><a href="https://docs.python.org/3/tutorial/index.html">Tutorial</a></li>
                                     <li><a href="https://docs.python.org/3/library/index.html">Library Reference</a></li>
                                     <li><a href="https://docs.python.org/3/reference/index.html">Language Reference</a></li>
@@ -67,7 +78,13 @@
                     <div class="medium-widget last">
                         <h2 class="widget-title"><span aria-hidden="true" class="icon-versions"></span>Python 2.x Resources</h2>
                         <ul>
-                            <li><a href="https://docs.python.org/2/">Browse Current Documentation</a> - <a href="http://docs.python.org/2/py-modindex.html">(Module Index)</a>
+                            <li>
+                                {% if latest_python2 %}
+                                <a href="https://docs.python.org/2/">Browse Python {{ latest_python2.get_version }} Documentation</a>
+                                {% else %}
+                                <a href="https://docs.python.org/2/">Browse Current Documentation</a>
+                                {% endif %}
+                                - <a href="http://docs.python.org/2/py-modindex.html">(Module Index)</a>
                                 <ul>
                                     <li><a href="https://docs.python.org/2/whatsnew/2.7.html">What's new in Python 2.7</a></li>
                                     <li><a href="https://docs.python.org/2/tutorial/index.html">Tutorial</a></li>


### PR DESCRIPTION
This is a follow-up to 9252841f0eea0d166a4a2ee9253fb6596d2fa9f2.

@ned-deily I've updated https://www.python.org/doc/ to show the latest Python releases.
