### PR TITLE
Installation docs: Mention Elasticsearch

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -181,3 +181,15 @@ To build this documentation locally::
 If you don't want to open the browser automatically, you can do::
 
     $ make -C docs/ html
+
+
+Optional: Install ElasticSearch
+-------------------------------
+
+The search feature in Python.org uses ElasticSearch engine.  If you want to
+test out this feature, you will need to install ElasticSearch_.
+
+Once you have it installed, update the URL value of ``HAYSTACK_CONNECTIONS``
+settings in ``pydotorg/settings/local.py`` to your local ElasticSearch server.
+
+.. _ElasticSearch: https://www.elastic.co/downloads/elasticsearch

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -99,6 +99,18 @@ Finally, start the development server::
     $ ./manage.py runserver
 
 
+Optional: Install Elasticsearch
+-------------------------------
+
+The search feature in Python.org uses Elasticsearch engine.  If you want to
+test out this feature, you will need to install Elasticsearch_.
+
+Once you have it installed, update the URL value of ``HAYSTACK_CONNECTIONS``
+settings in ``pydotorg/settings/local.py`` to your local ElasticSearch server.
+
+.. _Elasticsearch: https://www.elastic.co/downloads/elasticsearch
+
+
 Generating CSS files automatically
 ----------------------------------
 
@@ -181,15 +193,3 @@ To build this documentation locally::
 If you don't want to open the browser automatically, you can do::
 
     $ make -C docs/ html
-
-
-Optional: Install ElasticSearch
--------------------------------
-
-The search feature in Python.org uses ElasticSearch engine.  If you want to
-test out this feature, you will need to install ElasticSearch_.
-
-Once you have it installed, update the URL value of ``HAYSTACK_CONNECTIONS``
-settings in ``pydotorg/settings/local.py`` to your local ElasticSearch server.
-
-.. _ElasticSearch: https://www.elastic.co/downloads/elasticsearch


### PR DESCRIPTION
Add an optional Elasticsearch installation step in the documentation.

Closes https://github.com/python/pythondotorg/issues/1033

@berkerpeksag Let me know if this works, or if you have additional feedback.
Thanks :)