### PR TITLE
Switch to use non-forked version of django-comments-xtd

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -29,7 +29,8 @@ django-timedeltafield==0.7.3
 requests==2.5.1
 
 django-jsonfield==0.9.13
-git+https://github.com/danirus/django-comments-xtd.git@182b54afc62e5d3967be75ac6ed8b19071764a6d
+git+https://github.com/berkerpeksag/django-contrib-comments.git@pydotorg
+django-comments-xtd==1.5.1
 
 django-honeypot==0.4.0
 django-markupfield==1.3.2

--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -128,10 +128,10 @@ INSTALLED_APPS = [
     'django.contrib.redirects',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.comments',
     'django.contrib.admin',
     'django.contrib.admindocs',
 
+    'django_comments',
     'django_comments_xtd',
     'jsonfield',
     'pipeline',


### PR DESCRIPTION
The version we've been using doesn't support new migrations
so we can't write a data migration without proper
migration files.

The built-in comments application also doesn't have migrations
so we had to switch to 'django_comments'.

We have to use a forked version because of the following line
in setup.py:

    install_requires=['Django>=1.6']

This would install the latest stable version of Django which
would break our application.