### PR TITLE
Switch to django-rest-framework

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -36,3 +36,6 @@ django-markupfield==1.4.2
 django-allauth==0.32.0
 
 django-waffle==0.12
+
+djangorestframework==3.6.4
+django-filter==1.0.4

--- a/downloads/serializers.py
+++ b/downloads/serializers.py
@@ -1,0 +1,48 @@
+from rest_framework import serializers
+
+from downloads.models import OS, Release, ReleaseFile
+
+
+class OSSerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = OS
+        fields = ('name', 'slug', 'resource_uri')
+
+
+class ReleaseSerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = Release
+        fields = (
+            'name',
+            'slug',
+            'version',
+            'is_published',
+            'release_date',
+            'pre_release',
+            'release_page',
+            'release_notes_url',
+            'show_on_download_page',
+            'resource_uri',
+        )
+
+
+class ReleaseFileSerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = ReleaseFile
+        fields = (
+            'name',
+            'slug',
+            'os',
+            'release',
+            'description',
+            'is_source',
+            'url',
+            'gpg_signature_file',
+            'md5_sum',
+            'filesize',
+            'download_button',
+            'resource_uri',
+        )

--- a/downloads/tests/base.py
+++ b/downloads/tests/base.py
@@ -25,7 +25,7 @@ class DownloadMixin:
         cls.linux, _ = OS.objects.get_or_create(name='Linux')
 
 
-class BaseDownloadTests(DownloadMixin, TestCase):
+class BaseDownloadTests(DownloadMixin):
 
     def setUp(self):
         self.release_275_page = Page.objects.create(
@@ -66,6 +66,7 @@ class BaseDownloadTests(DownloadMixin, TestCase):
         )
 
         self.release_275_linux = ReleaseFile.objects.create(
+            name='Source tarball',
             os=self.linux,
             release=self.release_275,
             is_source=True,
@@ -79,6 +80,16 @@ class BaseDownloadTests(DownloadMixin, TestCase):
             is_published=False,
             release_page=self.release_275_page,
         )
+
+        self.draft_release_linux = ReleaseFile.objects.create(
+            name='Source tarball for a draft release',
+            os=self.linux,
+            release=self.draft_release,
+            is_source=True,
+            description='Gzipped source',
+            url='ftp/python/9.7.2/Python-9.7.2.tgz',
+        )
+
         self.hidden_release = Release.objects.create(
             version=Release.PYTHON3,
             name='Python 0.0.0',

--- a/pages/api.py
+++ b/pages/api.py
@@ -1,6 +1,13 @@
+from rest_framework.authentication import TokenAuthentication
+
 from pydotorg.resources import GenericResource, OnlyPublishedAuthorization
+from pydotorg.drf import (
+    BaseReadOnlyAPIViewSet, BaseFilterSet, IsStaffOrReadOnly,
+)
 
 from .models import Page
+from .serializers import PageSerializer
+
 
 class PageResource(GenericResource):
     class Meta(GenericResource.Meta):
@@ -20,3 +27,23 @@ class PageResource(GenericResource):
             'path': ('exact',),
             'is_published': ('exact',),
         }
+
+
+class PageFilterSet(BaseFilterSet):
+
+    class Meta:
+        model = Page
+        fields = {
+            'title': ['exact'],
+            'path': ['exact'],
+            'keywords': ['exact', 'icontains'],
+            'is_published': ['exact'],
+        }
+
+
+class PageViewSet(BaseReadOnlyAPIViewSet):
+    model = Page
+    serializer_class = PageSerializer
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsStaffOrReadOnly,)
+    filter_class = PageFilterSet

--- a/pages/factories.py
+++ b/pages/factories.py
@@ -1,0 +1,17 @@
+import factory
+
+from users.factories import UserFactory
+
+from .models import Page
+
+
+class PageFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Page
+        django_get_or_create = ('path',)
+
+    title = factory.Sequence(lambda n: 'Page Title #{}'.format(n))
+    path = factory.Sequence(lambda n: '/page-title-{}/'.format(n))
+    content = factory.Faker('paragraph', nb_sentences=5)
+    creator = factory.SubFactory(UserFactory)

--- a/pages/serializers.py
+++ b/pages/serializers.py
@@ -1,0 +1,19 @@
+from rest_framework import serializers
+
+from .models import Page
+
+
+class PageSerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = Page
+        fields = (
+            'title',
+            'path',
+            'keywords',
+            'description',
+            'content',
+            'is_published',
+            'template_name',
+            'resource_uri',
+        )

--- a/pages/tests/test_api.py
+++ b/pages/tests/test_api.py
@@ -1,0 +1,82 @@
+from rest_framework.test import APITestCase
+
+from pydotorg.drf import BaseAPITestCase
+
+from pages.factories import PageFactory
+from users.factories import UserFactory
+
+
+class PageApiViewsTest(BaseAPITestCase, APITestCase):
+    app_label = 'pages'
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.page = PageFactory(keywords='python, django')
+        cls.page2 = PageFactory(keywords='django')
+        cls.page_unpublished = PageFactory(keywords='python', is_published=False)
+        cls.staff_user = UserFactory(
+            username='staffuser',
+            password='passworduser',
+            is_staff=True,
+        )
+        cls.Authorization = 'Token {}'.format(cls.staff_user.auth_token.key)
+
+    def test_get_published_pages(self):
+        url = self.create_url('page')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 2)
+
+    def test_get_all_pages(self):
+        # Login to get all pages.
+        url = self.create_url('page')
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.Authorization)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 3)
+
+    def test_filter_page(self):
+        url = self.create_url('page', filters={'keywords__icontains': 'PYTHON'})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+        # Login to filter all pages.
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.Authorization)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 2)
+
+        # This should return an empty result because normal users
+        # cannot see unpublished pages.
+        url = self.create_url('page', filters={'is_published': False})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+        # This should return only unpublished pages.
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.Authorization)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+    def test_post_page(self):
+        url = self.create_url('page')
+        data = {
+            'title': 'Paradise Lost - The Longest Winter',
+            'path': '/the-longest-winter/',
+            'keywords': 'paradise lost, doom death metal',
+            'is_published': True,
+        }
+        response = self.json_client('POST', url, data)
+        self.assertEqual(response.status_code, 401)
+
+        # 'PageViewSet' is read-only.
+        response = self.json_client('POST', url, data, HTTP_AUTHORIZATION=self.Authorization)
+        self.assertEqual(response.status_code, 405)
+
+    def test_delete_page(self):
+        url = self.create_url('page', self.page.pk)
+        response = self.json_client('DELETE', url)
+        self.assertEqual(response.status_code, 401)
+
+        # 'PageViewSet' is read-only.
+        response = self.json_client('DELETE', url, HTTP_AUTHORIZATION=self.Authorization)
+        self.assertEqual(response.status_code, 405)

--- a/pydotorg/drf.py
+++ b/pydotorg/drf.py
@@ -1,0 +1,99 @@
+import json
+
+from urllib.parse import urlencode, urljoin
+
+from django.db.models.constants import LOOKUP_SEP
+from django.core.exceptions import ImproperlyConfigured
+
+from django_filters import rest_framework as filters
+from rest_framework import serializers
+from rest_framework import viewsets
+from rest_framework.permissions import SAFE_METHODS, IsAuthenticatedOrReadOnly
+
+
+class IsStaffOrReadOnly(IsAuthenticatedOrReadOnly):
+
+    def has_permission(self, request, view):
+        return (
+            request.method in SAFE_METHODS or
+            request.user and
+            request.user.is_staff
+        )
+
+
+class BaseAPIViewMixin:
+    # 'model' is not part of the rest_framework API.
+    model = None
+
+    def get_queryset(self):
+        # This is equivalent of 'OnlyPublishedAuthorization'
+        # in Tastypie.
+        if not self.request.user.is_staff:
+            return self.model.objects.filter(is_published=True)
+        return self.model.objects.all()
+
+
+class BaseAPIViewSet(BaseAPIViewMixin, viewsets.ModelViewSet):
+    pass
+
+
+class BaseReadOnlyAPIViewSet(BaseAPIViewMixin, viewsets.ReadOnlyModelViewSet):
+    pass
+
+
+class BaseFilterSet(filters.FilterSet):
+
+    @property
+    def qs(self):
+        errors = []
+        for param in set(self.data) - set(self.filters):
+            if LOOKUP_SEP not in param:
+                field, filter = param, 'exact'
+            else:
+                params = param.split(LOOKUP_SEP)
+                if len(params) == 2:
+                    field, filter = params
+                else:
+                    *field_parts, filter = params
+                    field = LOOKUP_SEP.join(field_parts)
+            errors.append(
+                '{!r} is not an allowed filter on the {!r} field.'.format(filter, field)
+            )
+        if errors:
+            raise serializers.ValidationError({'error': errors})
+        return super().qs
+
+
+class BaseAPITestCase:
+
+    api_version = 'v2'
+    app_label = None
+
+    def _check_testcase_config(self):
+        if self.api_version is None:
+            raise ImproperlyConfigured(
+                'Please set \'api_version\' attribute in your test case.'
+            )
+        if self.app_label is None:
+            raise ImproperlyConfigured(
+                'Please set \'app_label\' attribute in your test case.'
+            )
+
+    def create_url(self, model='', pk=None, *, filters=None, app_label=None):
+        self._check_testcase_config()
+        if app_label is None:
+            app_label = self.app_label
+        base_url = '/api/%s/%s/%s/' % (self.api_version, app_label, model)
+        if pk is not None:
+            base_url += '%d/' % pk
+        if filters is not None:
+            filters = '?' + urlencode(filters)
+            return urljoin(base_url, filters)
+        return base_url
+
+    def json_client(self, method, url, data=None, **headers):
+        self._check_testcase_config()
+        if not data:
+            data = {}
+        client_method = getattr(self.client, method.lower())
+        return client_method(url, json.dumps(data), content_type='application/json', **headers)

--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -179,6 +179,10 @@ INSTALLED_APPS = [
 
     # Tastypie needs the `users` app to be already loaded.
     'tastypie',
+
+    'rest_framework',
+    'rest_framework.authtoken',
+    'django_filters',
 ]
 
 # Fixtures
@@ -256,7 +260,29 @@ MESSAGE_TAGS = {
     constants.INFO: 'general',
 }
 
-
 ### SecurityMiddleware
 
 X_FRAME_OPTIONS = 'DENY'
+
+### django-rest-framework
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+    ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    ),
+    'URL_FIELD_NAME': 'resource_uri',
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
+    ),
+    'DEFAULT_THROTTLE_CLASSES': (
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle',
+    ),
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '100/day',
+        'user': '1000/day',
+    },
+}

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -51,3 +51,7 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
     }
 }
+
+REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] += (
+    'rest_framework.renderers.BrowsableAPIRenderer',
+)

--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -9,7 +9,7 @@ from cms.views import custom_404
 from users.views import HoneypotSignupView
 
 from . import views
-from .urls_api import v1_api
+from .urls_api import v1_api, router
 
 handler404 = custom_404
 
@@ -66,6 +66,7 @@ urlpatterns = [
 
     # api
     url(r'^api/', include(v1_api.urls)),
+    url(r'^api/v2/', include(router.urls)),
 ]
 
 urlpatterns += staticfiles_urlpatterns()

--- a/pydotorg/urls_api.py
+++ b/pydotorg/urls_api.py
@@ -1,10 +1,20 @@
+from rest_framework import routers
+
 from tastypie.api import Api
 
 from downloads.api import OSResource, ReleaseResource, ReleaseFileResource
+from downloads.api import OSViewSet, ReleaseViewSet, ReleaseFileViewSet
 from pages.api import PageResource
+from pages.api import PageViewSet
 
 v1_api = Api(api_name='v1')
 v1_api.register(PageResource())
 v1_api.register(OSResource())
 v1_api.register(ReleaseResource())
 v1_api.register(ReleaseFileResource())
+
+router = routers.DefaultRouter()
+router.register(r'pages/page', PageViewSet, base_name='page')
+router.register(r'downloads/os', OSViewSet)
+router.register(r'downloads/release', ReleaseViewSet, base_name='release')
+router.register(r'downloads/release_file', ReleaseFileViewSet)

--- a/users/__init__.py
+++ b/users/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'users.apps.UsersAppConfig'

--- a/users/admin.py
+++ b/users/admin.py
@@ -2,11 +2,16 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.utils.translation import ugettext_lazy as _
 
+from rest_framework.authtoken.admin import TokenAdmin
+
 from tastypie.admin import ApiKeyInline as TastypieApiKeyInline
 from tastypie.models import ApiKey
 
 from .actions import export_csv
 from .models import User, Membership
+
+TokenAdmin.search_fields = ('user__username',)
+TokenAdmin.raw_id_fields = ('user',)
 
 
 class MembershipInline(admin.StackedInline):

--- a/users/apps.py
+++ b/users/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class UsersAppConfig(AppConfig):
+
+    name = 'users'
+    verbose_name = 'Users'
+
+    def ready(self):
+        import users.listeners

--- a/users/listeners.py
+++ b/users/listeners.py
@@ -1,0 +1,12 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from rest_framework.authtoken.models import Token
+
+from .models import User
+
+
+@receiver(post_save, sender=User)
+def create_auth_token(sender, instance, created, **kwargs):
+    if created:
+        Token.objects.create(user=instance)


### PR DESCRIPTION
**TODOs:**

* [x] Upgrade to Django 1.8: #1127 
* [x] Make tests runnable for both `/v1/` and `/v2/` APIs
* [x] Make filtering work
* [x] Fix `TODO` comments
* [x] Add a test when an auth token is invalid