### PR TITLE
remove membership roster

### DIFF
--- a/templates/psf/index.html
+++ b/templates/psf/index.html
@@ -48,7 +48,6 @@
                         <h2 class="widget-title">Sponsors</h2>
                         {% featured_sponsor_rotation %}
                         <p><a class="button" href="/psf/sponsorship/">Sponsorship Possibilities</a></p>
-                        <p><a href="/psf/members/#sponsor-members">PSF Sponsors</a></p>
                     </div>
 
                 </div>


### PR DESCRIPTION
incorrect link listed, remove from sponsors block, membership roster is showing, although the sponsors link is listed.