### PR TITLE
Fix: non featured events are always included in get_events_upcoming

### DIFF
--- a/events/templatetags/events.py
+++ b/events/templatetags/events.py
@@ -12,5 +12,5 @@ def get_events_upcoming(limit=5, only_featured=False):
     qs = Event.objects.for_datetime(timezone.now()).order_by(
         'occurring_rule__dt_start')
     if only_featured:
-        qs.filter(featured=True)
+        qs = qs.filter(featured=True)
     return qs[:limit]

--- a/events/tests/test_views.py
+++ b/events/tests/test_views.py
@@ -149,7 +149,7 @@ class EventsViewsTests(TestCase):
 
     def test_upcoming_tag(self):
         self.assertEqual(len(get_events_upcoming()), 1)
-        self.assertEqual(len(get_events_upcoming(only_featured=True)), 1)
+        self.assertEqual(len(get_events_upcoming(only_featured=True)), 0)
         self.rule.begin = self.now - datetime.timedelta(days=3)
         self.rule.finish = self.now - datetime.timedelta(days=2)
         self.rule.save()


### PR DESCRIPTION
Just realized that `qs.filter(featured=True)` does not modify `qs` but returns the filtered result instead.