### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:14.04
+
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+    build-essential \
+    ca-certificates \
+    gcc \
+    git \
+    libpq-dev \
+    make \
+    mercurial \
+    pkg-config \
+    python3.4 \
+    python3.4-dev \
+    ssh \
+    libxml2-dev \
+    libxslt1-dev \
+    ruby \
+    && apt-get autoremove \
+    && apt-get clean
+
+ADD https://raw.githubusercontent.com/pypa/pip/5d927de5cdc7c05b1afbdd78ae0d1b127c04d9d0/contrib/get-pip.py /root/get-pip.py
+RUN python3.4 /root/get-pip.py
+RUN pip3.4 install -U "setuptools==18.4"
+RUN pip3.4 install -U "pip==7.1.2"
+RUN pip3.4 install -U "virtualenv==13.1.2"
+
+COPY ./*requirements.txt /app/
+RUN pip3.4 install -r /app/dev-requirements.txt
+
+COPY . /app
+WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+
+services:
+  postgres:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - DEBUG=false
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=1234
+      - POSTGRES_DB=pythondotorg
+
+  django:
+    restart: always
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+    links:
+      - postgres:db
+
+    command: ["/bin/bash","docker-start.sh"]
+    environment:
+      - DATABASE_URL=postgres://postgres:1234@db:5432/pythondotorg

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,5 @@
+sleep 5
+python3.4 manage.py migrate
+gem install bundler && bundle install
+python3.4 manage.py create_initial_data <<< "y"
+python3.4 manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
This PR adds support for Docker. This is intended to easy the initial set-up of the environment and requirements for recurring and first-time contributors alike. The advantage of using this approach is that the developer does not need to install and configure postgresql, ruby, python3.4 and all python packages locally, effectively simplifying the installation and set up of the environment. Also, if the environment is not needed, is very easy to clean.

To install all dependencies and start the containers:

1. Install docker and docker-compose

2. `docker-compose up --build`

The first set up will take a while, but after that everything will be cached and therefore new instantiation of the containers will take much less time.

3. Access the webpage on `localhost:8000`.

4. Profit! :moneybag: 

If you want to change anything in the project and see the result, just re-run `docker-compose up --build` again. Take into account that this will NOT reset the database. If you want to start **truly** clean, run `docker-compose rm` first to remove the previous containers.

------

One of the main targets of using this approach is to make much easier to set up everything for new developers and contributors, no mater if they use Windows, Linux or MacOS as long as they can run docker.