### PR TITLE
:racehorse: Adds venue to EventAdmin.raw_id_fields

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -33,6 +33,7 @@ class EventAdmin(ContentManageableModelAdmin):
     inlines = [OccurringRuleInline, RecurringRuleInline, AlarmInline]
     list_display = ['__str__', 'calendar', 'featured']
     list_filter = ['calendar', 'featured']
+    raw_id_fields = ['venue']
     search_fields = ['title']
 
 


### PR DESCRIPTION
I noticed that the Events admin has over 526 locations (called venues) which significantly slows down the page down. I added `venue` as a `raw_id_fields` which makes the page show up instantly. 

Signed-off-by: Jeff Triplett <jeff.triplett@gmail.com>