### PR TITLE
Proposal: use bolder font weight for code blocks on pep page

### DIFF
--- a/templates/pages/pep-page.html
+++ b/templates/pages/pep-page.html
@@ -33,7 +33,15 @@
         -webkit-box-shadow: 0 0 0 0;
         -moz-box-shadow: 0 0 0 0;
         box-shadow: 0 0 0 0;
-        font-weight: bold;
+   }
+   .pep-page pre.literal-block {
+       background-color: #e6e8ea;
+       font-weight: bold;
+       border: 1px solid #ddd;
+       padding: 1em;
+       -webkit-box-shadow: 0 0 1em rgba( 0, 0, 0, 0.2 );
+       -moz-box-shadow: 0 0 1em rgba( 0, 0, 0, 0.2 );
+       box-shadow: 0 0 1em rgba( 0, 0, 0, 0.2 );
    }
 </style>
 

--- a/templates/pages/pep-page.html
+++ b/templates/pages/pep-page.html
@@ -36,7 +36,6 @@
    }
    .pep-page pre.literal-block {
        background-color: #e6e8ea;
-       font-weight: bold;
        border: 1px solid #ddd;
        padding: 1em;
        -webkit-box-shadow: 0 0 1em rgba( 0, 0, 0, 0.2 );

--- a/templates/pages/pep-page.html
+++ b/templates/pages/pep-page.html
@@ -33,6 +33,7 @@
         -webkit-box-shadow: 0 0 0 0;
         -moz-box-shadow: 0 0 0 0;
         box-shadow: 0 0 0 0;
+        font-weight: bold;
    }
 </style>
 


### PR DESCRIPTION
I usually struggle reading code blocks for PEPs due to thin font rendering (using both Chrome and Firefox, macOS).

This is a small proposal to make font weight bold for the code blocks so they can be easier to read.

Before:
<img width="831" alt="image" src="https://user-images.githubusercontent.com/858295/35164809-e1e244c4-fd19-11e7-87c8-6df3d9905db7.png">

After:
<img width="830" alt="image" src="https://user-images.githubusercontent.com/858295/35164830-fa8802d4-fd19-11e7-9d42-b5bfcc16f212.png">
