### PR TITLE
Remove python2 cta

### DIFF
--- a/fixtures/boxes.json
+++ b/fixtures/boxes.json
@@ -387,7 +387,7 @@
 {
     "fields": {
         "label": "homepage-downloads",
-        "content": "<h2 class=\"widget-title\"><span aria-hidden=\"true\" class=\"icon-download\"></span>Download</h2>\n<p>Python source code and installers are available for download for all versions! Not sure which version to use? <a href=\"https://wiki.python.org/moin/Python2orPython3\">Check here</a>.</p>\n<p>Latest: <a href=\"/downloads/release/python-352/\">Python 3.5.2</a> - <a href=\"/downloads/release/python-2712/\">Python 2.7.12</a></p>",
+        "content": "<h2 class=\"widget-title\"><span aria-hidden=\"true\" class=\"icon-download\"></span>Download</h2>\n<p>Python source code and installers are available for download for all versions!.</p>\n<p>Latest: <a href=\"/downloads/release/python-352/\">Python 3.5.2</a></p>",
         "content_markup_type": "html"
     }
 }

--- a/fixtures/boxes.json
+++ b/fixtures/boxes.json
@@ -331,7 +331,7 @@
 {
     "fields": {
         "label": "download-banner",
-        "content": "<p>Wondering which version to use? <a href=\"https://wiki.python.org/moin/Python2orPython3\">Here&rsquo;s more about the difference between Python 2 and 3.</a> </p>\r\n<p style=\"margin-top: 0.35em\">Looking for Python with a different OS? Python for <a href=\"/downloads/windows/\">Windows</a>, <a href=\"/downloads/source/\">Linux/UNIX</a>, <a href=\"/downloads/mac-osx/\">Mac OS X</a>, <a href=\"/download/other/\">Other</a></p>\r\n<p style=\"margin-top: 0.35em\">Want to help test development versions of Python?  <a href=\"/download/pre-releases/\">Pre-releases</a></p>",
+        "content": "<p>Looking for Python with a different OS? Python for <a href=\"/downloads/windows/\">Windows</a>, <a href=\"/downloads/source/\">Linux/UNIX</a>, <a href=\"/downloads/mac-osx/\">Mac OS X</a>, <a href=\"/download/other/\">Other</a></p>\r\n<p style=\"margin-top: 0.35em\">Want to help test development versions of Python?  <a href=\"/download/pre-releases/\">Pre-releases</a></p>\r\n<p style="margin-top: 0.35em">Looking for Python 2.7? See below for specific releases</p>",
         "content_markup_type": "html"
     }
 },

--- a/templates/downloads/homepage-downloads-box.html
+++ b/templates/downloads/homepage-downloads-box.html
@@ -1,3 +1,3 @@
 <h2 class="widget-title"><span aria-hidden="true" class="icon-download"></span>Download</h2>
-<p>Python source code and installers are available for download for all versions! Not sure which version to use? <a href="https://wiki.python.org/moin/Python2orPython3">Check here</a>.</p>
-<p>Latest: <a href="{{ latest_python3.get_absolute_url }}">{{ latest_python3.name }}</a> - <a href="{{ latest_python2.get_absolute_url }}">{{ latest_python2.name }}</a></p>
+<p>Python source code and installers are available for download for all versions!</p>
+<p>Latest: <a href="{{ latest_python3.get_absolute_url }}">{{ latest_python3.name }}</a></p>

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -19,20 +19,14 @@
                         {% if data.python3 %}
                         <a class="button" href="{{ data.python3.url }}">Download {{ data.python3.release.name }}</a>
                         {% endif %}
-                        {% if data.python2 %}
-                        <a class="button" href="{{ data.python2.url }}">Download {{ data.python2.release.name }}</a>
-                        {% endif %}
                     </p>
                 </div>
             {% endfor %}
             <div class="download-unknown">
-                <h1 class="call-to-action">Download the latest versions of Python</h1>
+                <h1 class="call-to-action">Download the latest version of Python</h1>
                 <p class="download-buttons">
                     {% if latest_python3 %}
                     <a class="button" href="{{ latest_python3.get_absolute_url }}">Download {{ latest_python3.name }}</a>
-                    {% endif %}
-                    {% if latest_python2 %}
-                    <a class="button" href="{{ latest_python2.get_absolute_url }}">Download {{ latest_python2.name }}</a>
                     {% endif %}
                 </p>
             </div>

--- a/templates/downloads/supernav.html
+++ b/templates/downloads/supernav.html
@@ -9,7 +9,6 @@
         {% endif %}
         <p>
             <a class="button" href="{{ data.python3.url }}">{{ data.python3.release.name }}</a>
-            <a class="button" href="{{ data.python2.url }}">{{ data.python2.release.name }}</a>
         </p>
         {% if data.os.slug == 'windows' %}<p><strong>Note that Python 3.5+ <em>cannot</em> be used on Windows XP or earlier.</strong></p>{% endif %}
         <p>Not the OS you are looking for? Python can be used on many operating systems and environments. <a href="{% url 'download:download' %}">View the full list of downloads</a>.</p>


### PR DESCRIPTION
Fixes #1218...

**Remove the Python 2 CTA buttons from the downloads page**

As described in the original issue.

**Remove 'which version' text from download-banner box fixture**

As described in the original issue, this may have to be manually effected in production since it's in the "box" stuff that appears to be managed in the CMS (and was how I had to do it locally for the change to take effect). It seemed reasonable to refresh the fixture though.

With these changes, it the banner area on the downloads page looks like this:

<img width="719" alt="downloads-banner" src="https://user-images.githubusercontent.com/396822/35316636-c606d744-00a0-11e8-9c01-ddce1e4d5a9c.png">

**Remove the Python 2 CTA buttons from the downloads supernav**

Not described in the original issue but seemed like a good idea for consistency.

With this change, the downloads supernav looks like this:

<img width="664" alt="downloads-supernav" src="https://user-images.githubusercontent.com/396822/35316672-f07c2d76-00a0-11e8-9991-a0434e16e83a.png">

**Remove Python 2 from homepage downloads box**

Not described in the original issue, this also seemed like a good idea for consistency since the "wondering which version" text that the original issue is asking to remove also currently appears in the downloads box on the homepage. Again, I had to update the box in the CMS for the change to take effect, but the fixture has been updated to remove both the "which version" text as well as the link to the latest Python 2 version--this last seemed in the spirit of the CTA button removal.

With this change, the downloads box on the homepage looks like this:

<img width="1173" alt="homepage-downloads-box" src="https://user-images.githubusercontent.com/396822/35316703-0ae1e7e6-00a1-11e8-92db-fc045f518e5c.png">

**Not Undertaken**

There may be some opportunities to clean up the downloads view code to remove queries to get the latest Python 2 versions, which would trim a few ms, but I didn't feel comfortable ripping those out yet in case something else needed them or if the resulting change would be more extensive than desired. This can certainly be explored though.