### PR TITLE
Change default database for local development to sqlite. Changed defa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ static-root
 tmp/*
 media/*
 pydotorg/settings/mylocal.py
+.idea/

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -9,9 +9,12 @@ INTERNAL_IPS = ['127.0.0.1']
 # For example,
 # PYTHON_ORG_CONTENT_SVN_PATH = '/Users/flavio/working_copies/beta.python.org/build/data'
 PYTHON_ORG_CONTENT_SVN_PATH = ''
+DATABASE_URL = os.path.join(BASE, 'test_sqlite.db')
 
 DATABASES = {
-    'default': dj_database_url.config(default='postgres:///pythondotorg')
+    # 'default': dj_database_url.config(default='postgres:///pythondotorg')
+    # 'default': dj_database_url.parse('postgres:///pythondotorg')
+    'default': dj_database_url.parse('sqlite:////' + DATABASE_URL)
 }
 
 HAYSTACK_CONNECTIONS = {

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -9,7 +9,7 @@ INTERNAL_IPS = ['127.0.0.1']
 # For example,
 # PYTHON_ORG_CONTENT_SVN_PATH = '/Users/flavio/working_copies/beta.python.org/build/data'
 PYTHON_ORG_CONTENT_SVN_PATH = ''
-DATABASE_URL = os.path.join(BASE, 'test_sqlite.db')
+DATABASE_URL = os.path.join(BASE, 'pythondotorg.db')
 
 DATABASES = {
     # 'default': dj_database_url.config(default='postgres:///pythondotorg')


### PR DESCRIPTION
Modified default database in local.py to sqlite. This should allow users who do not wish to set up a fully fledged postgres database to quickly set up the project with sqlite database which will sit in the root of the project.
For access to previous settings the postgres setting is left commented out should the user want to choose this type of the database.

We should also add the following to the developers instructions as some people get lost when they need to create a postgres database.

We assume postgres is already installed.

1. Switch to base postgres account to create a database
- $ sudo su - postgres
2. Get into postgres shell
- postgres@<your pc name>:~$ psql
3. Create pythondotorg database
- postgres=#  createdb pythondotorg -E utf-8 -l en_US.UTF-8

4. Quit postgres shell
postgres-# /q
5. Go back to your own user account
- postgres@<your pc name>:~$ exit


