### PR TITLE
Bumping Pillow to 5.1.0

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -4,7 +4,7 @@ django-sitetree==1.8.0
 Django==1.11.7
 docutils==0.12
 Markdown==2.5.2
-Pillow==2.7.0
+Pillow==5.1.0
 psycopg2==2.7.3.2
 python3-openid==3.0.5
 # lxml used by BeautifulSoup.


### PR DESCRIPTION
Tests all pass on Pillow 5.1.0 and Imagekit 4.0.1, and this removes the compile issue (as 5.1.0 installs via a wheel)