### PR TITLE
--flush option for create_initial_data

### DIFF
--- a/cms/management/commands/create_initial_data.py
+++ b/cms/management/commands/create_initial_data.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
             '--flush',
             action='store_true',
             dest='do_flush',
-            help='Remove existing data in the database before creating new data.'
+            help='Remove existing data in the database before creating new data.',
         )
 
     def collect_initial_data_functions(self, app_label):
@@ -57,7 +57,8 @@ class Command(BaseCommand):
 
     def flush_handler(self, do_flush, verbosity):
         if do_flush:
-            msg = ('You have provided the --flush parameter, this will cleanup '
+            msg = (
+                'You have provided the --flush parameter, this will cleanup '
                 'the database before creating new data.\n'
                 'Type \'y\' or \'yes\' to continue, \'n\' or \'no\' to cancel: '
                 )
@@ -66,20 +67,16 @@ class Command(BaseCommand):
                 'Note that this command won\'t cleanup the database before '
                 'creating new data.\n'
                 'If you would like to cleanup the database before creating '
-                'new data, \nplease type \'n\' or \'no\' and call the '
-                'create_initial_data command adding the --flush parameter\n'
+                'new data, \ncall create_initial_data with --flush\n'
                 'Type \'y\' or \'yes\' to continue, \'n\' or \'no\' to cancel: '
             )
         confirm = input(self.style.WARNING(msg))
-        if do_flush and (confirm in ('y', 'yes')):
+        if do_flush and confirm in ('y', 'yes'):
             try:
-                cmd = flush.Command()
-                call_command(cmd, verbosity=verbosity, interactive=False)
+                call_command('flush', verbosity=verbosity, interactive=False)
             except Exception as exc:
                 self.stdout.write(self.style.ERROR('{}: {}'.format(type(exc).__name__, exc)))
-            return confirm
-        else:
-            return confirm
+        return confirm
 
     def handle(self, **options):
         verbosity = options['verbosity']

--- a/cms/management/commands/create_initial_data.py
+++ b/cms/management/commands/create_initial_data.py
@@ -4,7 +4,6 @@ import pprint
 
 from django.apps import apps
 from django.core.management import BaseCommand, call_command
-from django.core.management.commands import flush
 
 
 class Command(BaseCommand):
@@ -58,7 +57,7 @@ class Command(BaseCommand):
     def flush_handler(self, do_flush, verbosity):
         if do_flush:
             msg = (
-                'You have provided the --flush parameter, this will cleanup '
+                'You have provided the --flush argument, this will cleanup '
                 'the database before creating new data.\n'
                 'Type \'y\' or \'yes\' to continue, \'n\' or \'no\' to cancel: '
                 )
@@ -67,7 +66,7 @@ class Command(BaseCommand):
                 'Note that this command won\'t cleanup the database before '
                 'creating new data.\n'
                 'If you would like to cleanup the database before creating '
-                'new data, \ncall create_initial_data with --flush\n'
+                'new data, call create_initial_data with --flush.\n'
                 'Type \'y\' or \'yes\' to continue, \'n\' or \'no\' to cancel: '
             )
         confirm = input(self.style.WARNING(msg))


### PR DESCRIPTION
This addresses #1175. 

At the moment it will display a similar message as before depending if `--flush` is provided or not. The alternative would be to use `interactive=True` in the `call_command` and let this handle if the user wants to flush the database or not. The advantage of the current implementation is that a no will abort the whole process of creating data while when only using `interactive=True` and not adding the current confirmation step, the database would not be flushed and the data generated anyway which might not be desirable. This way the user is "forced" to be explicit with the command arguments she/he is providing.