### PR TITLE
Give database user CREATEDB privileges

### DIFF
--- a/provisioning/pythondotorg.yml
+++ b/provisioning/pythondotorg.yml
@@ -79,6 +79,7 @@
       postgresql_user: db={{ database.name }}
                        name={{ database.user }}
                        priv=ALL
+                       role_attr_flags=CREATEDB
                        state=present
       notify: Restart PostgreSQL
 


### PR DESCRIPTION
This makes it possible to run the tests

Before:

    (venv) vagrant@vagrant:~/pythondotorg$ ./manage.py test
    Creating test database for alias 'default'...
    Got an error creating the test database: permission denied to create database

After:

    (venv) vagrant@vagrant:~/pythondotorg$ ./manage.py test
    Creating test database for alias 'default'...
    System check identified no issues (0 silenced).
    [...]
    ----------------------------------------------------------------------
    Ran 246 tests in 59.560s

    OK
    Destroying test database for alias 'default'...