### PR TITLE
Add TestCase as base to DownloadModelTests

### DIFF
--- a/downloads/tests/base.py
+++ b/downloads/tests/base.py
@@ -25,7 +25,7 @@ class DownloadMixin:
         cls.linux, _ = OS.objects.get_or_create(name='Linux')
 
 
-class BaseDownloadTests(DownloadMixin):
+class BaseDownloadTests(DownloadMixin, TestCase):
 
     def setUp(self):
         self.release_275_page = Page.objects.create(

--- a/downloads/tests/test_views.py
+++ b/downloads/tests/test_views.py
@@ -28,7 +28,7 @@ TEST_THROTTLE_RATES = {
 }
 
 
-class DownloadViewsTests(BaseDownloadTests, TestCase):
+class DownloadViewsTests(BaseDownloadTests):
     def test_download_full_os_list(self):
         url = reverse('download:download_full_os_list')
         response = self.client.get(url)
@@ -432,7 +432,7 @@ class BaseDownloadApiViewsTest(BaseAPITestCase):
         self.assertEqual(len(content), 1)
 
 
-class DownloadApiV1ViewsTest(BaseDownloadApiViewsTest, BaseDownloadTests, TestCase):
+class DownloadApiV1ViewsTest(BaseDownloadApiViewsTest, BaseDownloadTests):
     api_version = 'v1'
 
 


### PR DESCRIPTION
The DownloadModelTests weren't actually running because they didn't inherit from TestCase

Before: `Ran 246 tests` 
After: `Ran 257 tests`