### PR TITLE
Shell slightly under-sized

### DIFF
--- a/templates/python/shell.html
+++ b/templates/python/shell.html
@@ -5,7 +5,7 @@
 {% block header_content %}
         <div class="slideshow">
 
-            <iframe style="border: none; width: 100%; height: 280px" name="embedded_python_anywhere" src="https://console.python.org/python-dot-org-console/"></iframe>
+            <iframe style="border: none; width: 100%; height: 300px" name="embedded_python_anywhere" src="https://console.python.org/python-dot-org-console/"></iframe>
 
         </div>
 


### PR DESCRIPTION
The shell is slightly under-sized, meaning that the shell is missing the last 1-2 lines

https://www.python.org/shell/

![image](https://user-images.githubusercontent.com/10530980/44473243-2984a500-a630-11e8-9e9d-77e3f1dc5f12.png)


A few more pixels and we're ok

![image](https://user-images.githubusercontent.com/10530980/44473163-01954180-a630-11e8-97ed-83007f8d9ae0.png)
