### PR TITLE
Make sure create_initial_data is executed in the same order each time

### DIFF
--- a/cms/management/commands/create_initial_data.py
+++ b/cms/management/commands/create_initial_data.py
@@ -1,3 +1,4 @@
+import collections
 import importlib
 import inspect
 import pprint
@@ -24,7 +25,7 @@ class Command(BaseCommand):
         )
 
     def collect_initial_data_functions(self, app_label):
-        functions = {}
+        functions = collections.OrderedDict()
         if app_label:
             try:
                 app_list = [apps.get_app_config(app_label)]


### PR DESCRIPTION
This could prevent random success/failure caused by the order of the function dict (I'm unsure if there are fixtures that depend on other fixtures to run before them).

This change is not necessary for Python < 3.7 (technically 3.6) as dicts will keep their insertion order.