### PR TITLE
Use timezone.now as default for updated field

### DIFF
--- a/blogs/migrations/0001_initial.py
+++ b/blogs/migrations/0001_initial.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('creator', models.ForeignKey(null=True, to=settings.AUTH_USER_MODEL, related_name='blogs_contributor_creator', blank=True, on_delete=models.CASCADE)),
                 ('last_modified_by', models.ForeignKey(null=True, to=settings.AUTH_USER_MODEL, related_name='blogs_contributor_modified', blank=True, on_delete=models.CASCADE)),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, related_name='blog_contributor', on_delete=models.CASCADE)),
@@ -77,7 +77,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('name', models.CharField(help_text='Internal Name', max_length=100)),
                 ('feed_url', models.URLField(verbose_name='Feed URL')),
                 ('blog_url', models.URLField(verbose_name='Blog URL')),
@@ -98,7 +98,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('name', models.CharField(max_length=100)),
                 ('url', models.URLField(verbose_name='URL')),
                 ('creator', models.ForeignKey(null=True, to=settings.AUTH_USER_MODEL, related_name='blogs_translation_creator', blank=True, on_delete=models.CASCADE)),

--- a/boxes/migrations/0001_initial.py
+++ b/boxes/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('label', models.SlugField(max_length=100, unique=True)),
                 ('content', markupfield.fields.MarkupField(rendered_field=True)),
                 ('content_markup_type', models.CharField(max_length=30, choices=[('', '--'), ('html', 'html'), ('plain', 'plain'), ('markdown', 'markdown'), ('restructuredtext', 'restructuredtext')], default='restructuredtext')),

--- a/cms/models.py
+++ b/cms/models.py
@@ -18,7 +18,7 @@ from django.utils import timezone
 
 class ContentManageable(models.Model):
     created = models.DateTimeField(default=timezone.now, blank=True, db_index=True)
-    updated = models.DateTimeField(blank=True)
+    updated = models.DateTimeField(default=timezone.now, blank=True)
 
     # We allow creator to be null=True so that we can, if we must, create a
     # ContentManageable object in a context where we don't have a creator (i.e.

--- a/codesamples/migrations/0001_initial.py
+++ b/codesamples/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('code', markupfield.fields.MarkupField(rendered_field=True, blank=True)),
                 ('code_markup_type', models.CharField(max_length=30, choices=[('', '--'), ('html', 'html'), ('plain', 'plain'), ('markdown', 'markdown'), ('restructuredtext', 'restructuredtext')], default='html', blank=True)),
                 ('copy', markupfield.fields.MarkupField(rendered_field=True, blank=True)),

--- a/community/migrations/0001_initial.py
+++ b/community/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('url', models.URLField(max_length=1000, verbose_name='URL', blank=True)),
                 ('creator', models.ForeignKey(null=True, to=settings.AUTH_USER_MODEL, related_name='community_link_creator', blank=True, on_delete=models.CASCADE)),
                 ('last_modified_by', models.ForeignKey(null=True, to=settings.AUTH_USER_MODEL, related_name='community_link_modified', blank=True, on_delete=models.CASCADE)),
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('image', models.ImageField(upload_to='community/photos/', blank=True)),
                 ('image_url', models.URLField(max_length=1000, verbose_name='Image URL', blank=True)),
                 ('caption', models.TextField(blank=True)),
@@ -59,7 +59,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('title', models.CharField(max_length=200, blank=True, null=True)),
                 ('content', markupfield.fields.MarkupField(rendered_field=True)),
                 ('abstract', models.TextField(null=True, blank=True)),
@@ -85,7 +85,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('video_embed', models.TextField(blank=True)),
                 ('video_data', models.FileField(upload_to='community/videos/', blank=True)),
                 ('caption', models.TextField(blank=True)),

--- a/community/migrations/0001_squashed_0004_auto_20170831_0541.py
+++ b/community/migrations/0001_squashed_0004_auto_20170831_0541.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(blank=True, db_index=True, default=django.utils.timezone.now)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('url', models.URLField(blank=True, max_length=1000, verbose_name='URL')),
                 ('creator', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='community_link_creator', to=settings.AUTH_USER_MODEL)),
                 ('last_modified_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='community_link_modified', to=settings.AUTH_USER_MODEL)),
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(blank=True, db_index=True, default=django.utils.timezone.now)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('image', models.ImageField(blank=True, upload_to='community/photos/')),
                 ('image_url', models.URLField(blank=True, max_length=1000, verbose_name='Image URL')),
                 ('caption', models.TextField(blank=True)),
@@ -63,7 +63,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(blank=True, db_index=True, default=django.utils.timezone.now)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('title', models.CharField(blank=True, max_length=200, null=True)),
                 ('content', markupfield.fields.MarkupField(rendered_field=True)),
                 ('abstract', models.TextField(blank=True, null=True)),
@@ -88,7 +88,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(blank=True, db_index=True, default=django.utils.timezone.now)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('video_embed', models.TextField(blank=True)),
                 ('video_data', models.FileField(blank=True, upload_to='community/videos/')),
                 ('caption', models.TextField(blank=True)),

--- a/downloads/migrations/0001_initial.py
+++ b/downloads/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('name', models.CharField(max_length=200)),
                 ('slug', models.SlugField(unique=True)),
                 ('creator', models.ForeignKey(null=True, to=settings.AUTH_USER_MODEL, related_name='downloads_os_creator', blank=True, on_delete=models.CASCADE)),
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('name', models.CharField(max_length=200)),
                 ('slug', models.SlugField(unique=True)),
                 ('version', models.IntegerField(choices=[(3, 'Python 3.x.x'), (2, 'Python 2.x.x'), (1, 'Python 1.x.x')], default=2)),
@@ -68,7 +68,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('name', models.CharField(max_length=200)),
                 ('slug', models.SlugField(unique=True)),
                 ('description', models.TextField(blank=True)),

--- a/events/migrations/0001_initial.py
+++ b/events/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('trigger', models.PositiveSmallIntegerField(verbose_name='hours before the event occurs', default=24)),
                 ('creator', models.ForeignKey(null=True, to=settings.AUTH_USER_MODEL, related_name='events_alarm_creator', blank=True, on_delete=models.CASCADE)),
             ],
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('url', models.URLField(verbose_name='URL iCal', blank=True, null=True)),
                 ('rss', models.URLField(verbose_name='RSS Feed', blank=True, null=True)),
                 ('embed', models.URLField(verbose_name='URL embed', blank=True, null=True)),
@@ -55,7 +55,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('uid', models.CharField(max_length=200, blank=True, null=True)),
                 ('title', models.CharField(max_length=200)),
                 ('description', markupfield.fields.MarkupField(rendered_field=True)),

--- a/jobs/migrations/0001_initial.py
+++ b/jobs/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('company_name', models.CharField(max_length=100, blank=True, null=True)),
                 ('company_description', markupfield.fields.MarkupField(rendered_field=True, blank=True)),
                 ('job_title', models.CharField(max_length=100)),

--- a/jobs/migrations/0011_jobreviewcomment.py
+++ b/jobs/migrations/0011_jobreviewcomment.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(serialize=False, verbose_name='ID', primary_key=True, auto_created=True)),
                 ('created', models.DateTimeField(blank=True, default=django.utils.timezone.now, db_index=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('comment', markupfield.fields.MarkupField(rendered_field=True)),
                 ('comment_markup_type', models.CharField(choices=[('', '--'), ('html', 'HTML'), ('plain', 'Plain'), ('markdown', 'Markdown'), ('restructuredtext', 'Restructured Text')], max_length=30, default='restructuredtext')),
                 ('_comment_rendered', models.TextField(editable=False)),

--- a/minutes/migrations/0001_initial.py
+++ b/minutes/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('date', models.DateField(db_index=True, verbose_name='Meeting Date')),
                 ('content', markupfield.fields.MarkupField(rendered_field=True)),
                 ('content_markup_type', models.CharField(max_length=30, choices=[('', '--'), ('html', 'html'), ('plain', 'plain'), ('markdown', 'markdown'), ('restructuredtext', 'restructuredtext')], default='restructuredtext')),

--- a/pages/migrations/0001_initial.py
+++ b/pages/migrations/0001_initial.py
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('title', models.CharField(max_length=500)),
                 ('keywords', models.CharField(help_text='HTTP meta-keywords', max_length=1000, blank=True)),
                 ('description', models.TextField(help_text='HTTP meta-description', blank=True)),

--- a/sponsors/migrations/0001_initial.py
+++ b/sponsors/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('content', markupfield.fields.MarkupField(rendered_field=True, blank=True)),
                 ('content_markup_type', models.CharField(max_length=30, choices=[('', '--'), ('html', 'html'), ('plain', 'plain'), ('markdown', 'markdown'), ('restructuredtext', 'restructuredtext')], default='restructuredtext', blank=True)),
                 ('is_published', models.BooleanField(db_index=True, default=False)),

--- a/successstories/migrations/0001_initial.py
+++ b/successstories/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(db_index=True, default=django.utils.timezone.now, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('name', models.CharField(max_length=200)),
                 ('slug', models.SlugField(unique=True)),
                 ('company_name', models.CharField(max_length=500)),

--- a/users/migrations/0001_initial.py
+++ b/users/migrations/0001_initial.py
@@ -58,7 +58,7 @@ class Migration(migrations.Migration):
                 ('psf_code_of_conduct', models.NullBooleanField(verbose_name='I agree to the PSF Code of Conduct')),
                 ('psf_announcements', models.NullBooleanField(verbose_name='I would like to receive occasional PSF email announcements')),
                 ('created', models.DateTimeField(blank=True, default=django.utils.timezone.now)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('creator', models.ForeignKey(null=True, to=settings.AUTH_USER_MODEL, blank=True, related_name='membership', on_delete=models.CASCADE)),
             ],
             options={

--- a/users/models.py
+++ b/users/models.py
@@ -88,7 +88,7 @@ class Membership(models.Model):
     last_vote_affirmation = models.DateTimeField(blank=True, null=True)
 
     created = models.DateTimeField(default=timezone.now, blank=True)
-    updated = models.DateTimeField(blank=True)
+    updated = models.DateTimeField(default=timezone.now, blank=True)
 
     creator = models.OneToOneField(
         User,

--- a/work_groups/migrations/0001_initial.py
+++ b/work_groups/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(default=django.utils.timezone.now, db_index=True, blank=True)),
-                ('updated', models.DateTimeField(blank=True)),
+                ('updated', models.DateTimeField(default=django.utils.timezone.now, blank=True)),
                 ('name', models.CharField(max_length=200)),
                 ('slug', models.SlugField(unique=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),


### PR DESCRIPTION
This makes it possible to `bulk_create` `ContentManageable` and `Membership` objects.

Since `bulk_create` skips `save` it is not possible to `bulk_create` objects that inherit from `ContentManageable` because the `updated` field doesn't get a value. By adding a default it becomes possible to `bulk_create`. The functionality remains the same, `updated` will always be set to the current time.