### PR TITLE
Use Box.objects.get_or_create

### DIFF
--- a/blogs/parser.py
+++ b/blogs/parser.py
@@ -40,6 +40,10 @@ def update_blog_supernav():
     latest_entry = BlogEntry.objects.filter(feed_id=1).latest()
     rendered_box = _render_blog_supernav(latest_entry)
 
-    box = Box.objects.get(label='supernav-python-blog')
-    box.content = rendered_box
-    box.save()
+    box, _ = Box.objects.update_or_create(
+        label='supernav-python-blog',
+        defaults={
+            'content': rendered_box,
+            'content_markup_type': 'html',
+        }
+    )

--- a/blogs/tests/test_templatetags.py
+++ b/blogs/tests/test_templatetags.py
@@ -15,9 +15,6 @@ class BlogTemplateTagTest(TestCase):
 
     def setUp(self):
         self.test_file_path = get_test_rss_path()
-        box = Box.objects.create(label='supernav-python-blog')
-        box.content.markup_type = 'html'
-        box.save()
 
     def test_get_latest_entries(self):
         """

--- a/blogs/tests/test_views.py
+++ b/blogs/tests/test_views.py
@@ -2,8 +2,6 @@ from django.core.management import call_command
 from django.urls import reverse
 from django.test import TestCase
 
-from boxes.models import Box
-
 from ..models import BlogEntry, Feed
 
 from .utils import get_test_rss_path
@@ -13,9 +11,6 @@ class BlogViewTest(TestCase):
 
     def setUp(self):
         self.test_file_path = get_test_rss_path()
-        box = Box.objects.create(label='supernav-python-blog')
-        box.content.markup_type = 'html'
-        box.save()
 
     def test_blog_home(self):
         """

--- a/downloads/models.py
+++ b/downloads/models.py
@@ -158,9 +158,13 @@ def update_supernav():
         'python_files': python_files,
     })
 
-    box = Box.objects.get(label='supernav-python-downloads')
-    box.content = content
-    box.save()
+    box, _ = Box.objects.update_or_create(
+        label='supernav-python-downloads',
+        defaults={
+            'content': content,
+            'content_markup_type': 'html',
+        }
+    )
 
     # Update latest Sources box on Download landing page
     if latest_python2:
@@ -173,13 +177,17 @@ def update_supernav():
     else:
         latest_python3_source = None
 
-    source_box = Box.objects.get(label='download-sources')
     source_content = render_to_string('downloads/download-sources-box.html', {
         'latest_python2_source': latest_python2_source,
         'latest_python3_source': latest_python3_source,
     })
-    source_box.content = source_content
-    source_box.save()
+    source_box, _ = Box.objects.update_or_create(
+        label='download-sources',
+        defaults={
+            'content': source_content,
+            'content_markup_type': 'html',
+        }
+    )
 
 
 def update_homepage_download_box():
@@ -198,9 +206,13 @@ def update_homepage_download_box():
         'latest_python3': latest_python3,
     })
 
-    box = Box.objects.get(label='homepage-downloads')
-    box.content = content
-    box.save()
+    box, _ = Box.objects.update_or_create(
+        label='homepage-downloads',
+        defaults={
+            'content': content,
+            'content_markup_type': 'html',
+        }
+    )
 
 
 @receiver(post_save, sender=Release)

--- a/downloads/tests/base.py
+++ b/downloads/tests/base.py
@@ -4,7 +4,6 @@ from django.test import TestCase
 from django.utils import timezone
 
 from pages.models import Page
-from boxes.models import Box
 from ..models import OS, Release, ReleaseFile
 
 
@@ -13,13 +12,6 @@ class DownloadMixin:
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.download_supernav_box, _ = Box.objects.get_or_create(label='supernav-python-downloads')
-        cls.download_supernav_box.content.markup_type = 'html'
-        cls.download_supernav_box.save()
-        cls.download_homepage_box, _ = Box.objects.get_or_create(label='homepage-downloads')
-        cls.download_homepage_box.content.markup_type = 'html'
-        cls.download_homepage_box.save()
-        cls.download_sources_box, _ = Box.objects.get_or_create(label='download-sources')
         cls.windows, _ = OS.objects.get_or_create(name='Windows')
         cls.osx, _ = OS.objects.get_or_create(name='Mac OSX')
         cls.linux, _ = OS.objects.get_or_create(name='Linux')

--- a/successstories/models.py
+++ b/successstories/models.py
@@ -100,9 +100,13 @@ def update_successstories_supernav(sender, instance, created, **kwargs):
             'story': instance,
         })
 
-        box, _ = Box.objects.get_or_create(label='supernav-python-success-stories')
-        box.content = content
-        box.save()
+        box, _ = Box.objects.update_or_create(
+            label='supernav-python-success-stories',
+            defaults={
+                'content': content,
+                'content_markup_type': 'html',
+            }
+        )
 
         # Purge Fastly cache
         purge_url('/box/supernav-python-success-stories/')


### PR DESCRIPTION
This makes it possible to create a release without installing the Box fixtures.

This should be perfectly safe as the box content is set immediately after getting/creating the box.