### PR TITLE
Added documentation for create_initial_data command options. Fixes #1281

### DIFF
--- a/cms/management/commands/commands.rst
+++ b/cms/management/commands/commands.rst
@@ -1,0 +1,30 @@
+Create Initial Data
+===================
+
+create_initial_data
+-------------------
+
+This command creates initial data for the app using factories. You can run it like::
+
+    $ ./manage.py create_initial_data
+
+If you want to remove all existing data in the database before creating new one, specify :option:`--flush` option::
+
+    $ ./manage.py create_initial_data --flush
+
+If you want to specify any label to create any app specific data, specify :option:`--app-label` option::
+
+    $ ./manage.py create_initial_data --app-label jobs
+
+Command-line options
+^^^^^^^^^^^^^^^^^^^^
+
+.. program:: manage.py create_initial_data
+
+.. option:: --flush
+
+	Removes existing data in the database before creating new data.
+
+.. option:: --app-label <app label>
+
+	Creates Initial Data with the *<app label>* provided.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ Contents:
    contributing
    administration
    pep_generation
+   commands
 
 Indices and tables
 ==================

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -121,6 +121,8 @@ To create initial data for the most used applications, run::
 
     $ ./manage.py create_initial_data
 
+See :doc: `../../cms/management/commands/commands` for the command options to specify while creating initial data.
+
 Finally, start the development server::
 
     $ ./manage.py runserver


### PR DESCRIPTION
Fixes #1281 

- [x]  Create `commands.rst`
- [x]  Add `commands.rst` to `toctree` in `index.rst`
- [x]  Add documentation for command options under `commands.rst`
- [x]  Add link to the `create_initial_data` documentation under `install.rst`