### PR TITLE
Upgrade vagrant box to run on python 3.6

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,6 @@ Vagrant.require_version ">= 1.7.0"
 
 Vagrant.configure(2) do |config|
   # TODO: https://askubuntu.com/a/854396
-  # config.vm.box = "ubuntu/bionic64"
   config.vm.box = "bento/ubuntu-18.04"
   config.vm.boot_timeout = 1200
   config.vm.network "forwarded_port", guest: 8000, host: 8001

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,8 @@ Vagrant.require_version ">= 1.7.0"
 
 Vagrant.configure(2) do |config|
   # TODO: https://askubuntu.com/a/854396
-  config.vm.box = "bento/ubuntu-16.04"
+  # config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "bento/ubuntu-18.04"
   config.vm.boot_timeout = 1200
   config.vm.network "forwarded_port", guest: 8000, host: 8001
   config.vm.synced_folder ".", "/home/vagrant/pythondotorg"

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -18,7 +18,7 @@ You should then be able to provision the Vagrant box.
 
     $ vagrant up
 
-The box will be provisioned with Python 3.5, a virtual environment with all
+The box will be provisioned with Python 3.6.5, a virtual environment with all
 the requirements installed, and a database ready to use.
 
 Once this is done it's time to create some data and run the server::

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -18,8 +18,8 @@ You should then be able to provision the Vagrant box.
 
     $ vagrant up
 
-The box will be provisioned with Python 3.6.5, a virtual environment with all
-the requirements installed, and a database ready to use.
+The box will be provisioned with a latest Python 3.6 version, a virtual
+environment with all the requirements installed, and a database ready to use.
 
 Once this is done it's time to create some data and run the server::
 

--- a/provisioning/pythondotorg.yml
+++ b/provisioning/pythondotorg.yml
@@ -6,11 +6,6 @@
   vars_files:
     - env_vars.yml
   tasks:
-    # TODO: Remove this when we have a better 16.04 LTS box.
-    - name: Make /etc/apt/sources.list useful
-      become: yes
-      shell: "sed -i -- 's/#deb-src/deb-src/g' /etc/apt/sources.list && sudo sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list"
-
     - name: Run apt-get update
       become: yes
       apt: update_cache=yes
@@ -36,13 +31,6 @@
       changed_when:
         "result.stdout is defined and '0 upgraded, 0 newly installed, 0 to remove and' not in result.stdout"
 
-    - name: Install python-lxml deps
-      become: yes
-      apt: pkg=python-lxml state=build-dep
-      register: result
-      changed_when:
-        "'0 upgraded, 0 newly installed, 0 to remove and' not in result.stdout"
-
     - name: Install base Ruby packages
       become: yes
       gem: name=bundler user_install=no
@@ -51,8 +39,8 @@
       apt: name={{ item }} state=installed
       become: yes
       with_items:
-        - postgresql #-9.5
-        - postgresql-contrib #-9.5
+        - postgresql
+        - postgresql-contrib
         - libpq-dev
         - python-psycopg2
 

--- a/provisioning/pythondotorg.yml
+++ b/provisioning/pythondotorg.yml
@@ -16,8 +16,6 @@
       with_items:
         - build-essential
         - libpq-dev
-        - libxml2-dev
-        - libxslt-dev
         - lib32z1-dev
         - git
         - python3
@@ -26,7 +24,6 @@
         - python3-pip
         - python3-venv
         - ruby
-        # - acl
       register: result
       changed_when:
         "result.stdout is defined and '0 upgraded, 0 newly installed, 0 to remove and' not in result.stdout"

--- a/provisioning/pythondotorg.yml
+++ b/provisioning/pythondotorg.yml
@@ -51,8 +51,8 @@
       apt: name={{ item }} state=installed
       become: yes
       with_items:
-        - postgresql-9.5
-        - postgresql-contrib-9.5
+        - postgresql #-9.5
+        - postgresql-contrib #-9.5
         - libpq-dev
         - python-psycopg2
 


### PR DESCRIPTION
Changed vagrant box to bento/ubuntu-18.04 which gives Python 3.6.5.

Fixes #1333