### PR TITLE
Reuse convenient model properties in job feed

### DIFF
--- a/jobs/feeds.py
+++ b/jobs/feeds.py
@@ -14,16 +14,12 @@ class JobFeed(Feed):
         return Job.objects.approved()[:20]
 
     def item_title(self, item):
-        return "{} - {}".format(item.job_title, item.company_name)
+        return item.display_name
 
     def item_description(self, item):
         """ Description """
-        location_parts = (item.city, item.region, item.country)
-        location = ",".join(location_part for location_part in location_parts
-            if location_part is not None)
-        return "{}\n{}\n{}".format(
-            location,
+        return '\n'.join([
+            item.display_location,
             item.description,
             item.requirements,
-        )
-
+        ])


### PR DESCRIPTION
Both `display_name` and `display_location` were more or less duplicated. 

These changes result is slightly different output: 

`display_name` joins `job_title` and `company_name` with a comma instead of a dash.

`display_location` joins the location parts with a ', ' instead of just a ',' and has a less strict check on the each location part (just `if location_part`).