### PR TITLE
Update Freenode's "register your nickname" link on Community page

### DIFF
--- a/fixtures/boxes.json
+++ b/fixtures/boxes.json
@@ -128,7 +128,7 @@
 {
     "fields": {
         "label": "community-irc-channels",
-        "content": "<h2 class=\"widget-title\"><span aria-hidden=\"true\" class=\"icon-freenode\"></span>Internet Relay Chat</h2>\r\n<p><a href=\"http://freenode.net/\">Freenode IRC</a> hosts several channels. <a href=\"http://www.irchelp.org/\">Select an IRC client</a>, <a href=\"http://freenode.net/faq.shtml#registering\">register your nickname with Freenode</a>, and you can be off and running!</p>\r\n    <h4>Freenode IRC General Channels</h4>\r\n    <ul class=\"menu\">\r\n        <li><strong>#python</strong> for general questions</li>\r\n        <li><strong>#python-dev</strong> for CPython developers</li>\r\n        <li><strong>#distutils</strong> for Python packaging discussion</li>\r\n    </ul>",
+        "content": "<h2 class=\"widget-title\"><span aria-hidden=\"true\" class=\"icon-freenode\"></span>Internet Relay Chat</h2>\r\n<p><a href=\"http://freenode.net/\">Freenode IRC</a> hosts several channels. <a href=\"http://www.irchelp.org/\">Select an IRC client</a>, <a href=\"https://freenode.net/kb/answer/registration\">register your nickname with Freenode</a>, and you can be off and running!</p>\r\n    <h4>Freenode IRC General Channels</h4>\r\n    <ul class=\"menu\">\r\n        <li><strong>#python</strong> for general questions</li>\r\n        <li><strong>#python-dev</strong> for CPython developers</li>\r\n        <li><strong>#distutils</strong> for Python packaging discussion</li>\r\n    </ul>",
         "content_markup_type": "html"
     }
 },


### PR DESCRIPTION
Current link returns HTTP 404. It changed to `https://freenode.net/kb/answer/registration` from `http://freenode.net/faq.shtml#registering`.

I'm not sure if fixture change is enough to fix it in production (maybe just database change is needed?).

[Community page.](https://www.python.org/community/)

![obraz](https://user-images.githubusercontent.com/9288014/52141694-d0955000-2656-11e9-8b5f-d82dd332abe9.png)
