### PR TITLE
Add ansible_python_interpreter on "Install dependencies for the Djangoapp inside virutal environment"

### DIFF
--- a/provisioning/pythondotorg.yml
+++ b/provisioning/pythondotorg.yml
@@ -76,6 +76,8 @@
            update=no
 
     - name: Install dependencies for the Django app inside virtual environment
+      vars:
+        ansible_python_interpreter: "/usr/bin/python3"
       pip: virtualenv={{ project.virtualenv }}
            virtualenv_command="/usr/bin/python3 -m venv"
            requirements={{ project.requirements }}


### PR DESCRIPTION
Add ansible_python_interpreter : "/usr/bin/python3"  to avoid
"setuptools is not installed" error message if python2 is installed.