### PR TITLE
Fix can't generate pep pages with local pep repo on local

### DIFF
--- a/docs/source/pep_generation.rst
+++ b/docs/source/pep_generation.rst
@@ -18,6 +18,7 @@ The PEP Page Generation process is as follows:
 2. From the cloned PEP Repository, run::
 
       $ make -j
+      $ make rss
 
 3. Set ``PEP_REPO_PATH`` in ``pydotorg/settings/local.py`` to the location
    of the cloned PEP Repository

--- a/peps/management/commands/generate_pep_pages.py
+++ b/peps/management/commands/generate_pep_pages.py
@@ -51,26 +51,7 @@ class Command(BaseCommand):
         verbose("== Starting PEP page generation")
 
         with ExitStack() as stack:
-            verbose(f"== Fetching PEP artifact from {settings.PEP_ARTIFACT_URL}")
-            peps_last_updated = get_peps_last_updated()
-            with requests.get(settings.PEP_ARTIFACT_URL, stream=True) as r:
-                artifact_last_modified = parsedate(r.headers['last-modified'])
-                if peps_last_updated > artifact_last_modified:
-                    verbose(f"== No update to artifacts, we're done here!")
-                    return
-
-                temp_file = stack.enter_context(TemporaryFile())
-                for chunk in r.iter_content(chunk_size=8192):
-                    if chunk:
-                        temp_file.write(chunk)
-
-            temp_file.seek(0)
-
-            temp_dir = stack.enter_context(TemporaryDirectory())
-            tar_ball = stack.enter_context(TarFile.open(fileobj=temp_file, mode='r:gz'))
-            tar_ball.extractall(path=temp_dir, numeric_owner=False)
-
-            artifacts_path = os.path.join(temp_dir, 'peps')
+            artifacts_path = self.get_artifacts_path(stack, verbose)
 
             verbose("Generating RSS Feed")
             peps_rss = get_peps_rss(artifacts_path)
@@ -129,3 +110,30 @@ class Command(BaseCommand):
                     verbose("- Skipping non-PEP related image '{}'".format(img))
 
         verbose("== Finished")
+
+    def get_artifacts_path(self, stack, verbose):
+        if settings.DEBUG and settings.PEP_REPO_PATH:
+            return settings.PEP_REPO_PATH
+
+        verbose(f"== Fetching PEP artifact from {settings.PEP_ARTIFACT_URL}")
+        peps_last_updated = get_peps_last_updated()
+        with requests.get(settings.PEP_ARTIFACT_URL, stream=True) as r:
+            artifact_last_modified = parsedate(r.headers['last-modified'])
+            if peps_last_updated > artifact_last_modified:
+                verbose(f"== No update to artifacts, we're done here!")
+                return
+
+            temp_file = stack.enter_context(TemporaryFile())
+            for chunk in r.iter_content(chunk_size=8192):
+                if chunk:
+                    temp_file.write(chunk)
+
+        temp_file.seek(0)
+
+        temp_dir = stack.enter_context(TemporaryDirectory())
+        tar_ball = stack.enter_context(
+            TarFile.open(fileobj=temp_file, mode='r:gz'))
+        tar_ball.extractall(path=temp_dir, numeric_owner=False)
+        artifacts_path = os.path.join(temp_dir, 'peps')
+
+        return artifacts_path

--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -227,7 +227,9 @@ PYTHON_BLOG_URL = "http://blog.python.org"
 ### Registration mailing lists
 MAILING_LIST_PSF_MEMBERS = "psf-members-announce-request@python.org"
 
-### PEP Repo Location
+### PEP Repo Location on local
+PEP_REPO_PATH = ''
+### PEP Repo Location on remote
 PEP_ARTIFACT_URL = 'https://pythondotorg-assets-staging.s3.amazonaws.com/fake-peps.tar.gz'
 
 ### Fastly ###

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -24,6 +24,9 @@ HAYSTACK_CONNECTIONS = {
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+# Set the path to where the PEP repo's HTML source files are located
+# For example, PEP_REPO_PATH = '/Users/frank/work/src/pythondotorg/tmp/peps'
+PEP_REPO_PATH = ''
 # Set the URL to where to fetch PEP artifacts from
 PEP_ARTIFACT_URL = 'https://pythondotorg-assets-staging.s3.amazonaws.com/fake-peps.tar.gz'
 


### PR DESCRIPTION
That issue is the result of https://github.com/python/pythondotorg/pull/1389 .