### PR TITLE
Always create a new venv when provisioning

### DIFF
--- a/provisioning/pythondotorg.yml
+++ b/provisioning/pythondotorg.yml
@@ -75,6 +75,11 @@
            clone=no
            update=no
 
+    - name: Ensure fresh virtual environment
+      file:
+        path: "{{ project.virtualenv }}"
+        state: absent
+
     - name: Install dependencies for the Django app inside virtual environment
       pip: virtualenv={{ project.virtualenv }}
            virtualenv_command="/usr/bin/python3 -m venv"


### PR DESCRIPTION
I still had an old vagrant box and venv laying around, but master now only works with Python 3.6.

Running `vagrant destroy && vagrant up` resulted in a strange error during provisioning. This was cause by the old `venv` that remained.

With this PR any `venv` in the root of the project is removed when setting up vagrant box for the first time or when running `vagrant up --provision`