### PR TITLE
Fixed 1 issue of type: PYTHON_E231 throughout 1 file in repo.

### DIFF
--- a/blogs/tests/test_templatetags.py
+++ b/blogs/tests/test_templatetags.py
@@ -68,7 +68,7 @@ class BlogTemplateTagTest(TestCase):
             slug='test',
             description='testing',
         )
-        fa.feeds.add(f1,f2)
+        fa.feeds.add(f1, f2)
 
 
         t = Template("""


### PR DESCRIPTION
PYTHON_E231: 'missing whitespace after ‘,’, ‘;’, or ‘:’'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.