### PR TITLE
Fixed 1 issue of type: PYTHON_E251 throughout 1 file in repo.

### DIFF
--- a/boxes/migrations/0003_auto_20171101_2138.py
+++ b/boxes/migrations/0003_auto_20171101_2138.py
@@ -7,8 +7,7 @@ from django.db import migrations
 
 def migrate_old_content(apps, schema_editor):
     Box = apps.get_model('boxes', 'Box')
-    Box.objects.filter(label='events-subscriptions').update(content=
-        '<h2 class=\"widget-title\">Python Events Calendars</h2>\r\n\r\n<br/>\r\n\r\n'
+    Box.objects.filter(label='events-subscriptions').update(content=        '<h2 class=\"widget-title\">Python Events Calendars</h2>\r\n\r\n<br/>\r\n\r\n'
         '<p>For Python events near you, please have a look at the <a href=\"http://lmorillas.github.io/python_events/\">'
         '<b>Python events map</b></a>.</p>\r\n\r\n'
         '<p>The Python events calendars are maintained by the <a href=\"https://wiki.python.org/moin/PythonEventsCalendar#Python_Calendar_Team\">events calendar team</a>.</p>\r\n\r\n'


### PR DESCRIPTION
PYTHON_E251: 'unexpected spaces around keyword / parameter equals'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.