### PR TITLE
Fixed 1 issue of type: PYTHON_W293 throughout 1 file in repo.

### DIFF
--- a/blogs/admin.py
+++ b/blogs/admin.py
@@ -38,7 +38,7 @@ class BlogEntryAdmin(admin.ModelAdmin):
         self.message_user(request, "Blog entries updated.")
 
     sync_new_entries.short_description = "Sync new blog entries"
-    
+
 
 admin.site.register(BlogEntry, BlogEntryAdmin)
 


### PR DESCRIPTION
PYTHON_W293: 'Remove trailing whitespace on blank line.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.