### PR TITLE
Remove PageAdminImageFileWidget

### DIFF
--- a/pages/admin.py
+++ b/pages/admin.py
@@ -1,37 +1,17 @@
-from django.conf import settings
 from django.contrib import admin
-from django.db import models
-from django.utils.safestring import mark_safe
-
-from bs4 import BeautifulSoup
 
 from cms.admin import ContentManageableModelAdmin
 from .models import Page, Image, DocumentFile
-
-
-class PageAdminImageFileWidget(admin.widgets.AdminFileWidget):
-
-    def render(self, name, value, attrs=None):
-        content = super().render(name, value, attrs=None)
-        return content
 
 
 class ImageInlineAdmin(admin.StackedInline):
     model = Image
     extra = 1
 
-    formfield_overrides = {
-        models.ImageField: {'widget': PageAdminImageFileWidget},
-    }
-
 
 class DocumentFileInlineAdmin(admin.StackedInline):
     model = DocumentFile
     extra = 1
-
-    formfield_overrides = {
-        models.FileField: {'widget': PageAdminImageFileWidget},
-    }
 
 
 class PagePathFilter(admin.SimpleListFilter):


### PR DESCRIPTION
Remove unused importers left over after PR #1389. 

Seems that after that PR `PageAdminImageFileWidget` doesn't really do anything anymore. It's just a call to super with `attrs` hardcoded to `None`, and that might even be unintentional.