### PR TITLE
Support use local file path as value of PEP_ARTIFACT_URL

### DIFF
--- a/peps/management/commands/generate_pep_pages.py
+++ b/peps/management/commands/generate_pep_pages.py
@@ -119,8 +119,7 @@ class Command(BaseCommand):
 
     def get_artifact_tarball(self, stack, verbose):
         artifact_url = settings.PEP_ARTIFACT_URL
-        if not (artifact_url.startswith('http://') or
-                artifact_url.startswith('https://')):
+        if not artifact_url.startswith(('http://', 'https://')):
             return stack.enter_context(open(artifact_url, 'rb'))
 
         peps_last_updated = get_peps_last_updated()

--- a/peps/management/commands/generate_pep_pages.py
+++ b/peps/management/commands/generate_pep_pages.py
@@ -117,7 +117,7 @@ class Command(BaseCommand):
 
         verbose("== Finished")
 
-    def get_artifact_tar_ball(self, stack, verbose):
+    def get_artifact_tarball(self, stack, verbose):
         artifact_url = settings.PEP_ARTIFACT_URL
         if not (artifact_url.startswith('http://') or
                 artifact_url.startswith('https://')):

--- a/peps/management/commands/generate_pep_pages.py
+++ b/peps/management/commands/generate_pep_pages.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
 
         with ExitStack() as stack:
             verbose(f"== Fetching PEP artifact from {settings.PEP_ARTIFACT_URL}")
-            temp_file = self.get_artifact_tar_ball(stack, verbose)
+            temp_file = self.get_artifact_tarball(stack, verbose)
             temp_dir = stack.enter_context(TemporaryDirectory())
             tar_ball = stack.enter_context(TarFile.open(fileobj=temp_file, mode='r:gz'))
             tar_ball.extractall(path=temp_dir, numeric_owner=False)

--- a/peps/tests/test_commands.py
+++ b/peps/tests/test_commands.py
@@ -32,7 +32,11 @@ class PEPManagementCommandTests(TestCase):
         )
 
     @responses.activate
-    def test_generate_pep_pages_real(self):
+    def test_generate_pep_pages_real_with_remote_artifact(self):
+        call_command('generate_pep_pages')
+
+    @override_settings(PEP_ARTIFACT_URL=FAKE_PEP_ARTIFACT)
+    def test_generate_pep_pages_real_with_local_artifact(self):
         call_command('generate_pep_pages')
 
     @responses.activate

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -25,7 +25,7 @@ HAYSTACK_CONNECTIONS = {
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # Set the path to where to fetch PEP artifacts from.
-# The value can be local path or remote URL
+# The value can be a local path or a remote URL.
 PEP_ARTIFACT_URL = os.path.join(BASE, 'peps/tests/peps.tar.gz')
 
 # Use Dummy SASS compiler to avoid performance issues and remove the need to

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -25,7 +25,7 @@ HAYSTACK_CONNECTIONS = {
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # Set the URL to where to fetch PEP artifacts from
-PEP_ARTIFACT_URL = 'https://pythondotorg-assets-staging.s3.amazonaws.com/fake-peps.tar.gz'
+PEP_ARTIFACT_URL = os.path.join(BASE, 'peps/tests/peps.tar.gz')
 
 # Use Dummy SASS compiler to avoid performance issues and remove the need to
 # have a sass compiler installed at all during local development if you aren't

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -24,7 +24,8 @@ HAYSTACK_CONNECTIONS = {
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-# Set the URL to where to fetch PEP artifacts from
+# Set the path to where to fetch PEP artifacts from.
+# The value can be local path or remote URL
 PEP_ARTIFACT_URL = os.path.join(BASE, 'peps/tests/peps.tar.gz')
 
 # Use Dummy SASS compiler to avoid performance issues and remove the need to


### PR DESCRIPTION
> I think we can set settings.PEP_ARTIFACT_URL to os.path.join(settings.BASE, 'peps/tests/peps.tar.gz') in settings/local.py. This way contributors wouldn't need to clone python/peps repo if they would like to work on our PEP converter code. 
> ---- @berkerpeksag  https://github.com/python/pythondotorg/pull/1412#discussion_r273556541

@berkerpeksag What do you think about this PR? Is it necessary?