### PR TITLE
Bump Vagrantfile above 2.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # vi: set ft=ruby :
 
-Vagrant.require_version ">= 1.7.0"
+Vagrant.require_version ">= 2.1.2"
 
 Vagrant.configure(2) do |config|
   # TODO: https://askubuntu.com/a/854396


### PR DESCRIPTION
Per #1441 the Vagrantfile should be bumped to 2.0+. 2.1.2 was released in the last year so I think it's a suitable minimum version.