### PR TITLE
Fix scroll to top and toggle menu

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -185,17 +185,17 @@ $().ready(function() {
 
     /* ! Not currently working in IE10/Windows 8, Chrome for Android, Firefox (all versions)... something about the animate() function */
     $("#close-python-network").click(function() {
-        $('body, html').animate({ scrollTop: $('#python-network').offset().top }, 300);
+        $('#sitetree_menu_trunk').toggle();
         return false;
     });
 
     $("#python-network").click(function() {
-        $('body, html').animate({ scrollTop: $('#top').offset().top }, 300);
+        $('html, body').animate({ scrollTop: 0 }, 500);
         return false;
     });
 
     $("#back-to-top-1, #back-to-top-2").click(function() {
-        $("body").animate({ scrollTop: $('#python-network').offset().top }, 500);
+        $('html, body').animate({ scrollTop: 0 }, 500);
         return false;
     });
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -165,7 +165,7 @@
                     <span aria-hidden="true" class="icon-arrow-down"><span>&#9660;</span></span> Close / Open
                 </a>
 
-                <div id="sitetree_menu_trunk">
+                <div id="sitetree_menu_trunk" style="display:none;">
                     {% sitetree_menu from "main" include "trunk" template "sitetree/top.html" %}                    
                 </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -162,10 +162,12 @@
 
                 {# Fallback for browsers that do not display generated content... HTML entity will be the icon instead #}
                 <a id="close-python-network" class="jump-link" href="#python-network" aria-hidden="true">
-                    <span aria-hidden="true" class="icon-arrow-down"><span>&#9660;</span></span> Close
+                    <span aria-hidden="true" class="icon-arrow-down"><span>&#9660;</span></span> Close / Open
                 </a>
 
-                {% sitetree_menu from "main" include "trunk" template "sitetree/top.html" %}
+                <div id="sitetree_menu_trunk">
+                    {% sitetree_menu from "main" include "trunk" template "sitetree/top.html" %}                    
+                </div>
 
                 <a id="python-network" class="jump-link" href="#top" aria-hidden="true">
                     <span aria-hidden="true" class="icon-arrow-up"><span>&#9650;</span></span> The Python Network


### PR DESCRIPTION
Fixes issue #1278: "Back to top not working properly"

Fixes two scroll to top buttons on smaller screen sizes that now scroll to the top of the screen.

Additionally, this fixes a menu close button at the top that now closes the menu.