### PR TITLE
Fix-1472: Add multiversion of python to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+dist: xenial
 language: python
-python: 3.6
+python:
+  - "3.6"
+  - "3.7"
 cache: pip
 addons:
   postgresql: "9.4"


### PR DESCRIPTION
Add distribution xenial and add python3.7

Send a proposal for #1472 