### PR TITLE
bpo-37613: Fix "Back to top" on Chrome for Android

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -183,7 +183,7 @@ $().ready(function() {
     }
     /* Animate some scrolling for smoother transitions */
 
-    /* ! Not currently working in IE10/Windows 8, Chrome for Android, Firefox (all versions)... something about the animate() function */
+    /* ! Not currently working in IE10/Windows 8, Firefox (all versions)... something about the animate() function */
     $("#close-python-network").click(function() {
         $('body, html').animate({ scrollTop: $('#python-network').offset().top }, 300);
         return false;
@@ -195,7 +195,7 @@ $().ready(function() {
     });
 
     $("#back-to-top-1, #back-to-top-2").click(function() {
-        $("body").animate({ scrollTop: $('#python-network').offset().top }, 500);
+        $('body, html').animate({ scrollTop: $('#python-network').offset().top }, 500);
         return false;
     });
 


### PR DESCRIPTION
Update the selector on which to call the `animate` function to fix "Back to top" links on Chrome for Android.

Example session using the remote debugger:

![back-to-top](https://user-images.githubusercontent.com/153842/61420377-1d50a880-a8d0-11e9-8fd3-b70a2723dcc5.gif)
