### PR TITLE
Invalidate nominations pages in CDN

### DIFF
--- a/nominations/models.py
+++ b/nominations/models.py
@@ -1,8 +1,12 @@
 import datetime
 
 from django.db import models
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.urls import reverse
 from django.utils.text import slugify
 
+from fastly.utils import purge_url
 from markupfield.fields import MarkupField
 
 from users.models import User
@@ -82,6 +86,12 @@ class Nominee(models.Model):
     approved = models.BooleanField(null=False, default=False)
 
     slug = models.SlugField(max_length=255, blank=True, null=True)
+
+    def get_absolute_url(self):
+        return reverse(
+            "nominations:nominee_detail",
+            kwargs={"election": self.election.slug, "slug": self.slug},
+        )
 
     @property
     def name(self):
@@ -180,6 +190,18 @@ class Nomination(models.Model):
 
     accepted = models.BooleanField(null=False, default=False)
     approved = models.BooleanField(null=False, default=False)
+
+    def get_absolute_url(self):
+        return reverse(
+            "nominations:nomination_detail",
+            kwargs={"election": self.election.slug, "pk": self.pk},
+        )
+
+    def get_edit_url(self):
+        return reverse(
+            "nominations:nomination_edit",
+            kwargs={"election": self.election.slug, "pk": self.pk},
+        )
 
     def editable(self, user=None):
         if (

--- a/nominations/models.py
+++ b/nominations/models.py
@@ -231,3 +231,26 @@ class Nomination(models.Model):
             return True
 
         return False
+
+
+@receiver(post_save, sender=Nomination)
+def purge_nomination_pages(sender, instance, created, **kwargs):
+    """ Purge pages that contain the rendered markup """
+    # Skip in fixtures
+    if kwargs.get("raw", False):
+        return
+
+    # Purge the nomination page itself
+    purge_url(instance.get_absolute_url())
+
+    if instance.nominee:
+        # Purge the nominee page
+        purge_url(instance.nominee.get_absolute_url())
+
+    if instance.election:
+        # Purge the election page
+        purge_url(
+            reverse(
+                "nominations:nominees_list", kwargs={"election": instance.election.slug}
+            )
+        )

--- a/nominations/urls.py
+++ b/nominations/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url
-from django.views.generic import TemplateView
 
 from . import views
 

--- a/templates/nominations/nomination_detail.html
+++ b/templates/nominations/nomination_detail.html
@@ -18,7 +18,7 @@ Nomination for {{ nomination.name }}
   <center>
     <i>You are the nominee for this nomination.</i>
   {% if editable %}
-    <a href="{% url 'nominations:nomination_edit' election=nomination.election.slug pk=nomination.id %}">Edit</a>
+    <a href="{{ nomination.get_edit_url }}">Edit</a>
   {% else %}
     <i>It is no longer editable as nominations are closed.</i>
   {% endif %}
@@ -27,7 +27,7 @@ Nomination for {{ nomination.name }}
   <center>
     <i>You made this nomination.</i>
   {% if editable %}
-    <a href="{% url 'nominations:nomination_edit' election=nomination.election.slug pk=nomination.id %}">Edit</a>
+    <a href="{{ nomination.get_edit_url }}">Edit</a>
   {% else %}
     {% if nomination.election.nominations_open %}
     <i>It is no longer editable as it has been accepted.</i>

--- a/templates/nominations/nominee_list.html
+++ b/templates/nominations/nominee_list.html
@@ -330,7 +330,7 @@ details div p
   <p>Nominations close at {{ election.nominations_close_at }}, this is a preview of only nominations relevant to you.</p>
   {% endif %}
   {% for nominee in object_list|shuffle %}
-  <h2><a href="{% url 'nominations:nominee_detail' election=election.slug slug=nominee.slug %}">{{ nominee.display_name }}</a></h2>
+  <h2><a href="{{ nominee.get_absolute_url }}">{{ nominee.display_name }}</a></h2>
   <details id="{{ nominee.slug }}">
     <summary>
       Nomination details

--- a/templates/users/nominations_view.html
+++ b/templates/users/nominations_view.html
@@ -28,7 +28,7 @@
     {% else %}
     Nomination from {{ nomination.nominator.first_name }} {{ nomination.nominator.last_name }}
     {% endif %}
-    <a href="{% url 'nominations:nomination_detail' election=election.slug pk=nomination.id %}">
+    <a href="{{ nomination.get_absolute_url }}">
       {% if nomination.is_editable %}
       View/Edit
       {% else %}
@@ -50,7 +50,7 @@
     {% else %}
     {{ nomination.name }}
     {% endif %}
-    <a href="{% url 'nominations:nomination_detail' election=election.slug pk=nomination.id %}">
+    <a href="{{ nomination.get_absolute_url }}">
       {% if nomination.is_editable %}
       View/Edit
       {% else %}


### PR DESCRIPTION
This also makes use of get_absolute_url for easier URL construction similar to other apps in the project.

Fixes #1444.