### PR TITLE
add configurable global Surrogate-Key header

### DIFF
--- a/pydotorg/middleware.py
+++ b/pydotorg/middleware.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+
+
 class AdminNoCaching:
     """
     Middleware to ensure the admin is not cached by Fastly or other caches
@@ -8,6 +11,25 @@ class AdminNoCaching:
 
     def __call__(self, request):
         response = self.get_response(request)
-        if request.path.startswith('/admin'):
-            response['Cache-Control'] = 'private'
+        if request.path.startswith("/admin"):
+            response["Cache-Control"] = "private"
+        return response
+
+
+class GlobalSurrogateKey:
+    """
+    Middleware to insert a Surrogate-Key for purging in Fastly or other caches
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if hasattr(settings, "GLOBAL_SURROGATE_KEY"):
+            response["Surrogate-Key"] = " ".join(
+                filter(
+                    None, [settings.GLOBAL_SURROGATE_KEY, response.get("Surrogate-Key")]
+                )
+            )
         return response

--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -118,6 +118,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'pydotorg.middleware.AdminNoCaching',
+    'pydotorg.middleware.GlobalSurrogateKey',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'waffle.middleware.WaffleMiddleware',
@@ -281,3 +282,7 @@ REST_FRAMEWORK = {
         'user': '1000/day',
     },
 }
+
+### pydotorg.middleware.GlobalSurrogateKey
+
+GLOBAL_SURROGATE_KEY = 'pydotorg-app'


### PR DESCRIPTION
This will allow us to safely purge Django pages from the CDN without causing
expensive large files like binary and tarball artifacts from being purged as
well.