### PR TITLE
Add dev.to link to footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -302,6 +302,7 @@
                         <li class="tier-1 element-1"><a href="/about/help/">Help &amp; <span class="say-no-more">General</span> Contact</a></li>
                         <li class="tier-1 element-2"><a href="/community/diversity/">Diversity <span class="say-no-more">Initiatives</span></a></li>
                         <li class="tier-1 element-3"><a href="https://github.com/python/pythondotorg/issues">Submit Website Bug</a></li>
+                        <li class="tier-1 element-3"><a href="https://dev.to/t/python">DEV Community</a></li>
                         <li class="tier-1 element-4">
                             <a href="https://status.python.org/">Status <span class="python-status-indicator-default" id="python-status-indicator"></span></a>
                         </li>


### PR DESCRIPTION
[DEV Community](https://dev.to/) is a burgeoning source of guidance and discussion on software topics, especially web dev. This will be a useful link to point to the official place to discuss Python related stuff on DEV.

A few additional links pertaining to dev.to

Traffic stats: https://www.similarweb.com/website/dev.to
Twitter: https://twitter.com/thepracticaldev
Python tag (as included in PR): https://dev.to/t/python
Websites Including DEV : [React](https://reactjs.org/), [React Native](https://facebook.github.io/react-native/)

Some example Python posts:
https://dev.to/seattledataguy/the-interview-study-guide-for-software-engineers-764
https://dev.to/codemouse92/introducing-dead-simple-python-563o