### PR TITLE
Removing Python 2.x references from supernav and /doc/

### DIFF
--- a/fixtures/boxes.json
+++ b/fixtures/boxes.json
@@ -45,7 +45,7 @@
 {
     "fields": {
         "label": "supernav-python-documentation",
-        "content": "                            <li class=\"tier-2 super-navigation\">\r\n                                <h4>Python&rsquo;s standard documentation: download, browse or watch a tutorial.</h4>\r\n                                <p>Get started below, or visit the <a href=\"/doc/versions/\">Documentation page to browse by version</a>. </p>\r\n                                <p class=\"download-buttons\">\r\n                                    <a class=\"button\" href=\"http://docs.python.org/3/\">Python 3.x Docs</a> \r\n                                    <a class=\"button\" href=\"http://docs.python.org/2/\">Python 2.x Docs</a>\r\n                                </p>\r\n                                <p>See also <a href=\"https://wiki.python.org/moin/Python2orPython3\">Should I use Python 2 or 3</a>? </p>\r\n                            </li>",
+        "content": "                            <li class=\"tier-2 super-navigation\">\r\n                                <h4>Python&rsquo;s standard documentation: download, browse or watch a tutorial.</h4>\r\n                                <p>Get started below, or visit the <a href=\"/doc/versions/\">Documentation page to browse by version</a>. </p>\r\n                                <p class=\"download-buttons\">\r\n                                    <a class=\"button\" href=\"http://docs.python.org/3/\">Python 3.x Docs</a> \r\n</p>                            </li>",
         "content_markup_type": "html"
     }
 },
@@ -178,14 +178,14 @@
 {
     "fields": {
         "label": "documentation-beginners",
-        "content": "<h2 class=\"widget-title\"><span aria-hidden=\"true\" class=\"icon-beginner\"></span>Beginner</h2>\r\n<ul> \r\n    <li><a href=\"https://wiki.python.org/moin/BeginnersGuide\">Beginner&rsquo;s Guide</a></li>\r\n    <li><a href=\"https://wiki.python.org/moin/Python2orPython3\">Python 2&nbsp;or&nbsp;3?</a></li>\r\n    <li><a href=\"//docs.python.org/faq/\">Python FAQs</a></li>\r\n</ul>",
+        "content": "<h2 class=\"widget-title\"><span aria-hidden=\"true\" class=\"icon-beginner\"></span>Beginner</h2>\r\n<ul> \r\n    <li><a href=\"https://wiki.python.org/moin/BeginnersGuide\">Beginner&rsquo;s Guide</a></li>\r\n    <li><a href=\"//docs.python.org/faq/\">Python FAQs</a></li>\r\n</ul>",
         "content_markup_type": "html"
     }
 },
 {
     "fields": {
         "label": "documentation-banner",
-        "content": "<h1 class=\"call-to-action\">Browse the docs online or download a copy of your own. Python's documentation, tutorials, and guides are constantly evolving.</h1>\r\n<p>Get started here, or scroll down for documentation broken out by type and subject.</p>\r\n<p class=\"download-buttons\">\r\n    <a class=\"button\" href=\"http://docs.python.org/3/\">Python 3.x Docs</a> \r\n    <a class=\"button\" href=\"http://docs.python.org/2/\">Python 2.x Docs</a>\r\n</p>\r\n<p>See also <a href=\"/doc/versions/\">Documentation Releases by Version</a> and <a href=\"https://wiki.python.org/moin/Python2orPython3\">Should I use Python 2 or 3</a>? </p>",
+        "content": "<h1 class=\"call-to-action\">Browse the docs online or download a copy of your own. Python's documentation, tutorials, and guides are constantly evolving.</h1>\r\n<p>Get started here, or scroll down for documentation broken out by type and subject.</p>\r\n<p class=\"download-buttons\">\r\n    <a class=\"button\" href=\"http://docs.python.org/3/\">Python 3.x Docs</a> \r\n</p>\r\n<p>See also <a href=\"/doc/versions/\">Documentation Releases by Version</a>\r\n</p>",
         "content_markup_type": "html"
     }
 },


### PR DESCRIPTION
Fixes #1255  

This PR is similar to #1219 - in pursuit of further de-emphasizing Python 2.x presence in light of imminent EOL: 
* Removes Python 2 button from the Docs supernav
* Removes Python 2.x Docs button from /doc/
* Removes 'Python 2 or 3?' from Beginner's section

**Not done, needs CMS access I believe:**
* Replace ‘Python 2.x Resources’ widget with, potentially, ‘Porting from Python 2 to Python 3’ with links to:
- [FAQ: Sunsetting Python 2](https://www.python.org/doc/sunset-python-2/)
- [Final Python 2.7 Release Schedule](https://www.python.org/dev/peps/pep-0373/)
- [Python 3 Statement](https://python3statement.org)
- [Porting Python 2 Code to Python 3](https://docs.python.org/3/howto/pyporting.html)
-- [Determine what projects are blocking you from porting to Python 3](https://pypi.org/project/caniusepython3/)
-- [Python 2 Support and Migration](https://wiki.python.org/moin/PythonConsulting/Python%202%20support%20and%20migration)
