### PR TITLE
upgrade django-allauth to mitigate cve-2019-19844 vuln

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -29,7 +29,7 @@ requests[security]>=2.20.0
 django-honeypot==0.6.0
 django-markupfield==1.4.3
 
-django-allauth==0.36.0
+django-allauth==0.41.0
 
 django-waffle==0.14
 


### PR DESCRIPTION
since we're using django-allauth for password resets, this covers us. need to get to an up to date version of Django sooner than later!