### PR TITLE
Allow modifying pep images with same name

### DIFF
--- a/peps/converters.py
+++ b/peps/converters.py
@@ -2,6 +2,7 @@ import functools
 import datetime
 import re
 import os
+import filecmp
 
 from bs4 import BeautifulSoup
 
@@ -221,8 +222,15 @@ def add_pep_image(artifact_path, pep_number, path):
             FOUND = True
             break
 
-    if not FOUND:
-        image = Image(page=page)
+    # Add image if it does not exist or the new image differs from the existing
+    if not FOUND or not filecmp.cmp(image_path, image.image.path):
+        # If it does not exist we need a new image object ...
+        if not FOUND:
+            image = Image(page=page)
+        # ... otherwise we re-use the existing object from the loop above but
+        # first remove the image file (django does not override)
+        else:
+            os.remove(image.image.path)
 
         with open(image_path, 'rb') as image_obj:
             image.image.save(path, File(image_obj))


### PR DESCRIPTION
Fixes #824

Currently, `peps.converters.add_pep_image` does not allow to add an image that already exists in the database for the same name. As a consequence images cannot be updated.

This PR modifies `peps.converters.add_pep_image` to also update the image db record if the corresponding file has changed as per `filecmp.cmp'` This requires removing the file prior to the db update, because the django `FileField` does not override existing files.

Alternatives to the ad hoc removal of the file in `add_pep_image` include passing a custom `OverwriteStorage` to the used `ImageField`, see e.g.:

https://code.djangoproject.com/ticket/4339
https://stackoverflow.com/questions/9522759/imagefield-overwrite-image-file-with-same-name
