### PR TITLE
Add Active Python Releases to Downloads Page

### DIFF
--- a/static/sass/_layout.scss
+++ b/static/sass/_layout.scss
@@ -447,6 +447,23 @@
     .release-download { width: 25%; }
     .release-enhancements { width: 25%; }
 
+    .release-version,
+    .release-status,
+    .release-start,
+    .release-end,
+    .release-pep {
+        -moz-box-orient: vertical;
+        display: inline-block;
+        margin-right: -4px;
+        vertical-align: middle;
+    }
+
+    .release-version { width: 15%; }
+    .release-status { width: 20%; }
+    .release-start { width: 25%; }
+    .release-end { width: 25%; }
+    .release-pep { width: 15%; }
+
     /* Previous Next pattern */
     .previous-next {
         @include clearfix();

--- a/static/sass/mq.css
+++ b/static/sass/mq.css
@@ -2,12 +2,15 @@
 /* Define constants for the application and to configure the blueprint framework. */
 /* ===== Compass Imports ===== */
 /* DO NOT include Blueprint here. We are using Susy for the grid, and if Blueprint is here, it will mess things up */
+/* @import "compass/css3/columns" */
+/* @import "compass/css3/hyphenation"; */
 /* Needed for the link-colors() function */
 /* Needed for the horizontal-list() function */
 /* When remembering whether or not there's a hyphen in white-space is too hard */
 /* Use pie-clearfix when there is no width set ont the element to avoid edge cases */
 /* Use to calculate color legibility: http://compass-style.org/reference/compass/utilities/color/contrast/ */
 /* Other interesting functions: 
+	@import "compass/utilities/color/contrast";
 		detailed here: http://compass-style.org/reference/compass/utilities/color/contrast/
 		Used to pass two colors into a get out the most readable color. 
 		Good for situations where we dont want to create a new color, 
@@ -174,7 +177,7 @@
 .slides,
 .flex-control-nav,
 .flex-direction-nav {margin: 0; padding: 0; list-style: none;} */
-                                                                               /* FlexSlider Necessary Styles 
+/* FlexSlider Necessary Styles 
 .flexslider {margin: 0; padding: 0;}
 .flexslider .slides > li {display: none; -webkit-backface-visibility: hidden;} /* Hide the slides before the JS is loaded. Avoids image jumping 
 .flexslider .slides img {width: 100%; display: block;}
@@ -222,12 +225,15 @@ html[xmlns] .slides { display: block; }
 /* Define constants for the application and to configure the blueprint framework. */
 /* ===== Compass Imports ===== */
 /* DO NOT include Blueprint here. We are using Susy for the grid, and if Blueprint is here, it will mess things up */
+/* @import "compass/css3/columns" */
+/* @import "compass/css3/hyphenation"; */
 /* Needed for the link-colors() function */
 /* Needed for the horizontal-list() function */
 /* When remembering whether or not there's a hyphen in white-space is too hard */
 /* Use pie-clearfix when there is no width set ont the element to avoid edge cases */
 /* Use to calculate color legibility: http://compass-style.org/reference/compass/utilities/color/contrast/ */
 /* Other interesting functions: 
+	@import "compass/utilities/color/contrast";
 		detailed here: http://compass-style.org/reference/compass/utilities/color/contrast/
 		Used to pass two colors into a get out the most readable color. 
 		Good for situations where we dont want to create a new color, 
@@ -522,7 +528,7 @@ html[xmlns] .slides { display: block; }
       /* We do this more explictly (the descendant selector) to avoid also styling links in the Supernav content */ }
       .main-navigation .tier-1 > a, .main-navigation .tier-2 > a {
         display: block;
-        padding: 0.5em 1.5em 0.4em 1em;
+        padding: .5em 1.5em .4em 1em;
         position: relative; }
     .main-navigation .tier-1 {
       display: block;
@@ -548,20 +554,20 @@ html[xmlns] .slides { display: block; }
       .no-touch .main-navigation .subnav {
         min-width: 100%;
         display: none;
-        -webkit-transition: all 0s ease;
         -moz-transition: all 0s ease;
         -o-transition: all 0s ease;
+        -webkit-transition: all 0s ease;
         transition: all 0s ease; }
       .touch .main-navigation .subnav {
         top: 120%;
         display: none;
         opacity: 0;
-        -webkit-transition: opacity 0.25s ease-in-out;
         -moz-transition: opacity 0.25s ease-in-out;
         -o-transition: opacity 0.25s ease-in-out;
+        -webkit-transition: opacity 0.25s ease-in-out;
         transition: opacity 0.25s ease-in-out;
-        -webkit-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
         -moz-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
+        -webkit-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
         box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6); }
         .touch .main-navigation .subnav:before {
           position: absolute;
@@ -576,16 +582,16 @@ html[xmlns] .slides { display: block; }
     .no-touch .main-navigation .element-1:hover .subnav, .no-touch .main-navigation .element-1:focus .subnav, .no-touch .main-navigation .element-2:hover .subnav, .no-touch .main-navigation .element-2:focus .subnav, .no-touch .main-navigation .element-3:hover .subnav, .no-touch .main-navigation .element-3:focus .subnav, .no-touch .main-navigation .element-4:hover .subnav, .no-touch .main-navigation .element-4:focus .subnav {
       left: 0;
       display: initial;
-      -webkit-transition-delay: 0.25s;
       -moz-transition-delay: 0.25s;
       -o-transition-delay: 0.25s;
+      -webkit-transition-delay: 0.25s;
       transition-delay: 0.25s; }
     .no-touch .main-navigation .element-5:hover .subnav, .no-touch .main-navigation .element-5:focus .subnav, .no-touch .main-navigation .element-6:hover .subnav, .no-touch .main-navigation .element-6:focus .subnav, .no-touch .main-navigation .element-7:hover .subnav, .no-touch .main-navigation .element-7:focus .subnav, .no-touch .main-navigation .element-8:hover .subnav, .no-touch .main-navigation .element-8:focus .subnav, .no-touch .main-navigation .last:hover .subnav, .no-touch .main-navigation .last:focus .subnav {
       right: 0;
       display: initial;
-      -webkit-transition-delay: 0.25s;
       -moz-transition-delay: 0.25s;
       -o-transition-delay: 0.25s;
+      -webkit-transition-delay: 0.25s;
       transition-delay: 0.25s; }
     .touch .main-navigation .element-1, .touch .main-navigation .element-2, .touch .main-navigation .element-3, .touch .main-navigation .element-4 {
       /* Position the pointer element */ }
@@ -614,13 +620,11 @@ html[xmlns] .slides { display: block; }
     display: block;
     clear: both;
     text-align: center;
-    -webkit-border-radius: 8px 8px 0 0;
     -moz-border-radius: 8px 8px 0 0;
-    -ms-border-radius: 8px 8px 0 0;
-    -o-border-radius: 8px 8px 0 0;
+    -webkit-border-radius: 8px;
     border-radius: 8px 8px 0 0;
-    -webkit-box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
     -moz-box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    -webkit-box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.2); }
     .no-touch .main-navigation .tier-1 {
       float: left;
@@ -653,8 +657,8 @@ html[xmlns] .slides { display: block; }
       .no-touch .main-navigation .tier-2 > a {
         border-right: 1px solid rgba(255, 255, 255, 0.8); }
     .no-touch .main-navigation .subnav {
-      -webkit-box-shadow: 0 0.5em 0.5em rgba(0, 0, 0, 0.3);
       -moz-box-shadow: 0 0.5em 0.5em rgba(0, 0, 0, 0.3);
+      -webkit-box-shadow: 0 0.5em 0.5em rgba(0, 0, 0, 0.3);
       box-shadow: 0 0.5em 0.5em rgba(0, 0, 0, 0.3); }
 
   /* Shorten the amount of blue space under the nav on inner pages */
@@ -705,7 +709,7 @@ html[xmlns] .slides { display: block; }
     /* Reset some styles from the drop down menus */ }
     .touch .main-navigation a {
       text-align: center;
-      padding: 0.65em 1.25em 0.55em; }
+      padding: .65em 1.25em .55em; }
     .touch .main-navigation .tier-2 {
       font-size: 0.875em; }
     .touch .main-navigation .subnav {
@@ -713,27 +717,25 @@ html[xmlns] .slides { display: block; }
       display: block;
       opacity: 1;
       border-top: 0;
-      -webkit-box-shadow: none;
       -moz-box-shadow: none;
+      -webkit-box-shadow: none;
       box-shadow: none; }
 
   /* TO DO: With Javascript, look for a left-right swipe action and also trigger the menu to open */
   .touch #touchnav-wrapper {
-    -webkit-transition: -webkit-transform 300ms ease;
     -moz-transition: -moz-transform 300ms ease;
     -o-transition: -o-transform 300ms ease;
+    -webkit-transition: -webkit-transform 300ms ease;
     transition: transform 300ms ease;
-    -webkit-transform: translate3d(0, 0, 0);
     -moz-transform: translate3d(0, 0, 0);
     -ms-transform: translate3d(0, 0, 0);
-    -o-transform: translate3d(0, 0, 0);
+    -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0);
     -webkit-backface-visibility: hidden; }
   .touch .show-sidemenu #touchnav-wrapper {
-    -webkit-transform: translate3d(260px, 0, 0);
     -moz-transform: translate3d(260px, 0, 0);
     -ms-transform: translate3d(260px, 0, 0);
-    -o-transform: translate3d(260px, 0, 0);
+    -webkit-transform: translate3d(260px, 0, 0);
     transform: translate3d(260px, 0, 0); }
 
   /* Simple Column Structure */
@@ -782,9 +784,9 @@ html[xmlns] .slides { display: block; }
       border-color: transparent; }
 
   .search-field {
-    -webkit-transition: width 0.3s ease-in-out;
     -moz-transition: width 0.3s ease-in-out;
     -o-transition: width 0.3s ease-in-out;
+    -webkit-transition: width 0.3s ease-in-out;
     transition: width 0.3s ease-in-out; }
 
   .search-field:focus {
@@ -839,10 +841,11 @@ html[xmlns] .slides { display: block; }
     background-color: #2d618c;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF3776AB', endColorstr='#FF2D618C');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiMzNzc2YWIiLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iIzJkNjE4YyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #3776ab), color-stop(95%, #2d618c));
-    background-image: -webkit-linear-gradient(#3776ab 30%, #2d618c 95%);
     background-image: -moz-linear-gradient(#3776ab 30%, #2d618c 95%);
-    background-image: -o-linear-gradient(#3776ab 30%, #2d618c 95%);
+    background-image: -webkit-linear-gradient(#3776ab 30%, #2d618c 95%);
     background-image: linear-gradient(#3776ab 30%, #2d618c 95%);
     border-top: 1px solid #629ccd;
     border-bottom: 1px solid #18334b;
@@ -859,14 +862,15 @@ html[xmlns] .slides { display: block; }
         border-bottom: 1px solid transparent;
         letter-spacing: 0.01em; }
         .python-navigation .tier-1 > a:hover, .python-navigation .tier-1 > a:focus, .python-navigation .tier-1 > a .tier-1:hover > a {
-          color: white;
+          color: #fff;
           background-color: #2d618c;
           *zoom: 1;
           filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF326B9C', endColorstr='#FF2D618C');
+          background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMzMjZiOWMiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzJkNjE4YyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+          background-size: 100%;
           background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #326b9c), color-stop(90%, #2d618c));
-          background-image: -webkit-linear-gradient(#326b9c 10%, #2d618c 90%);
           background-image: -moz-linear-gradient(#326b9c 10%, #2d618c 90%);
-          background-image: -o-linear-gradient(#326b9c 10%, #2d618c 90%);
+          background-image: -webkit-linear-gradient(#326b9c 10%, #2d618c 90%);
           background-image: linear-gradient(#326b9c 10%, #2d618c 90%);
           border-top: 1px solid #3776ab;
           border-bottom: 1px solid #2d618c; }
@@ -875,13 +879,14 @@ html[xmlns] .slides { display: block; }
       background-color: #d6e5f2;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFBBD4E9', endColorstr='#FFD6E5F2');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNiYmQ0ZTkiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2Q2ZTVmMiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #bbd4e9), color-stop(90%, #d6e5f2));
-      background-image: -webkit-linear-gradient(#bbd4e9 10%, #d6e5f2 90%);
       background-image: -moz-linear-gradient(#bbd4e9 10%, #d6e5f2 90%);
-      background-image: -o-linear-gradient(#bbd4e9 10%, #d6e5f2 90%);
+      background-image: -webkit-linear-gradient(#bbd4e9 10%, #d6e5f2 90%);
       background-image: linear-gradient(#bbd4e9 10%, #d6e5f2 90%);
-      -webkit-box-shadow: inset 0 0 20px rgba(55, 118, 171, 0.15);
       -moz-box-shadow: inset 0 0 20px rgba(55, 118, 171, 0.15);
+      -webkit-box-shadow: inset 0 0 20px rgba(55, 118, 171, 0.15);
       box-shadow: inset 0 0 20px rgba(55, 118, 171, 0.15);
       /*modernizr*/ }
       .touch .python-navigation .subnav:before {
@@ -896,25 +901,27 @@ html[xmlns] .slides { display: block; }
     .python-navigation .tier-2:last-child > a {
       border-bottom: 1px solid rgba(55, 118, 171, 0.25); }
     .python-navigation .current_item {
-      color: white;
+      color: #fff;
       background-color: #244e71;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF2B5B84', endColorstr='#FF244E71');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMyYjViODQiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzI0NGU3MSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #2b5b84), color-stop(90%, #244e71));
-      background-image: -webkit-linear-gradient(#2b5b84 10%, #244e71 90%);
       background-image: -moz-linear-gradient(#2b5b84 10%, #244e71 90%);
-      background-image: -o-linear-gradient(#2b5b84 10%, #244e71 90%);
+      background-image: -webkit-linear-gradient(#2b5b84 10%, #244e71 90%);
       background-image: linear-gradient(#2b5b84 10%, #244e71 90%); }
     .python-navigation .super-navigation {
-      color: #666666;
+      color: #666;
       border: 1px solid #89b4d9;
       background-color: #d6e5f2;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFCFDFE', endColorstr='#FFD6E5F2');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmY2ZkZmUiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2Q2ZTVmMiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #fcfdfe), color-stop(90%, #d6e5f2));
-      background-image: -webkit-linear-gradient(#fcfdfe 10%, #d6e5f2 90%);
       background-image: -moz-linear-gradient(#fcfdfe 10%, #d6e5f2 90%);
-      background-image: -o-linear-gradient(#fcfdfe 10%, #d6e5f2 90%);
+      background-image: -webkit-linear-gradient(#fcfdfe 10%, #d6e5f2 90%);
       background-image: linear-gradient(#fcfdfe 10%, #d6e5f2 90%); }
       .python-navigation .super-navigation a:not(.button) {
         color: #3776ab; }
@@ -925,17 +932,18 @@ html[xmlns] .slides { display: block; }
     background-color: #646565;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF78797A', endColorstr='#FF646565');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiM3ODc5N2EiLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iIzY0NjU2NSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #78797a), color-stop(95%, #646565));
-    background-image: -webkit-linear-gradient(#78797a 30%, #646565 95%);
     background-image: -moz-linear-gradient(#78797a 30%, #646565 95%);
-    background-image: -o-linear-gradient(#78797a 30%, #646565 95%);
+    background-image: -webkit-linear-gradient(#78797a 30%, #646565 95%);
     background-image: linear-gradient(#78797a 30%, #646565 95%);
     border-top: 1px solid #9e9fa0;
     border-bottom: 1px solid #39393a;
     /*a*/ }
     .psf-navigation .tier-1 {
       border-top: 1px solid #929393;
-      border-right: 1px solid #5f5f60;
+      border-right: 1px solid #5f6060;
       border-bottom: 1px solid #454647;
       border-left: 1px solid #929393; }
       .psf-navigation .tier-1 > a {
@@ -945,14 +953,15 @@ html[xmlns] .slides { display: block; }
         border-bottom: 1px solid transparent;
         letter-spacing: 0.01em; }
         .psf-navigation .tier-1 > a:hover, .psf-navigation .tier-1 > a:focus, .psf-navigation .tier-1 > a .tier-1:hover > a {
-          color: white;
+          color: #fff;
           background-color: #646565;
           *zoom: 1;
           filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF6E6F70', endColorstr='#FF646565');
+          background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM2ZTZmNzAiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzY0NjU2NSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+          background-size: 100%;
           background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #6e6f70), color-stop(90%, #646565));
-          background-image: -webkit-linear-gradient(#6e6f70 10%, #646565 90%);
           background-image: -moz-linear-gradient(#6e6f70 10%, #646565 90%);
-          background-image: -o-linear-gradient(#6e6f70 10%, #646565 90%);
+          background-image: -webkit-linear-gradient(#6e6f70 10%, #646565 90%);
           background-image: linear-gradient(#6e6f70 10%, #646565 90%);
           border-top: 1px solid #78797a;
           border-bottom: 1px solid #646565; }
@@ -961,13 +970,14 @@ html[xmlns] .slides { display: block; }
       background-color: #ececec;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFDADADA', endColorstr='#FFECECEC');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNkYWRhZGEiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2VjZWNlYyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #dadada), color-stop(90%, #ececec));
-      background-image: -webkit-linear-gradient(#dadada 10%, #ececec 90%);
       background-image: -moz-linear-gradient(#dadada 10%, #ececec 90%);
-      background-image: -o-linear-gradient(#dadada 10%, #ececec 90%);
+      background-image: -webkit-linear-gradient(#dadada 10%, #ececec 90%);
       background-image: linear-gradient(#dadada 10%, #ececec 90%);
-      -webkit-box-shadow: inset 0 0 20px rgba(120, 121, 122, 0.15);
       -moz-box-shadow: inset 0 0 20px rgba(120, 121, 122, 0.15);
+      -webkit-box-shadow: inset 0 0 20px rgba(120, 121, 122, 0.15);
       box-shadow: inset 0 0 20px rgba(120, 121, 122, 0.15);
       /*modernizr*/ }
       .touch .psf-navigation .subnav:before {
@@ -982,25 +992,27 @@ html[xmlns] .slides { display: block; }
     .psf-navigation .tier-2:last-child > a {
       border-bottom: 1px solid rgba(120, 121, 122, 0.25); }
     .psf-navigation .current_item {
-      color: white;
+      color: #fff;
       background-color: #525353;
       *zoom: 1;
-      filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF5F5F60', endColorstr='#FF525353');
-      background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #5f5f60), color-stop(90%, #525353));
-      background-image: -webkit-linear-gradient(#5f5f60 10%, #525353 90%);
-      background-image: -moz-linear-gradient(#5f5f60 10%, #525353 90%);
-      background-image: -o-linear-gradient(#5f5f60 10%, #525353 90%);
-      background-image: linear-gradient(#5f5f60 10%, #525353 90%); }
+      filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF5F6060', endColorstr='#FF525353');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM1ZjYwNjAiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzUyNTM1MyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
+      background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #5f6060), color-stop(90%, #525353));
+      background-image: -moz-linear-gradient(#5f6060 10%, #525353 90%);
+      background-image: -webkit-linear-gradient(#5f6060 10%, #525353 90%);
+      background-image: linear-gradient(#5f6060 10%, #525353 90%); }
     .psf-navigation .super-navigation {
-      color: #666666;
+      color: #666;
       border: 1px solid #b8b9b9;
       background-color: #ececec;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFECECEC');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2VjZWNlYyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #ececec));
-      background-image: -webkit-linear-gradient(#ffffff 10%, #ececec 90%);
       background-image: -moz-linear-gradient(#ffffff 10%, #ececec 90%);
-      background-image: -o-linear-gradient(#ffffff 10%, #ececec 90%);
+      background-image: -webkit-linear-gradient(#ffffff 10%, #ececec 90%);
       background-image: linear-gradient(#ffffff 10%, #ececec 90%); }
       .psf-navigation .super-navigation a:not(.button) {
         color: #78797a; }
@@ -1011,12 +1023,13 @@ html[xmlns] .slides { display: block; }
     background-color: #ffc91a;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFD343', endColorstr='#FFFFC91A');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiNmZmQzNDMiLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iI2ZmYzkxYSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #ffd343), color-stop(95%, #ffc91a));
-    background-image: -webkit-linear-gradient(#ffd343 30%, #ffc91a 95%);
     background-image: -moz-linear-gradient(#ffd343 30%, #ffc91a 95%);
-    background-image: -o-linear-gradient(#ffd343 30%, #ffc91a 95%);
+    background-image: -webkit-linear-gradient(#ffd343 30%, #ffc91a 95%);
     background-image: linear-gradient(#ffd343 30%, #ffc91a 95%);
-    border-top: 1px solid #ffe58f;
+    border-top: 1px solid #ffe590;
     border-bottom: 1px solid #c39500;
     /*a*/ }
     .docs-navigation .tier-1 {
@@ -1025,20 +1038,21 @@ html[xmlns] .slides { display: block; }
       border-bottom: 1px solid #dca900;
       border-left: 1px solid #ffdf76; }
       .docs-navigation .tier-1 > a {
-        color: #333333;
+        color: #333;
         background-color: transparent;
         border-top: 1px solid transparent;
         border-bottom: 1px solid transparent;
         letter-spacing: 0.01em; }
         .docs-navigation .tier-1 > a:hover, .docs-navigation .tier-1 > a:focus, .docs-navigation .tier-1 > a .tier-1:hover > a {
-          color: white;
+          color: #fff;
           background-color: #ffc91a;
           *zoom: 1;
           filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFCE2F', endColorstr='#FFFFC91A');
+          background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmNlMmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZmYzkxYSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+          background-size: 100%;
           background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffce2f), color-stop(90%, #ffc91a));
-          background-image: -webkit-linear-gradient(#ffce2f 10%, #ffc91a 90%);
           background-image: -moz-linear-gradient(#ffce2f 10%, #ffc91a 90%);
-          background-image: -o-linear-gradient(#ffce2f 10%, #ffc91a 90%);
+          background-image: -webkit-linear-gradient(#ffce2f 10%, #ffc91a 90%);
           background-image: linear-gradient(#ffce2f 10%, #ffc91a 90%);
           border-top: 1px solid #ffd343;
           border-bottom: 1px solid #ffc91a; }
@@ -1047,13 +1061,14 @@ html[xmlns] .slides { display: block; }
       background-color: white;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFFFFFFF');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #ffffff));
-      background-image: -webkit-linear-gradient(#ffffff 10%, #ffffff 90%);
       background-image: -moz-linear-gradient(#ffffff 10%, #ffffff 90%);
-      background-image: -o-linear-gradient(#ffffff 10%, #ffffff 90%);
+      background-image: -webkit-linear-gradient(#ffffff 10%, #ffffff 90%);
       background-image: linear-gradient(#ffffff 10%, #ffffff 90%);
-      -webkit-box-shadow: inset 0 0 20px rgba(255, 211, 67, 0.15);
       -moz-box-shadow: inset 0 0 20px rgba(255, 211, 67, 0.15);
+      -webkit-box-shadow: inset 0 0 20px rgba(255, 211, 67, 0.15);
       box-shadow: inset 0 0 20px rgba(255, 211, 67, 0.15);
       /*modernizr*/ }
       .touch .docs-navigation .subnav:before {
@@ -1068,39 +1083,42 @@ html[xmlns] .slides { display: block; }
     .docs-navigation .tier-2:last-child > a {
       border-bottom: 1px solid rgba(255, 211, 67, 0.25); }
     .docs-navigation .current_item {
-      color: white;
-      background-color: #f5bc00;
+      color: #fff;
+      background-color: #f6bc00;
       *zoom: 1;
-      filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFC710', endColorstr='#FFF5BC00');
-      background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffc710), color-stop(90%, #f5bc00));
-      background-image: -webkit-linear-gradient(#ffc710 10%, #f5bc00 90%);
-      background-image: -moz-linear-gradient(#ffc710 10%, #f5bc00 90%);
-      background-image: -o-linear-gradient(#ffc710 10%, #f5bc00 90%);
-      background-image: linear-gradient(#ffc710 10%, #f5bc00 90%); }
+      filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFC710', endColorstr='#FFF6BC00');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmM3MTAiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2Y2YmMwMCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
+      background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffc710), color-stop(90%, #f6bc00));
+      background-image: -moz-linear-gradient(#ffc710 10%, #f6bc00 90%);
+      background-image: -webkit-linear-gradient(#ffc710 10%, #f6bc00 90%);
+      background-image: linear-gradient(#ffc710 10%, #f6bc00 90%); }
     .docs-navigation .super-navigation {
-      color: #666666;
-      border: 1px solid #fff1c2;
+      color: #666;
+      border: 1px solid #fff1c3;
       background-color: white;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFFFFFFF');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #ffffff));
-      background-image: -webkit-linear-gradient(#ffffff 10%, #ffffff 90%);
       background-image: -moz-linear-gradient(#ffffff 10%, #ffffff 90%);
-      background-image: -o-linear-gradient(#ffffff 10%, #ffffff 90%);
+      background-image: -webkit-linear-gradient(#ffffff 10%, #ffffff 90%);
       background-image: linear-gradient(#ffffff 10%, #ffffff 90%); }
       .docs-navigation .super-navigation a:not(.button) {
         color: #ffd343; }
       .docs-navigation .super-navigation h4 {
-        color: #ffcd29; }
+        color: #ffcd2a; }
 
   .pypl-navigation {
     background-color: #6c9238;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF82B043', endColorstr='#FF6C9238');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiM4MmIwNDMiLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iIzZjOTIzOCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #82b043), color-stop(95%, #6c9238));
-    background-image: -webkit-linear-gradient(#82b043 30%, #6c9238 95%);
     background-image: -moz-linear-gradient(#82b043 30%, #6c9238 95%);
-    background-image: -o-linear-gradient(#82b043 30%, #6c9238 95%);
+    background-image: -webkit-linear-gradient(#82b043 30%, #6c9238 95%);
     background-image: linear-gradient(#82b043 30%, #6c9238 95%);
     border-top: 1px solid #a6ca75;
     border-bottom: 1px solid #3e5420;
@@ -1117,14 +1135,15 @@ html[xmlns] .slides { display: block; }
         border-bottom: 1px solid transparent;
         letter-spacing: 0.01em; }
         .pypl-navigation .tier-1 > a:hover, .pypl-navigation .tier-1 > a:focus, .pypl-navigation .tier-1 > a .tier-1:hover > a {
-          color: white;
+          color: #fff;
           background-color: #6c9238;
           *zoom: 1;
           filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF77A13D', endColorstr='#FF6C9238');
+          background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM3N2ExM2QiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzZjOTIzOCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+          background-size: 100%;
           background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #77a13d), color-stop(90%, #6c9238));
-          background-image: -webkit-linear-gradient(#77a13d 10%, #6c9238 90%);
           background-image: -moz-linear-gradient(#77a13d 10%, #6c9238 90%);
-          background-image: -o-linear-gradient(#77a13d 10%, #6c9238 90%);
+          background-image: -webkit-linear-gradient(#77a13d 10%, #6c9238 90%);
           background-image: linear-gradient(#77a13d 10%, #6c9238 90%);
           border-top: 1px solid #82b043;
           border-bottom: 1px solid #6c9238; }
@@ -1133,13 +1152,14 @@ html[xmlns] .slides { display: block; }
       background-color: #eef5e4;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFDDEBCA', endColorstr='#FFEEF5E4');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNkZGViY2EiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2VlZjVlNCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ddebca), color-stop(90%, #eef5e4));
-      background-image: -webkit-linear-gradient(#ddebca 10%, #eef5e4 90%);
       background-image: -moz-linear-gradient(#ddebca 10%, #eef5e4 90%);
-      background-image: -o-linear-gradient(#ddebca 10%, #eef5e4 90%);
+      background-image: -webkit-linear-gradient(#ddebca 10%, #eef5e4 90%);
       background-image: linear-gradient(#ddebca 10%, #eef5e4 90%);
-      -webkit-box-shadow: inset 0 0 20px rgba(130, 176, 67, 0.15);
       -moz-box-shadow: inset 0 0 20px rgba(130, 176, 67, 0.15);
+      -webkit-box-shadow: inset 0 0 20px rgba(130, 176, 67, 0.15);
       box-shadow: inset 0 0 20px rgba(130, 176, 67, 0.15);
       /*modernizr*/ }
       .touch .pypl-navigation .subnav:before {
@@ -1154,25 +1174,27 @@ html[xmlns] .slides { display: block; }
     .pypl-navigation .tier-2:last-child > a {
       border-bottom: 1px solid rgba(130, 176, 67, 0.25); }
     .pypl-navigation .current_item {
-      color: white;
+      color: #fff;
       background-color: #59792e;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF678B35', endColorstr='#FF59792E');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM2NzhiMzUiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzU5NzkyZSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #678b35), color-stop(90%, #59792e));
-      background-image: -webkit-linear-gradient(#678b35 10%, #59792e 90%);
       background-image: -moz-linear-gradient(#678b35 10%, #59792e 90%);
-      background-image: -o-linear-gradient(#678b35 10%, #59792e 90%);
+      background-image: -webkit-linear-gradient(#678b35 10%, #59792e 90%);
       background-image: linear-gradient(#678b35 10%, #59792e 90%); }
     .pypl-navigation .super-navigation {
-      color: #666666;
+      color: #666;
       border: 1px solid #bed99a;
       background-color: #eef5e4;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFEEF5E4');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2VlZjVlNCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #eef5e4));
-      background-image: -webkit-linear-gradient(#ffffff 10%, #eef5e4 90%);
       background-image: -moz-linear-gradient(#ffffff 10%, #eef5e4 90%);
-      background-image: -o-linear-gradient(#ffffff 10%, #eef5e4 90%);
+      background-image: -webkit-linear-gradient(#ffffff 10%, #eef5e4 90%);
       background-image: linear-gradient(#ffffff 10%, #eef5e4 90%); }
       .pypl-navigation .super-navigation a:not(.button) {
         color: #82b043; }
@@ -1183,10 +1205,11 @@ html[xmlns] .slides { display: block; }
     background-color: #8b5792;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFA06BA7', endColorstr='#FF8B5792');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiNhMDZiYTciLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iIzhiNTc5MiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #a06ba7), color-stop(95%, #8b5792));
-    background-image: -webkit-linear-gradient(#a06ba7 30%, #8b5792 95%);
     background-image: -moz-linear-gradient(#a06ba7 30%, #8b5792 95%);
-    background-image: -o-linear-gradient(#a06ba7 30%, #8b5792 95%);
+    background-image: -webkit-linear-gradient(#a06ba7 30%, #8b5792 95%);
     background-image: linear-gradient(#a06ba7 30%, #8b5792 95%);
     border-top: 1px solid #bf9bc4;
     border-bottom: 1px solid #58375c;
@@ -1203,14 +1226,15 @@ html[xmlns] .slides { display: block; }
         border-bottom: 1px solid transparent;
         letter-spacing: 0.01em; }
         .jobs-navigation .tier-1 > a:hover, .jobs-navigation .tier-1 > a:focus, .jobs-navigation .tier-1 > a .tier-1:hover > a {
-          color: white;
+          color: #fff;
           background-color: #8b5792;
           *zoom: 1;
           filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF985F9F', endColorstr='#FF8B5792');
+          background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM5ODVmOWYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzhiNTc5MiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+          background-size: 100%;
           background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #985f9f), color-stop(90%, #8b5792));
-          background-image: -webkit-linear-gradient(#985f9f 10%, #8b5792 90%);
           background-image: -moz-linear-gradient(#985f9f 10%, #8b5792 90%);
-          background-image: -o-linear-gradient(#985f9f 10%, #8b5792 90%);
+          background-image: -webkit-linear-gradient(#985f9f 10%, #8b5792 90%);
           background-image: linear-gradient(#985f9f 10%, #8b5792 90%);
           border-top: 1px solid #a06ba7;
           border-bottom: 1px solid #8b5792; }
@@ -1219,13 +1243,14 @@ html[xmlns] .slides { display: block; }
       background-color: #fcfbfd;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFEEE5EF', endColorstr='#FFFCFBFD');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNlZWU1ZWYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZjZmJmZCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #eee5ef), color-stop(90%, #fcfbfd));
-      background-image: -webkit-linear-gradient(#eee5ef 10%, #fcfbfd 90%);
       background-image: -moz-linear-gradient(#eee5ef 10%, #fcfbfd 90%);
-      background-image: -o-linear-gradient(#eee5ef 10%, #fcfbfd 90%);
+      background-image: -webkit-linear-gradient(#eee5ef 10%, #fcfbfd 90%);
       background-image: linear-gradient(#eee5ef 10%, #fcfbfd 90%);
-      -webkit-box-shadow: inset 0 0 20px rgba(160, 107, 167, 0.15);
       -moz-box-shadow: inset 0 0 20px rgba(160, 107, 167, 0.15);
+      -webkit-box-shadow: inset 0 0 20px rgba(160, 107, 167, 0.15);
       box-shadow: inset 0 0 20px rgba(160, 107, 167, 0.15);
       /*modernizr*/ }
       .touch .jobs-navigation .subnav:before {
@@ -1240,25 +1265,27 @@ html[xmlns] .slides { display: block; }
     .jobs-navigation .tier-2:last-child > a {
       border-bottom: 1px solid rgba(160, 107, 167, 0.25); }
     .jobs-navigation .current_item {
-      color: white;
+      color: #fff;
       background-color: #764a7c;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF85538C', endColorstr='#FF764A7C');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM4NTUzOGMiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzc2NGE3YyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #85538c), color-stop(90%, #764a7c));
-      background-image: -webkit-linear-gradient(#85538c 10%, #764a7c 90%);
       background-image: -moz-linear-gradient(#85538c 10%, #764a7c 90%);
-      background-image: -o-linear-gradient(#85538c 10%, #764a7c 90%);
+      background-image: -webkit-linear-gradient(#85538c 10%, #764a7c 90%);
       background-image: linear-gradient(#85538c 10%, #764a7c 90%); }
     .jobs-navigation .super-navigation {
-      color: #666666;
+      color: #666;
       border: 1px solid #d3bbd7;
       background-color: #fcfbfd;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFFCFBFD');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZjZmJmZCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #fcfbfd));
-      background-image: -webkit-linear-gradient(#ffffff 10%, #fcfbfd 90%);
       background-image: -moz-linear-gradient(#ffffff 10%, #fcfbfd 90%);
-      background-image: -o-linear-gradient(#ffffff 10%, #fcfbfd 90%);
+      background-image: -webkit-linear-gradient(#ffffff 10%, #fcfbfd 90%);
       background-image: linear-gradient(#ffffff 10%, #fcfbfd 90%); }
       .jobs-navigation .super-navigation a:not(.button) {
         color: #a06ba7; }
@@ -1269,10 +1296,11 @@ html[xmlns] .slides { display: block; }
     background-color: #9e4650;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFB55863', endColorstr='#FF9E4650');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiNiNTU4NjMiLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iIzllNDY1MCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #b55863), color-stop(95%, #9e4650));
-    background-image: -webkit-linear-gradient(#b55863 30%, #9e4650 95%);
     background-image: -moz-linear-gradient(#b55863 30%, #9e4650 95%);
-    background-image: -o-linear-gradient(#b55863 30%, #9e4650 95%);
+    background-image: -webkit-linear-gradient(#b55863 30%, #9e4650 95%);
     background-image: linear-gradient(#b55863 30%, #9e4650 95%);
     border-top: 1px solid #cc8d95;
     border-bottom: 1px solid #622b32;
@@ -1289,14 +1317,15 @@ html[xmlns] .slides { display: block; }
         border-bottom: 1px solid transparent;
         letter-spacing: 0.01em; }
         .shop-navigation .tier-1 > a:hover, .shop-navigation .tier-1 > a:focus, .shop-navigation .tier-1 > a .tier-1:hover > a {
-          color: white;
+          color: #fff;
           background-color: #9e4650;
           *zoom: 1;
           filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFAC4C58', endColorstr='#FF9E4650');
+          background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNhYzRjNTgiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzllNDY1MCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+          background-size: 100%;
           background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ac4c58), color-stop(90%, #9e4650));
-          background-image: -webkit-linear-gradient(#ac4c58 10%, #9e4650 90%);
           background-image: -moz-linear-gradient(#ac4c58 10%, #9e4650 90%);
-          background-image: -o-linear-gradient(#ac4c58 10%, #9e4650 90%);
+          background-image: -webkit-linear-gradient(#ac4c58 10%, #9e4650 90%);
           background-image: linear-gradient(#ac4c58 10%, #9e4650 90%);
           border-top: 1px solid #b55863;
           border-bottom: 1px solid #9e4650; }
@@ -1305,13 +1334,14 @@ html[xmlns] .slides { display: block; }
       background-color: #fbf7f8;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFF1DEE0', endColorstr='#FFFBF7F8');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmMWRlZTAiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZiZjdmOCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #f1dee0), color-stop(90%, #fbf7f8));
-      background-image: -webkit-linear-gradient(#f1dee0 10%, #fbf7f8 90%);
       background-image: -moz-linear-gradient(#f1dee0 10%, #fbf7f8 90%);
-      background-image: -o-linear-gradient(#f1dee0 10%, #fbf7f8 90%);
+      background-image: -webkit-linear-gradient(#f1dee0 10%, #fbf7f8 90%);
       background-image: linear-gradient(#f1dee0 10%, #fbf7f8 90%);
-      -webkit-box-shadow: inset 0 0 20px rgba(181, 88, 99, 0.15);
       -moz-box-shadow: inset 0 0 20px rgba(181, 88, 99, 0.15);
+      -webkit-box-shadow: inset 0 0 20px rgba(181, 88, 99, 0.15);
       box-shadow: inset 0 0 20px rgba(181, 88, 99, 0.15);
       /*modernizr*/ }
       .touch .shop-navigation .subnav:before {
@@ -1326,25 +1356,27 @@ html[xmlns] .slides { display: block; }
     .shop-navigation .tier-2:last-child > a {
       border-bottom: 1px solid rgba(181, 88, 99, 0.25); }
     .shop-navigation .current_item {
-      color: white;
+      color: #fff;
       background-color: #853b44;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF97434D', endColorstr='#FF853B44');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM5NzQzNGQiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzg1M2I0NCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #97434d), color-stop(90%, #853b44));
-      background-image: -webkit-linear-gradient(#97434d 10%, #853b44 90%);
       background-image: -moz-linear-gradient(#97434d 10%, #853b44 90%);
-      background-image: -o-linear-gradient(#97434d 10%, #853b44 90%);
+      background-image: -webkit-linear-gradient(#97434d 10%, #853b44 90%);
       background-image: linear-gradient(#97434d 10%, #853b44 90%); }
     .shop-navigation .super-navigation {
-      color: #666666;
+      color: #666;
       border: 1px solid #dcb0b6;
       background-color: #fbf7f8;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFFBF7F8');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZiZjdmOCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #fbf7f8));
-      background-image: -webkit-linear-gradient(#ffffff 10%, #fbf7f8 90%);
       background-image: -moz-linear-gradient(#ffffff 10%, #fbf7f8 90%);
-      background-image: -o-linear-gradient(#ffffff 10%, #fbf7f8 90%);
+      background-image: -webkit-linear-gradient(#ffffff 10%, #fbf7f8 90%);
       background-image: linear-gradient(#ffffff 10%, #fbf7f8 90%); }
       .shop-navigation .super-navigation a:not(.button) {
         color: #b55863; }
@@ -1424,7 +1456,7 @@ html[xmlns] .slides { display: block; }
   .pep-list-header,
   .pep-index-list li,
   .info-key {
-    margin: 0 -0.5em; }
+    margin: 0 -.5em; }
 
   .pep-list-header {
     display: block; }
@@ -1463,15 +1495,15 @@ html[xmlns] .slides { display: block; }
 
   .listing-company-category:before {
     content: "Category: ";
-    color: #666666; }
+    color: #666; }
 
   .listing-job-title:before {
     content: "Title: ";
-    color: #666666; }
+    color: #666; }
 
   .listing-job-type:before {
     content: "Looking for: ";
-    color: #666666; }
+    color: #666; }
 
   .release-number,
   .release-date,
@@ -1494,13 +1526,38 @@ html[xmlns] .slides { display: block; }
   .release-enhancements {
     width: 25%; }
 
+  .release-version,
+  .release-status,
+  .release-start,
+  .release-end,
+  .release-pep {
+    -moz-box-orient: vertical;
+    display: inline-block;
+    margin-right: -4px;
+    vertical-align: middle; }
+
+  .release-version {
+    width: 15%; }
+
+  .release-status {
+    width: 20%; }
+
+  .release-start {
+    width: 25%; }
+
+  .release-end {
+    width: 25%; }
+
+  .release-pep {
+    width: 15%; }
+
   /* Previous Next pattern */
   .previous-next {
     overflow: hidden;
     *zoom: 1; }
     .previous-next a {
-      -webkit-box-sizing: border-box;
       -moz-box-sizing: border-box;
+      -webkit-box-sizing: border-box;
       box-sizing: border-box; }
     .previous-next .prev-button {
       width: 48.93617%;
@@ -1540,7 +1597,7 @@ html[xmlns] .slides { display: block; }
     speak: none; }
 
   .site-headline {
-    margin: 0.25em 0 0.5em; }
+    margin: .25em 0 .5em; }
 
   .site-headline a .python-logo {
     width: 255.2px;
@@ -1556,8 +1613,8 @@ html[xmlns] .slides { display: block; }
     margin: 0.875em 0; }
 
   .search-field {
-    background: white;
-    padding: 0.4em 0.5em 0.3em;
+    background: #fff;
+    padding: .4em .5em .3em;
     margin-right: .5em;
     width: 11em; }
     .search-field:focus {
@@ -1601,39 +1658,38 @@ html[xmlns] .slides { display: block; }
         top: -9999px;
         right: 2.6em;
         white-space: nowrap;
-        padding: 0.4em 0.75em 0.35em;
-        color: #999999;
+        padding: .4em .75em .35em;
+        color: #999;
         background-color: #1f1f1f;
         *zoom: 1;
         filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF333333', endColorstr='#FF1F1F1F');
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMzMzMzMzMiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzFmMWYxZiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
         background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #333333), color-stop(90%, #1f1f1f));
-        background-image: -webkit-linear-gradient(#333333 10%, #1f1f1f 90%);
         background-image: -moz-linear-gradient(#333333 10%, #1f1f1f 90%);
-        background-image: -o-linear-gradient(#333333 10%, #1f1f1f 90%);
+        background-image: -webkit-linear-gradient(#333333 10%, #1f1f1f 90%);
         background-image: linear-gradient(#333333 10%, #1f1f1f 90%);
-        border-top: 1px solid #444444;
-        border-right: 1px solid #444444;
-        border-bottom: 1px solid #444444;
-        border-left: 1px solid #444444;
-        -webkit-border-radius: 6px;
+        border-top: 1px solid #444;
+        border-right: 1px solid #444;
+        border-bottom: 1px solid #444;
+        border-left: 1px solid #444;
         -moz-border-radius: 6px;
-        -ms-border-radius: 6px;
-        -o-border-radius: 6px;
+        -webkit-border-radius: 6px;
         border-radius: 6px;
-        -webkit-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05);
         -moz-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05);
+        -webkit-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05);
         box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05);
-        -webkit-transition: opacity 0.25s ease-in-out, top 0s linear;
-        -webkit-transition-delay: 0s, 0.25s;
         -moz-transition: opacity 0.25s ease-in-out, top 0s linear 0.25s;
         -o-transition: opacity 0.25s ease-in-out, top 0s linear 0.25s;
+        -webkit-transition: opacity 0.25s ease-in-out, top 0s linear;
+        -webkit-transition-delay: 0s, 0.25s;
         transition: opacity 0.25s ease-in-out, top 0s linear 0.25s; }
       .flexslide .launch-shell .button:hover .message {
         opacity: 1;
         top: 0;
-        -webkit-transition: opacity 0.25s ease-in-out, top 0s linear;
         -moz-transition: opacity 0.25s ease-in-out, top 0s linear;
         -o-transition: opacity 0.25s ease-in-out, top 0s linear;
+        -webkit-transition: opacity 0.25s ease-in-out, top 0s linear;
         transition: opacity 0.25s ease-in-out, top 0s linear; }
 
   .introduction {
@@ -1662,24 +1718,24 @@ html[xmlns] .slides { display: block; }
     padding-top: 1em; }
 
   .about-banner {
-    background: 120% 0 no-repeat url('../img/landing-about.png?1543670309') transparent;
+    background: 120% 0 no-repeat url('../img/landing-about.png?1576869008') transparent;
     min-height: 345px;
     padding-bottom: 3.5em;
     margin-bottom: -2.5em; }
 
   .download-for-current-os {
-    background: 130% 0 no-repeat url('../img/landing-downloads.png?1543670309') transparent;
+    background: 130% 0 no-repeat url('../img/landing-downloads.png?1576869008') transparent;
     min-height: 345px;
     padding-bottom: 4em;
     margin-bottom: -3em; }
 
   .documentation-banner {
-    background: 130% 0 no-repeat url('../img/landing-docs.png?1543670309') transparent;
+    background: 130% 0 no-repeat url('../img/landing-docs.png?1576869008') transparent;
     padding-bottom: 1em; }
 
   .community-banner {
     text-align: left;
-    background: 110% 0 no-repeat url('../img/landing-community.png?1543670309') transparent;
+    background: 110% 0 no-repeat url('../img/landing-community.png?1576869008') transparent;
     min-height: 345px;
     padding-bottom: 2em;
     margin-bottom: -1.25em; }
@@ -1783,7 +1839,7 @@ html[xmlns] .slides { display: block; }
       right: 1em;
       width: 210px;
       height: 210px;
-      background: top left no-repeat url('../img/python-logo-large.png?1543670309') transparent; }
+      background: top left no-repeat url('../img/python-logo-large.png?1576869008') transparent; }
     .psf-widget .widget-title, .psf-widget p, .python-needs-you-widget .widget-title, .python-needs-you-widget p {
       margin-right: 34.04255%; }
 
@@ -1831,7 +1887,7 @@ html[xmlns] .slides { display: block; }
     float: left;
     margin-right: 2.12766%; }
     .listing-company .listing-company-name a:hover:after, .listing-company .listing-company-name a:focus:after {
-      color: #666666;
+      color: #666;
       content: " View Details";
       font-size: .75em; }
   .listing-company .listing-location {
@@ -1948,7 +2004,7 @@ html[xmlns] .slides { display: block; }
       /* We do this more explictly (the descendant selector) to avoid also styling links in the Supernav content */ }
       .main-navigation .tier-1 > a, .main-navigation .tier-2 > a {
         display: block;
-        padding: 0.5em 1.5em 0.4em 1em;
+        padding: .5em 1.5em .4em 1em;
         position: relative; }
     .main-navigation .tier-1 {
       display: block;
@@ -1974,20 +2030,20 @@ html[xmlns] .slides { display: block; }
       .no-touch .main-navigation .subnav {
         min-width: 100%;
         display: none;
-        -webkit-transition: all 0s ease;
         -moz-transition: all 0s ease;
         -o-transition: all 0s ease;
+        -webkit-transition: all 0s ease;
         transition: all 0s ease; }
       .touch .main-navigation .subnav {
         top: 120%;
         display: none;
         opacity: 0;
-        -webkit-transition: opacity 0.25s ease-in-out;
         -moz-transition: opacity 0.25s ease-in-out;
         -o-transition: opacity 0.25s ease-in-out;
+        -webkit-transition: opacity 0.25s ease-in-out;
         transition: opacity 0.25s ease-in-out;
-        -webkit-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
         -moz-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
+        -webkit-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
         box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6); }
         .touch .main-navigation .subnav:before {
           position: absolute;
@@ -2002,16 +2058,16 @@ html[xmlns] .slides { display: block; }
     .no-touch .main-navigation .element-1:hover .subnav, .no-touch .main-navigation .element-1:focus .subnav, .no-touch .main-navigation .element-2:hover .subnav, .no-touch .main-navigation .element-2:focus .subnav, .no-touch .main-navigation .element-3:hover .subnav, .no-touch .main-navigation .element-3:focus .subnav, .no-touch .main-navigation .element-4:hover .subnav, .no-touch .main-navigation .element-4:focus .subnav {
       left: 0;
       display: initial;
-      -webkit-transition-delay: 0.25s;
       -moz-transition-delay: 0.25s;
       -o-transition-delay: 0.25s;
+      -webkit-transition-delay: 0.25s;
       transition-delay: 0.25s; }
     .no-touch .main-navigation .element-5:hover .subnav, .no-touch .main-navigation .element-5:focus .subnav, .no-touch .main-navigation .element-6:hover .subnav, .no-touch .main-navigation .element-6:focus .subnav, .no-touch .main-navigation .element-7:hover .subnav, .no-touch .main-navigation .element-7:focus .subnav, .no-touch .main-navigation .element-8:hover .subnav, .no-touch .main-navigation .element-8:focus .subnav, .no-touch .main-navigation .last:hover .subnav, .no-touch .main-navigation .last:focus .subnav {
       right: 0;
       display: initial;
-      -webkit-transition-delay: 0.25s;
       -moz-transition-delay: 0.25s;
       -o-transition-delay: 0.25s;
+      -webkit-transition-delay: 0.25s;
       transition-delay: 0.25s; }
     .touch .main-navigation .element-1, .touch .main-navigation .element-2, .touch .main-navigation .element-3, .touch .main-navigation .element-4 {
       /* Position the pointer element */ }
@@ -2040,13 +2096,11 @@ html[xmlns] .slides { display: block; }
     display: block;
     text-align: center;
     font-size: 1.125em;
-    -webkit-border-radius: 8px;
     -moz-border-radius: 8px;
-    -ms-border-radius: 8px;
-    -o-border-radius: 8px;
+    -webkit-border-radius: 8px;
     border-radius: 8px;
-    -webkit-box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
     -moz-box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    -webkit-box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.2); }
     .no-touch .main-navigation .menu {
       text-align: center; }
@@ -2074,7 +2128,7 @@ html[xmlns] .slides { display: block; }
       .no-touch .main-navigation .tier-1.element-6, .no-touch .main-navigation .tier-1.element-7 {
         width: auto; }
       .no-touch .main-navigation .tier-1 > a {
-        padding: 0.65em 1.25em 0.55em; }
+        padding: .65em 1.25em .55em; }
     .no-touch .main-navigation .tier-2 {
       font-size: 0.875em; }
 
@@ -2134,7 +2188,7 @@ html[xmlns] .slides { display: block; }
 
   /*.subnav li*/
   .super-navigation {
-    color: #666666;
+    color: #666;
     position: absolute;
     /* relative to the containing LI */
     top: 0;
@@ -2161,7 +2215,7 @@ html[xmlns] .slides { display: block; }
       line-height: 1.25em;
       margin-bottom: 0; }
     .super-navigation p.date-posted {
-      color: #666666;
+      color: #666;
       font-size: 0.625em !important;
       font-style: italic; }
     .super-navigation p.excert {
@@ -2233,7 +2287,7 @@ html[xmlns] .slides { display: block; }
   .text {
     /* Make the intro/first paragraphs slightly larger? */ }
     .text > p:first-of-type {
-      color: #666666;
+      color: #666;
       font-size: 1.125em;
       line-height: 1.6875;
       margin-bottom: 1.25em; }
@@ -2363,7 +2417,7 @@ html[xmlns] .slides { display: block; }
   .home-slideshow .flex-direction-nav .flex-prev, .home-slideshow .flex-direction-nav .flex-next {
     top: 40%;
     font-size: 1.5em;
-    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+    filter: progid:DXImageTransform.Microsoft.Alpha(enabled=false);
     opacity: 1; }
   .home-slideshow .flex-direction-nav .flex-prev {
     left: -.75em; }
@@ -2409,7 +2463,7 @@ html[xmlns] .slides { display: block; }
     /* Reset some styles from the drop down menus */ }
     .touch .main-navigation a {
       text-align: center;
-      padding: 0.65em 1.25em 0.55em; }
+      padding: .65em 1.25em .55em; }
     .touch .main-navigation .tier-2 {
       font-size: 0.875em; }
     .touch .main-navigation .subnav {
@@ -2417,27 +2471,25 @@ html[xmlns] .slides { display: block; }
       display: block;
       opacity: 1;
       border-top: 0;
-      -webkit-box-shadow: none;
       -moz-box-shadow: none;
+      -webkit-box-shadow: none;
       box-shadow: none; }
 
   /* TO DO: With Javascript, look for a left-right swipe action and also trigger the menu to open */
   .touch #touchnav-wrapper {
-    -webkit-transition: -webkit-transform 300ms ease;
     -moz-transition: -moz-transform 300ms ease;
     -o-transition: -o-transform 300ms ease;
+    -webkit-transition: -webkit-transform 300ms ease;
     transition: transform 300ms ease;
-    -webkit-transform: translate3d(0, 0, 0);
     -moz-transform: translate3d(0, 0, 0);
     -ms-transform: translate3d(0, 0, 0);
-    -o-transform: translate3d(0, 0, 0);
+    -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0);
     -webkit-backface-visibility: hidden; }
   .touch .show-sidemenu #touchnav-wrapper {
-    -webkit-transform: translate3d(260px, 0, 0);
     -moz-transform: translate3d(260px, 0, 0);
     -ms-transform: translate3d(260px, 0, 0);
-    -o-transform: translate3d(260px, 0, 0);
+    -webkit-transform: translate3d(260px, 0, 0);
     transform: translate3d(260px, 0, 0); } }
 /* - - - Larger than 1024px - - - */
 @media (min-width: 64em) {
@@ -2533,6 +2585,7 @@ html[xmlns] .slides { display: block; }
  */
 @-ms-viewport {
   width: device-width; }
-
 @viewport {
   width: device-width; }
+
+/*# sourceMappingURL=mq.css.map */

--- a/static/sass/no-mq.css
+++ b/static/sass/no-mq.css
@@ -2,12 +2,15 @@
 /* Define constants for the application and to configure the blueprint framework. */
 /* ===== Compass Imports ===== */
 /* DO NOT include Blueprint here. We are using Susy for the grid, and if Blueprint is here, it will mess things up */
+/* @import "compass/css3/columns" */
+/* @import "compass/css3/hyphenation"; */
 /* Needed for the link-colors() function */
 /* Needed for the horizontal-list() function */
 /* When remembering whether or not there's a hyphen in white-space is too hard */
 /* Use pie-clearfix when there is no width set ont the element to avoid edge cases */
 /* Use to calculate color legibility: http://compass-style.org/reference/compass/utilities/color/contrast/ */
 /* Other interesting functions: 
+	@import "compass/utilities/color/contrast";
 		detailed here: http://compass-style.org/reference/compass/utilities/color/contrast/
 		Used to pass two colors into a get out the most readable color. 
 		Good for situations where we dont want to create a new color, 
@@ -174,7 +177,7 @@
 .slides,
 .flex-control-nav,
 .flex-direction-nav {margin: 0; padding: 0; list-style: none;} */
-                                                                               /* FlexSlider Necessary Styles 
+/* FlexSlider Necessary Styles 
 .flexslider {margin: 0; padding: 0;}
 .flexslider .slides > li {display: none; -webkit-backface-visibility: hidden;} /* Hide the slides before the JS is loaded. Avoids image jumping 
 .flexslider .slides img {width: 100%; display: block;}
@@ -222,12 +225,15 @@ html[xmlns] .slides { display: block; }
 /* Define constants for the application and to configure the blueprint framework. */
 /* ===== Compass Imports ===== */
 /* DO NOT include Blueprint here. We are using Susy for the grid, and if Blueprint is here, it will mess things up */
+/* @import "compass/css3/columns" */
+/* @import "compass/css3/hyphenation"; */
 /* Needed for the link-colors() function */
 /* Needed for the horizontal-list() function */
 /* When remembering whether or not there's a hyphen in white-space is too hard */
 /* Use pie-clearfix when there is no width set ont the element to avoid edge cases */
 /* Use to calculate color legibility: http://compass-style.org/reference/compass/utilities/color/contrast/ */
 /* Other interesting functions: 
+	@import "compass/utilities/color/contrast";
 		detailed here: http://compass-style.org/reference/compass/utilities/color/contrast/
 		Used to pass two colors into a get out the most readable color. 
 		Good for situations where we dont want to create a new color, 
@@ -499,9 +505,9 @@ a.button {
     border-color: transparent; }
 
 .search-field {
-  -webkit-transition: width 0.3s ease-in-out;
   -moz-transition: width 0.3s ease-in-out;
   -o-transition: width 0.3s ease-in-out;
+  -webkit-transition: width 0.3s ease-in-out;
   transition: width 0.3s ease-in-out; }
 
 .search-field:focus {
@@ -556,10 +562,11 @@ a.button {
   background-color: #2d618c;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF3776AB', endColorstr='#FF2D618C');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiMzNzc2YWIiLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iIzJkNjE4YyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #3776ab), color-stop(95%, #2d618c));
-  background-image: -webkit-linear-gradient(#3776ab 30%, #2d618c 95%);
   background-image: -moz-linear-gradient(#3776ab 30%, #2d618c 95%);
-  background-image: -o-linear-gradient(#3776ab 30%, #2d618c 95%);
+  background-image: -webkit-linear-gradient(#3776ab 30%, #2d618c 95%);
   background-image: linear-gradient(#3776ab 30%, #2d618c 95%);
   border-top: 1px solid #629ccd;
   border-bottom: 1px solid #18334b;
@@ -576,14 +583,15 @@ a.button {
       border-bottom: 1px solid transparent;
       letter-spacing: 0.01em; }
       .python-navigation .tier-1 > a:hover, .python-navigation .tier-1 > a:focus, .python-navigation .tier-1 > a .tier-1:hover > a {
-        color: white;
+        color: #fff;
         background-color: #2d618c;
         *zoom: 1;
         filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF326B9C', endColorstr='#FF2D618C');
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMzMjZiOWMiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzJkNjE4YyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
         background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #326b9c), color-stop(90%, #2d618c));
-        background-image: -webkit-linear-gradient(#326b9c 10%, #2d618c 90%);
         background-image: -moz-linear-gradient(#326b9c 10%, #2d618c 90%);
-        background-image: -o-linear-gradient(#326b9c 10%, #2d618c 90%);
+        background-image: -webkit-linear-gradient(#326b9c 10%, #2d618c 90%);
         background-image: linear-gradient(#326b9c 10%, #2d618c 90%);
         border-top: 1px solid #3776ab;
         border-bottom: 1px solid #2d618c; }
@@ -592,13 +600,14 @@ a.button {
     background-color: #d6e5f2;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFBBD4E9', endColorstr='#FFD6E5F2');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNiYmQ0ZTkiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2Q2ZTVmMiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #bbd4e9), color-stop(90%, #d6e5f2));
-    background-image: -webkit-linear-gradient(#bbd4e9 10%, #d6e5f2 90%);
     background-image: -moz-linear-gradient(#bbd4e9 10%, #d6e5f2 90%);
-    background-image: -o-linear-gradient(#bbd4e9 10%, #d6e5f2 90%);
+    background-image: -webkit-linear-gradient(#bbd4e9 10%, #d6e5f2 90%);
     background-image: linear-gradient(#bbd4e9 10%, #d6e5f2 90%);
-    -webkit-box-shadow: inset 0 0 20px rgba(55, 118, 171, 0.15);
     -moz-box-shadow: inset 0 0 20px rgba(55, 118, 171, 0.15);
+    -webkit-box-shadow: inset 0 0 20px rgba(55, 118, 171, 0.15);
     box-shadow: inset 0 0 20px rgba(55, 118, 171, 0.15);
     /*modernizr*/ }
     .touch .python-navigation .subnav:before {
@@ -613,25 +622,27 @@ a.button {
   .python-navigation .tier-2:last-child > a {
     border-bottom: 1px solid rgba(55, 118, 171, 0.25); }
   .python-navigation .current_item {
-    color: white;
+    color: #fff;
     background-color: #244e71;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF2B5B84', endColorstr='#FF244E71');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMyYjViODQiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzI0NGU3MSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #2b5b84), color-stop(90%, #244e71));
-    background-image: -webkit-linear-gradient(#2b5b84 10%, #244e71 90%);
     background-image: -moz-linear-gradient(#2b5b84 10%, #244e71 90%);
-    background-image: -o-linear-gradient(#2b5b84 10%, #244e71 90%);
+    background-image: -webkit-linear-gradient(#2b5b84 10%, #244e71 90%);
     background-image: linear-gradient(#2b5b84 10%, #244e71 90%); }
   .python-navigation .super-navigation {
-    color: #666666;
+    color: #666;
     border: 1px solid #89b4d9;
     background-color: #d6e5f2;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFCFDFE', endColorstr='#FFD6E5F2');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmY2ZkZmUiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2Q2ZTVmMiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #fcfdfe), color-stop(90%, #d6e5f2));
-    background-image: -webkit-linear-gradient(#fcfdfe 10%, #d6e5f2 90%);
     background-image: -moz-linear-gradient(#fcfdfe 10%, #d6e5f2 90%);
-    background-image: -o-linear-gradient(#fcfdfe 10%, #d6e5f2 90%);
+    background-image: -webkit-linear-gradient(#fcfdfe 10%, #d6e5f2 90%);
     background-image: linear-gradient(#fcfdfe 10%, #d6e5f2 90%); }
     .python-navigation .super-navigation a:not(.button) {
       color: #3776ab; }
@@ -642,17 +653,18 @@ a.button {
   background-color: #646565;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF78797A', endColorstr='#FF646565');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiM3ODc5N2EiLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iIzY0NjU2NSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #78797a), color-stop(95%, #646565));
-  background-image: -webkit-linear-gradient(#78797a 30%, #646565 95%);
   background-image: -moz-linear-gradient(#78797a 30%, #646565 95%);
-  background-image: -o-linear-gradient(#78797a 30%, #646565 95%);
+  background-image: -webkit-linear-gradient(#78797a 30%, #646565 95%);
   background-image: linear-gradient(#78797a 30%, #646565 95%);
   border-top: 1px solid #9e9fa0;
   border-bottom: 1px solid #39393a;
   /*a*/ }
   .psf-navigation .tier-1 {
     border-top: 1px solid #929393;
-    border-right: 1px solid #5f5f60;
+    border-right: 1px solid #5f6060;
     border-bottom: 1px solid #454647;
     border-left: 1px solid #929393; }
     .psf-navigation .tier-1 > a {
@@ -662,14 +674,15 @@ a.button {
       border-bottom: 1px solid transparent;
       letter-spacing: 0.01em; }
       .psf-navigation .tier-1 > a:hover, .psf-navigation .tier-1 > a:focus, .psf-navigation .tier-1 > a .tier-1:hover > a {
-        color: white;
+        color: #fff;
         background-color: #646565;
         *zoom: 1;
         filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF6E6F70', endColorstr='#FF646565');
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM2ZTZmNzAiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzY0NjU2NSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
         background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #6e6f70), color-stop(90%, #646565));
-        background-image: -webkit-linear-gradient(#6e6f70 10%, #646565 90%);
         background-image: -moz-linear-gradient(#6e6f70 10%, #646565 90%);
-        background-image: -o-linear-gradient(#6e6f70 10%, #646565 90%);
+        background-image: -webkit-linear-gradient(#6e6f70 10%, #646565 90%);
         background-image: linear-gradient(#6e6f70 10%, #646565 90%);
         border-top: 1px solid #78797a;
         border-bottom: 1px solid #646565; }
@@ -678,13 +691,14 @@ a.button {
     background-color: #ececec;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFDADADA', endColorstr='#FFECECEC');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNkYWRhZGEiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2VjZWNlYyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #dadada), color-stop(90%, #ececec));
-    background-image: -webkit-linear-gradient(#dadada 10%, #ececec 90%);
     background-image: -moz-linear-gradient(#dadada 10%, #ececec 90%);
-    background-image: -o-linear-gradient(#dadada 10%, #ececec 90%);
+    background-image: -webkit-linear-gradient(#dadada 10%, #ececec 90%);
     background-image: linear-gradient(#dadada 10%, #ececec 90%);
-    -webkit-box-shadow: inset 0 0 20px rgba(120, 121, 122, 0.15);
     -moz-box-shadow: inset 0 0 20px rgba(120, 121, 122, 0.15);
+    -webkit-box-shadow: inset 0 0 20px rgba(120, 121, 122, 0.15);
     box-shadow: inset 0 0 20px rgba(120, 121, 122, 0.15);
     /*modernizr*/ }
     .touch .psf-navigation .subnav:before {
@@ -699,25 +713,27 @@ a.button {
   .psf-navigation .tier-2:last-child > a {
     border-bottom: 1px solid rgba(120, 121, 122, 0.25); }
   .psf-navigation .current_item {
-    color: white;
+    color: #fff;
     background-color: #525353;
     *zoom: 1;
-    filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF5F5F60', endColorstr='#FF525353');
-    background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #5f5f60), color-stop(90%, #525353));
-    background-image: -webkit-linear-gradient(#5f5f60 10%, #525353 90%);
-    background-image: -moz-linear-gradient(#5f5f60 10%, #525353 90%);
-    background-image: -o-linear-gradient(#5f5f60 10%, #525353 90%);
-    background-image: linear-gradient(#5f5f60 10%, #525353 90%); }
+    filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF5F6060', endColorstr='#FF525353');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM1ZjYwNjAiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzUyNTM1MyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
+    background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #5f6060), color-stop(90%, #525353));
+    background-image: -moz-linear-gradient(#5f6060 10%, #525353 90%);
+    background-image: -webkit-linear-gradient(#5f6060 10%, #525353 90%);
+    background-image: linear-gradient(#5f6060 10%, #525353 90%); }
   .psf-navigation .super-navigation {
-    color: #666666;
+    color: #666;
     border: 1px solid #b8b9b9;
     background-color: #ececec;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFECECEC');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2VjZWNlYyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #ececec));
-    background-image: -webkit-linear-gradient(#ffffff 10%, #ececec 90%);
     background-image: -moz-linear-gradient(#ffffff 10%, #ececec 90%);
-    background-image: -o-linear-gradient(#ffffff 10%, #ececec 90%);
+    background-image: -webkit-linear-gradient(#ffffff 10%, #ececec 90%);
     background-image: linear-gradient(#ffffff 10%, #ececec 90%); }
     .psf-navigation .super-navigation a:not(.button) {
       color: #78797a; }
@@ -728,12 +744,13 @@ a.button {
   background-color: #ffc91a;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFD343', endColorstr='#FFFFC91A');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiNmZmQzNDMiLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iI2ZmYzkxYSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #ffd343), color-stop(95%, #ffc91a));
-  background-image: -webkit-linear-gradient(#ffd343 30%, #ffc91a 95%);
   background-image: -moz-linear-gradient(#ffd343 30%, #ffc91a 95%);
-  background-image: -o-linear-gradient(#ffd343 30%, #ffc91a 95%);
+  background-image: -webkit-linear-gradient(#ffd343 30%, #ffc91a 95%);
   background-image: linear-gradient(#ffd343 30%, #ffc91a 95%);
-  border-top: 1px solid #ffe58f;
+  border-top: 1px solid #ffe590;
   border-bottom: 1px solid #c39500;
   /*a*/ }
   .docs-navigation .tier-1 {
@@ -742,20 +759,21 @@ a.button {
     border-bottom: 1px solid #dca900;
     border-left: 1px solid #ffdf76; }
     .docs-navigation .tier-1 > a {
-      color: #333333;
+      color: #333;
       background-color: transparent;
       border-top: 1px solid transparent;
       border-bottom: 1px solid transparent;
       letter-spacing: 0.01em; }
       .docs-navigation .tier-1 > a:hover, .docs-navigation .tier-1 > a:focus, .docs-navigation .tier-1 > a .tier-1:hover > a {
-        color: white;
+        color: #fff;
         background-color: #ffc91a;
         *zoom: 1;
         filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFCE2F', endColorstr='#FFFFC91A');
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmNlMmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZmYzkxYSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
         background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffce2f), color-stop(90%, #ffc91a));
-        background-image: -webkit-linear-gradient(#ffce2f 10%, #ffc91a 90%);
         background-image: -moz-linear-gradient(#ffce2f 10%, #ffc91a 90%);
-        background-image: -o-linear-gradient(#ffce2f 10%, #ffc91a 90%);
+        background-image: -webkit-linear-gradient(#ffce2f 10%, #ffc91a 90%);
         background-image: linear-gradient(#ffce2f 10%, #ffc91a 90%);
         border-top: 1px solid #ffd343;
         border-bottom: 1px solid #ffc91a; }
@@ -764,13 +782,14 @@ a.button {
     background-color: white;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFFFFFFF');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #ffffff));
-    background-image: -webkit-linear-gradient(#ffffff 10%, #ffffff 90%);
     background-image: -moz-linear-gradient(#ffffff 10%, #ffffff 90%);
-    background-image: -o-linear-gradient(#ffffff 10%, #ffffff 90%);
+    background-image: -webkit-linear-gradient(#ffffff 10%, #ffffff 90%);
     background-image: linear-gradient(#ffffff 10%, #ffffff 90%);
-    -webkit-box-shadow: inset 0 0 20px rgba(255, 211, 67, 0.15);
     -moz-box-shadow: inset 0 0 20px rgba(255, 211, 67, 0.15);
+    -webkit-box-shadow: inset 0 0 20px rgba(255, 211, 67, 0.15);
     box-shadow: inset 0 0 20px rgba(255, 211, 67, 0.15);
     /*modernizr*/ }
     .touch .docs-navigation .subnav:before {
@@ -785,39 +804,42 @@ a.button {
   .docs-navigation .tier-2:last-child > a {
     border-bottom: 1px solid rgba(255, 211, 67, 0.25); }
   .docs-navigation .current_item {
-    color: white;
-    background-color: #f5bc00;
+    color: #fff;
+    background-color: #f6bc00;
     *zoom: 1;
-    filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFC710', endColorstr='#FFF5BC00');
-    background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffc710), color-stop(90%, #f5bc00));
-    background-image: -webkit-linear-gradient(#ffc710 10%, #f5bc00 90%);
-    background-image: -moz-linear-gradient(#ffc710 10%, #f5bc00 90%);
-    background-image: -o-linear-gradient(#ffc710 10%, #f5bc00 90%);
-    background-image: linear-gradient(#ffc710 10%, #f5bc00 90%); }
+    filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFC710', endColorstr='#FFF6BC00');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmM3MTAiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2Y2YmMwMCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
+    background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffc710), color-stop(90%, #f6bc00));
+    background-image: -moz-linear-gradient(#ffc710 10%, #f6bc00 90%);
+    background-image: -webkit-linear-gradient(#ffc710 10%, #f6bc00 90%);
+    background-image: linear-gradient(#ffc710 10%, #f6bc00 90%); }
   .docs-navigation .super-navigation {
-    color: #666666;
-    border: 1px solid #fff1c2;
+    color: #666;
+    border: 1px solid #fff1c3;
     background-color: white;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFFFFFFF');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #ffffff));
-    background-image: -webkit-linear-gradient(#ffffff 10%, #ffffff 90%);
     background-image: -moz-linear-gradient(#ffffff 10%, #ffffff 90%);
-    background-image: -o-linear-gradient(#ffffff 10%, #ffffff 90%);
+    background-image: -webkit-linear-gradient(#ffffff 10%, #ffffff 90%);
     background-image: linear-gradient(#ffffff 10%, #ffffff 90%); }
     .docs-navigation .super-navigation a:not(.button) {
       color: #ffd343; }
     .docs-navigation .super-navigation h4 {
-      color: #ffcd29; }
+      color: #ffcd2a; }
 
 .pypl-navigation {
   background-color: #6c9238;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF82B043', endColorstr='#FF6C9238');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiM4MmIwNDMiLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iIzZjOTIzOCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #82b043), color-stop(95%, #6c9238));
-  background-image: -webkit-linear-gradient(#82b043 30%, #6c9238 95%);
   background-image: -moz-linear-gradient(#82b043 30%, #6c9238 95%);
-  background-image: -o-linear-gradient(#82b043 30%, #6c9238 95%);
+  background-image: -webkit-linear-gradient(#82b043 30%, #6c9238 95%);
   background-image: linear-gradient(#82b043 30%, #6c9238 95%);
   border-top: 1px solid #a6ca75;
   border-bottom: 1px solid #3e5420;
@@ -834,14 +856,15 @@ a.button {
       border-bottom: 1px solid transparent;
       letter-spacing: 0.01em; }
       .pypl-navigation .tier-1 > a:hover, .pypl-navigation .tier-1 > a:focus, .pypl-navigation .tier-1 > a .tier-1:hover > a {
-        color: white;
+        color: #fff;
         background-color: #6c9238;
         *zoom: 1;
         filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF77A13D', endColorstr='#FF6C9238');
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM3N2ExM2QiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzZjOTIzOCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
         background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #77a13d), color-stop(90%, #6c9238));
-        background-image: -webkit-linear-gradient(#77a13d 10%, #6c9238 90%);
         background-image: -moz-linear-gradient(#77a13d 10%, #6c9238 90%);
-        background-image: -o-linear-gradient(#77a13d 10%, #6c9238 90%);
+        background-image: -webkit-linear-gradient(#77a13d 10%, #6c9238 90%);
         background-image: linear-gradient(#77a13d 10%, #6c9238 90%);
         border-top: 1px solid #82b043;
         border-bottom: 1px solid #6c9238; }
@@ -850,13 +873,14 @@ a.button {
     background-color: #eef5e4;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFDDEBCA', endColorstr='#FFEEF5E4');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNkZGViY2EiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2VlZjVlNCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ddebca), color-stop(90%, #eef5e4));
-    background-image: -webkit-linear-gradient(#ddebca 10%, #eef5e4 90%);
     background-image: -moz-linear-gradient(#ddebca 10%, #eef5e4 90%);
-    background-image: -o-linear-gradient(#ddebca 10%, #eef5e4 90%);
+    background-image: -webkit-linear-gradient(#ddebca 10%, #eef5e4 90%);
     background-image: linear-gradient(#ddebca 10%, #eef5e4 90%);
-    -webkit-box-shadow: inset 0 0 20px rgba(130, 176, 67, 0.15);
     -moz-box-shadow: inset 0 0 20px rgba(130, 176, 67, 0.15);
+    -webkit-box-shadow: inset 0 0 20px rgba(130, 176, 67, 0.15);
     box-shadow: inset 0 0 20px rgba(130, 176, 67, 0.15);
     /*modernizr*/ }
     .touch .pypl-navigation .subnav:before {
@@ -871,25 +895,27 @@ a.button {
   .pypl-navigation .tier-2:last-child > a {
     border-bottom: 1px solid rgba(130, 176, 67, 0.25); }
   .pypl-navigation .current_item {
-    color: white;
+    color: #fff;
     background-color: #59792e;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF678B35', endColorstr='#FF59792E');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM2NzhiMzUiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzU5NzkyZSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #678b35), color-stop(90%, #59792e));
-    background-image: -webkit-linear-gradient(#678b35 10%, #59792e 90%);
     background-image: -moz-linear-gradient(#678b35 10%, #59792e 90%);
-    background-image: -o-linear-gradient(#678b35 10%, #59792e 90%);
+    background-image: -webkit-linear-gradient(#678b35 10%, #59792e 90%);
     background-image: linear-gradient(#678b35 10%, #59792e 90%); }
   .pypl-navigation .super-navigation {
-    color: #666666;
+    color: #666;
     border: 1px solid #bed99a;
     background-color: #eef5e4;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFEEF5E4');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2VlZjVlNCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #eef5e4));
-    background-image: -webkit-linear-gradient(#ffffff 10%, #eef5e4 90%);
     background-image: -moz-linear-gradient(#ffffff 10%, #eef5e4 90%);
-    background-image: -o-linear-gradient(#ffffff 10%, #eef5e4 90%);
+    background-image: -webkit-linear-gradient(#ffffff 10%, #eef5e4 90%);
     background-image: linear-gradient(#ffffff 10%, #eef5e4 90%); }
     .pypl-navigation .super-navigation a:not(.button) {
       color: #82b043; }
@@ -900,10 +926,11 @@ a.button {
   background-color: #8b5792;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFA06BA7', endColorstr='#FF8B5792');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiNhMDZiYTciLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iIzhiNTc5MiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #a06ba7), color-stop(95%, #8b5792));
-  background-image: -webkit-linear-gradient(#a06ba7 30%, #8b5792 95%);
   background-image: -moz-linear-gradient(#a06ba7 30%, #8b5792 95%);
-  background-image: -o-linear-gradient(#a06ba7 30%, #8b5792 95%);
+  background-image: -webkit-linear-gradient(#a06ba7 30%, #8b5792 95%);
   background-image: linear-gradient(#a06ba7 30%, #8b5792 95%);
   border-top: 1px solid #bf9bc4;
   border-bottom: 1px solid #58375c;
@@ -920,14 +947,15 @@ a.button {
       border-bottom: 1px solid transparent;
       letter-spacing: 0.01em; }
       .jobs-navigation .tier-1 > a:hover, .jobs-navigation .tier-1 > a:focus, .jobs-navigation .tier-1 > a .tier-1:hover > a {
-        color: white;
+        color: #fff;
         background-color: #8b5792;
         *zoom: 1;
         filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF985F9F', endColorstr='#FF8B5792');
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM5ODVmOWYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzhiNTc5MiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
         background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #985f9f), color-stop(90%, #8b5792));
-        background-image: -webkit-linear-gradient(#985f9f 10%, #8b5792 90%);
         background-image: -moz-linear-gradient(#985f9f 10%, #8b5792 90%);
-        background-image: -o-linear-gradient(#985f9f 10%, #8b5792 90%);
+        background-image: -webkit-linear-gradient(#985f9f 10%, #8b5792 90%);
         background-image: linear-gradient(#985f9f 10%, #8b5792 90%);
         border-top: 1px solid #a06ba7;
         border-bottom: 1px solid #8b5792; }
@@ -936,13 +964,14 @@ a.button {
     background-color: #fcfbfd;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFEEE5EF', endColorstr='#FFFCFBFD');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNlZWU1ZWYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZjZmJmZCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #eee5ef), color-stop(90%, #fcfbfd));
-    background-image: -webkit-linear-gradient(#eee5ef 10%, #fcfbfd 90%);
     background-image: -moz-linear-gradient(#eee5ef 10%, #fcfbfd 90%);
-    background-image: -o-linear-gradient(#eee5ef 10%, #fcfbfd 90%);
+    background-image: -webkit-linear-gradient(#eee5ef 10%, #fcfbfd 90%);
     background-image: linear-gradient(#eee5ef 10%, #fcfbfd 90%);
-    -webkit-box-shadow: inset 0 0 20px rgba(160, 107, 167, 0.15);
     -moz-box-shadow: inset 0 0 20px rgba(160, 107, 167, 0.15);
+    -webkit-box-shadow: inset 0 0 20px rgba(160, 107, 167, 0.15);
     box-shadow: inset 0 0 20px rgba(160, 107, 167, 0.15);
     /*modernizr*/ }
     .touch .jobs-navigation .subnav:before {
@@ -957,25 +986,27 @@ a.button {
   .jobs-navigation .tier-2:last-child > a {
     border-bottom: 1px solid rgba(160, 107, 167, 0.25); }
   .jobs-navigation .current_item {
-    color: white;
+    color: #fff;
     background-color: #764a7c;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF85538C', endColorstr='#FF764A7C');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM4NTUzOGMiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzc2NGE3YyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #85538c), color-stop(90%, #764a7c));
-    background-image: -webkit-linear-gradient(#85538c 10%, #764a7c 90%);
     background-image: -moz-linear-gradient(#85538c 10%, #764a7c 90%);
-    background-image: -o-linear-gradient(#85538c 10%, #764a7c 90%);
+    background-image: -webkit-linear-gradient(#85538c 10%, #764a7c 90%);
     background-image: linear-gradient(#85538c 10%, #764a7c 90%); }
   .jobs-navigation .super-navigation {
-    color: #666666;
+    color: #666;
     border: 1px solid #d3bbd7;
     background-color: #fcfbfd;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFFCFBFD');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZjZmJmZCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #fcfbfd));
-    background-image: -webkit-linear-gradient(#ffffff 10%, #fcfbfd 90%);
     background-image: -moz-linear-gradient(#ffffff 10%, #fcfbfd 90%);
-    background-image: -o-linear-gradient(#ffffff 10%, #fcfbfd 90%);
+    background-image: -webkit-linear-gradient(#ffffff 10%, #fcfbfd 90%);
     background-image: linear-gradient(#ffffff 10%, #fcfbfd 90%); }
     .jobs-navigation .super-navigation a:not(.button) {
       color: #a06ba7; }
@@ -986,10 +1017,11 @@ a.button {
   background-color: #9e4650;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFB55863', endColorstr='#FF9E4650');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIzMCUiIHN0b3AtY29sb3I9IiNiNTU4NjMiLz48c3RvcCBvZmZzZXQ9Ijk1JSIgc3RvcC1jb2xvcj0iIzllNDY1MCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(30%, #b55863), color-stop(95%, #9e4650));
-  background-image: -webkit-linear-gradient(#b55863 30%, #9e4650 95%);
   background-image: -moz-linear-gradient(#b55863 30%, #9e4650 95%);
-  background-image: -o-linear-gradient(#b55863 30%, #9e4650 95%);
+  background-image: -webkit-linear-gradient(#b55863 30%, #9e4650 95%);
   background-image: linear-gradient(#b55863 30%, #9e4650 95%);
   border-top: 1px solid #cc8d95;
   border-bottom: 1px solid #622b32;
@@ -1006,14 +1038,15 @@ a.button {
       border-bottom: 1px solid transparent;
       letter-spacing: 0.01em; }
       .shop-navigation .tier-1 > a:hover, .shop-navigation .tier-1 > a:focus, .shop-navigation .tier-1 > a .tier-1:hover > a {
-        color: white;
+        color: #fff;
         background-color: #9e4650;
         *zoom: 1;
         filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFAC4C58', endColorstr='#FF9E4650');
+        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNhYzRjNTgiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzllNDY1MCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+        background-size: 100%;
         background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ac4c58), color-stop(90%, #9e4650));
-        background-image: -webkit-linear-gradient(#ac4c58 10%, #9e4650 90%);
         background-image: -moz-linear-gradient(#ac4c58 10%, #9e4650 90%);
-        background-image: -o-linear-gradient(#ac4c58 10%, #9e4650 90%);
+        background-image: -webkit-linear-gradient(#ac4c58 10%, #9e4650 90%);
         background-image: linear-gradient(#ac4c58 10%, #9e4650 90%);
         border-top: 1px solid #b55863;
         border-bottom: 1px solid #9e4650; }
@@ -1022,13 +1055,14 @@ a.button {
     background-color: #fbf7f8;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFF1DEE0', endColorstr='#FFFBF7F8');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmMWRlZTAiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZiZjdmOCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #f1dee0), color-stop(90%, #fbf7f8));
-    background-image: -webkit-linear-gradient(#f1dee0 10%, #fbf7f8 90%);
     background-image: -moz-linear-gradient(#f1dee0 10%, #fbf7f8 90%);
-    background-image: -o-linear-gradient(#f1dee0 10%, #fbf7f8 90%);
+    background-image: -webkit-linear-gradient(#f1dee0 10%, #fbf7f8 90%);
     background-image: linear-gradient(#f1dee0 10%, #fbf7f8 90%);
-    -webkit-box-shadow: inset 0 0 20px rgba(181, 88, 99, 0.15);
     -moz-box-shadow: inset 0 0 20px rgba(181, 88, 99, 0.15);
+    -webkit-box-shadow: inset 0 0 20px rgba(181, 88, 99, 0.15);
     box-shadow: inset 0 0 20px rgba(181, 88, 99, 0.15);
     /*modernizr*/ }
     .touch .shop-navigation .subnav:before {
@@ -1043,25 +1077,27 @@ a.button {
   .shop-navigation .tier-2:last-child > a {
     border-bottom: 1px solid rgba(181, 88, 99, 0.25); }
   .shop-navigation .current_item {
-    color: white;
+    color: #fff;
     background-color: #853b44;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF97434D', endColorstr='#FF853B44');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM5NzQzNGQiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzg1M2I0NCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #97434d), color-stop(90%, #853b44));
-    background-image: -webkit-linear-gradient(#97434d 10%, #853b44 90%);
     background-image: -moz-linear-gradient(#97434d 10%, #853b44 90%);
-    background-image: -o-linear-gradient(#97434d 10%, #853b44 90%);
+    background-image: -webkit-linear-gradient(#97434d 10%, #853b44 90%);
     background-image: linear-gradient(#97434d 10%, #853b44 90%); }
   .shop-navigation .super-navigation {
-    color: #666666;
+    color: #666;
     border: 1px solid #dcb0b6;
     background-color: #fbf7f8;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FFFBF7F8');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmZmZmYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZiZjdmOCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffffff), color-stop(90%, #fbf7f8));
-    background-image: -webkit-linear-gradient(#ffffff 10%, #fbf7f8 90%);
     background-image: -moz-linear-gradient(#ffffff 10%, #fbf7f8 90%);
-    background-image: -o-linear-gradient(#ffffff 10%, #fbf7f8 90%);
+    background-image: -webkit-linear-gradient(#ffffff 10%, #fbf7f8 90%);
     background-image: linear-gradient(#ffffff 10%, #fbf7f8 90%); }
     .shop-navigation .super-navigation a:not(.button) {
       color: #b55863; }
@@ -1141,7 +1177,7 @@ a.button {
 .pep-list-header,
 .pep-index-list li,
 .info-key {
-  margin: 0 -0.5em; }
+  margin: 0 -.5em; }
 
 .pep-list-header {
   display: block; }
@@ -1180,15 +1216,15 @@ a.button {
 
 .listing-company-category:before {
   content: "Category: ";
-  color: #666666; }
+  color: #666; }
 
 .listing-job-title:before {
   content: "Title: ";
-  color: #666666; }
+  color: #666; }
 
 .listing-job-type:before {
   content: "Looking for: ";
-  color: #666666; }
+  color: #666; }
 
 .release-number,
 .release-date,
@@ -1211,13 +1247,38 @@ a.button {
 .release-enhancements {
   width: 25%; }
 
+.release-version,
+.release-status,
+.release-start,
+.release-end,
+.release-pep {
+  -moz-box-orient: vertical;
+  display: inline-block;
+  margin-right: -4px;
+  vertical-align: middle; }
+
+.release-version {
+  width: 15%; }
+
+.release-status {
+  width: 20%; }
+
+.release-start {
+  width: 25%; }
+
+.release-end {
+  width: 25%; }
+
+.release-pep {
+  width: 15%; }
+
 /* Previous Next pattern */
 .previous-next {
   overflow: hidden;
   *zoom: 1; }
   .previous-next a {
-    -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     box-sizing: border-box; }
   .previous-next .prev-button {
     width: 48.93617%;
@@ -1251,7 +1312,7 @@ a.button {
     display: inline-block; }
 
 .site-headline {
-  margin: 0.25em 0 0.5em; }
+  margin: .25em 0 .5em; }
 
 .site-headline a .python-logo {
   width: 255.2px;
@@ -1267,8 +1328,8 @@ a.button {
   margin: 0.875em 0; }
 
 .search-field {
-  background: white;
-  padding: 0.4em 0.5em 0.3em;
+  background: #fff;
+  padding: .4em .5em .3em;
   margin-right: .5em;
   width: 11em; }
   .search-field:focus {
@@ -1312,39 +1373,38 @@ a.button {
       top: -9999px;
       right: 2.6em;
       white-space: nowrap;
-      padding: 0.4em 0.75em 0.35em;
-      color: #999999;
+      padding: .4em .75em .35em;
+      color: #999;
       background-color: #1f1f1f;
       *zoom: 1;
       filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF333333', endColorstr='#FF1F1F1F');
+      background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMzMzMzMzMiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzFmMWYxZiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+      background-size: 100%;
       background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #333333), color-stop(90%, #1f1f1f));
-      background-image: -webkit-linear-gradient(#333333 10%, #1f1f1f 90%);
       background-image: -moz-linear-gradient(#333333 10%, #1f1f1f 90%);
-      background-image: -o-linear-gradient(#333333 10%, #1f1f1f 90%);
+      background-image: -webkit-linear-gradient(#333333 10%, #1f1f1f 90%);
       background-image: linear-gradient(#333333 10%, #1f1f1f 90%);
-      border-top: 1px solid #444444;
-      border-right: 1px solid #444444;
-      border-bottom: 1px solid #444444;
-      border-left: 1px solid #444444;
-      -webkit-border-radius: 6px;
+      border-top: 1px solid #444;
+      border-right: 1px solid #444;
+      border-bottom: 1px solid #444;
+      border-left: 1px solid #444;
       -moz-border-radius: 6px;
-      -ms-border-radius: 6px;
-      -o-border-radius: 6px;
+      -webkit-border-radius: 6px;
       border-radius: 6px;
-      -webkit-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05);
       -moz-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05);
+      -webkit-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05);
       box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05);
-      -webkit-transition: opacity 0.25s ease-in-out, top 0s linear;
-      -webkit-transition-delay: 0s, 0.25s;
       -moz-transition: opacity 0.25s ease-in-out, top 0s linear 0.25s;
       -o-transition: opacity 0.25s ease-in-out, top 0s linear 0.25s;
+      -webkit-transition: opacity 0.25s ease-in-out, top 0s linear;
+      -webkit-transition-delay: 0s, 0.25s;
       transition: opacity 0.25s ease-in-out, top 0s linear 0.25s; }
     .flexslide .launch-shell .button:hover .message {
       opacity: 1;
       top: 0;
-      -webkit-transition: opacity 0.25s ease-in-out, top 0s linear;
       -moz-transition: opacity 0.25s ease-in-out, top 0s linear;
       -o-transition: opacity 0.25s ease-in-out, top 0s linear;
+      -webkit-transition: opacity 0.25s ease-in-out, top 0s linear;
       transition: opacity 0.25s ease-in-out, top 0s linear; }
 
 .introduction {
@@ -1373,24 +1433,24 @@ a.button {
   padding-top: 1em; }
 
 .about-banner {
-  background: 120% 0 no-repeat url('../img/landing-about.png?1543670309') transparent;
+  background: 120% 0 no-repeat url('../img/landing-about.png?1576869008') transparent;
   min-height: 345px;
   padding-bottom: 3.5em;
   margin-bottom: -2.5em; }
 
 .download-for-current-os {
-  background: 130% 0 no-repeat url('../img/landing-downloads.png?1543670309') transparent;
+  background: 130% 0 no-repeat url('../img/landing-downloads.png?1576869008') transparent;
   min-height: 345px;
   padding-bottom: 4em;
   margin-bottom: -3em; }
 
 .documentation-banner {
-  background: 130% 0 no-repeat url('../img/landing-docs.png?1543670309') transparent;
+  background: 130% 0 no-repeat url('../img/landing-docs.png?1576869008') transparent;
   padding-bottom: 1em; }
 
 .community-banner {
   text-align: left;
-  background: 110% 0 no-repeat url('../img/landing-community.png?1543670309') transparent;
+  background: 110% 0 no-repeat url('../img/landing-community.png?1576869008') transparent;
   min-height: 345px;
   padding-bottom: 2em;
   margin-bottom: -1.25em; }
@@ -1494,7 +1554,7 @@ a.button {
     right: 1em;
     width: 210px;
     height: 210px;
-    background: top left no-repeat url('../img/python-logo-large.png?1543670309') transparent; }
+    background: top left no-repeat url('../img/python-logo-large.png?1576869008') transparent; }
   .psf-widget .widget-title, .psf-widget p, .python-needs-you-widget .widget-title, .python-needs-you-widget p {
     margin-right: 34.04255%; }
 
@@ -1542,7 +1602,7 @@ a.button {
   float: left;
   margin-right: 2.12766%; }
   .listing-company .listing-company-name a:hover:after, .listing-company .listing-company-name a:focus:after {
-    color: #666666;
+    color: #666;
     content: " View Details";
     font-size: .75em; }
 .listing-company .listing-location {
@@ -1639,7 +1699,7 @@ a.button {
     /* We do this more explictly (the descendant selector) to avoid also styling links in the Supernav content */ }
     .main-navigation .tier-1 > a, .main-navigation .tier-2 > a {
       display: block;
-      padding: 0.5em 1.5em 0.4em 1em;
+      padding: .5em 1.5em .4em 1em;
       position: relative; }
   .main-navigation .tier-1 {
     display: block;
@@ -1665,20 +1725,20 @@ a.button {
     .no-touch .main-navigation .subnav {
       min-width: 100%;
       display: none;
-      -webkit-transition: all 0s ease;
       -moz-transition: all 0s ease;
       -o-transition: all 0s ease;
+      -webkit-transition: all 0s ease;
       transition: all 0s ease; }
     .touch .main-navigation .subnav {
       top: 120%;
       display: none;
       opacity: 0;
-      -webkit-transition: opacity 0.25s ease-in-out;
       -moz-transition: opacity 0.25s ease-in-out;
       -o-transition: opacity 0.25s ease-in-out;
+      -webkit-transition: opacity 0.25s ease-in-out;
       transition: opacity 0.25s ease-in-out;
-      -webkit-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
       -moz-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
+      -webkit-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
       box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6); }
       .touch .main-navigation .subnav:before {
         position: absolute;
@@ -1693,16 +1753,16 @@ a.button {
   .no-touch .main-navigation .element-1:hover .subnav, .no-touch .main-navigation .element-1:focus .subnav, .no-touch .main-navigation .element-2:hover .subnav, .no-touch .main-navigation .element-2:focus .subnav, .no-touch .main-navigation .element-3:hover .subnav, .no-touch .main-navigation .element-3:focus .subnav, .no-touch .main-navigation .element-4:hover .subnav, .no-touch .main-navigation .element-4:focus .subnav {
     left: 0;
     display: initial;
-    -webkit-transition-delay: 0.25s;
     -moz-transition-delay: 0.25s;
     -o-transition-delay: 0.25s;
+    -webkit-transition-delay: 0.25s;
     transition-delay: 0.25s; }
   .no-touch .main-navigation .element-5:hover .subnav, .no-touch .main-navigation .element-5:focus .subnav, .no-touch .main-navigation .element-6:hover .subnav, .no-touch .main-navigation .element-6:focus .subnav, .no-touch .main-navigation .element-7:hover .subnav, .no-touch .main-navigation .element-7:focus .subnav, .no-touch .main-navigation .element-8:hover .subnav, .no-touch .main-navigation .element-8:focus .subnav, .no-touch .main-navigation .last:hover .subnav, .no-touch .main-navigation .last:focus .subnav {
     right: 0;
     display: initial;
-    -webkit-transition-delay: 0.25s;
     -moz-transition-delay: 0.25s;
     -o-transition-delay: 0.25s;
+    -webkit-transition-delay: 0.25s;
     transition-delay: 0.25s; }
   .touch .main-navigation .element-1, .touch .main-navigation .element-2, .touch .main-navigation .element-3, .touch .main-navigation .element-4 {
     /* Position the pointer element */ }
@@ -1731,13 +1791,11 @@ a.button {
   display: block;
   text-align: center;
   font-size: 1.125em;
-  -webkit-border-radius: 8px;
   -moz-border-radius: 8px;
-  -ms-border-radius: 8px;
-  -o-border-radius: 8px;
+  -webkit-border-radius: 8px;
   border-radius: 8px;
-  -webkit-box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   -moz-box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2); }
   .no-touch .main-navigation .menu {
     text-align: center; }
@@ -1765,7 +1823,7 @@ a.button {
     .no-touch .main-navigation .tier-1.element-6, .no-touch .main-navigation .tier-1.element-7 {
       width: auto; }
     .no-touch .main-navigation .tier-1 > a {
-      padding: 0.65em 1.25em 0.55em; }
+      padding: .65em 1.25em .55em; }
   .no-touch .main-navigation .tier-2 {
     font-size: 0.875em; }
 
@@ -1825,7 +1883,7 @@ a.button {
 
 /*.subnav li*/
 .super-navigation {
-  color: #666666;
+  color: #666;
   position: absolute;
   /* relative to the containing LI */
   top: 0;
@@ -1852,7 +1910,7 @@ a.button {
     line-height: 1.25em;
     margin-bottom: 0; }
   .super-navigation p.date-posted {
-    color: #666666;
+    color: #666;
     font-size: 0.625em !important;
     font-style: italic; }
   .super-navigation p.excert {
@@ -1924,7 +1982,7 @@ a.button {
 .text {
   /* Make the intro/first paragraphs slightly larger? */ }
   .text > p:first-of-type {
-    color: #666666;
+    color: #666;
     font-size: 1.125em;
     line-height: 1.6875;
     margin-bottom: 1.25em; }
@@ -2054,7 +2112,7 @@ a.button {
 .home-slideshow .flex-direction-nav .flex-prev, .home-slideshow .flex-direction-nav .flex-next {
   top: 40%;
   font-size: 1.5em;
-  filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+  filter: progid:DXImageTransform.Microsoft.Alpha(enabled=false);
   opacity: 1; }
 .home-slideshow .flex-direction-nav .flex-prev {
   left: -.75em; }
@@ -2073,3 +2131,5 @@ a.button {
 .site-headline a, .site-headline a .python-logo {
   width: 290px;
   height: 82px; }
+
+/*# sourceMappingURL=no-mq.css.map */

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -2,12 +2,15 @@
 /* Define constants for the application and to configure the blueprint framework. */
 /* ===== Compass Imports ===== */
 /* DO NOT include Blueprint here. We are using Susy for the grid, and if Blueprint is here, it will mess things up */
+/* @import "compass/css3/columns" */
+/* @import "compass/css3/hyphenation"; */
 /* Needed for the link-colors() function */
 /* Needed for the horizontal-list() function */
 /* When remembering whether or not there's a hyphen in white-space is too hard */
 /* Use pie-clearfix when there is no width set ont the element to avoid edge cases */
 /* Use to calculate color legibility: http://compass-style.org/reference/compass/utilities/color/contrast/ */
 /* Other interesting functions: 
+	@import "compass/utilities/color/contrast";
 		detailed here: http://compass-style.org/reference/compass/utilities/color/contrast/
 		Used to pass two colors into a get out the most readable color. 
 		Good for situations where we dont want to create a new color, 
@@ -112,13 +115,14 @@
   background-color: #2b5b84;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF1E415E', endColorstr='#FF2B5B84');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMxZTQxNWUiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzJiNWI4NCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #1e415e), color-stop(90%, #2b5b84));
-  background-image: -webkit-linear-gradient(#1e415e 10%, #2b5b84 90%);
   background-image: -moz-linear-gradient(#1e415e 10%, #2b5b84 90%);
-  background-image: -o-linear-gradient(#1e415e 10%, #2b5b84 90%);
+  background-image: -webkit-linear-gradient(#1e415e 10%, #2b5b84 90%);
   background-image: linear-gradient(#1e415e 10%, #2b5b84 90%);
-  -webkit-box-shadow: inset 0 0 50px rgba(0, 0, 0, 0.03), inset 0 0 20px rgba(0, 0, 0, 0.03);
   -moz-box-shadow: inset 0 0 50px rgba(0, 0, 0, 0.03), inset 0 0 20px rgba(0, 0, 0, 0.03);
+  -webkit-box-shadow: inset 0 0 50px rgba(0, 0, 0, 0.03), inset 0 0 20px rgba(0, 0, 0, 0.03);
   box-shadow: inset 0 0 50px rgba(0, 0, 0, 0.03), inset 0 0 20px rgba(0, 0, 0, 0.03); }
 
 .psf-widget, .python-needs-you-widget {
@@ -134,13 +138,14 @@
   background-color: #d8dbde;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFE6E8EA', endColorstr='#FFD8DBDE');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNlNmU4ZWEiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2Q4ZGJkZSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #e6e8ea), color-stop(90%, #d8dbde));
-  background-image: -webkit-linear-gradient(#e6e8ea 10%, #d8dbde 90%);
   background-image: -moz-linear-gradient(#e6e8ea 10%, #d8dbde 90%);
-  background-image: -o-linear-gradient(#e6e8ea 10%, #d8dbde 90%);
+  background-image: -webkit-linear-gradient(#e6e8ea 10%, #d8dbde 90%);
   background-image: linear-gradient(#e6e8ea 10%, #d8dbde 90%);
-  -webkit-box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.01);
   -moz-box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.01);
+  -webkit-box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.01);
   box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.01); }
 
 .pep-widget, .most-recent-events .more-by-location {
@@ -157,13 +162,14 @@
   background-color: #ffdd6c;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFE89F', endColorstr='#FFFFDD6C');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmU4OWYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZmZGQ2YyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffe89f), color-stop(90%, #ffdd6c));
-  background-image: -webkit-linear-gradient(#ffe89f 10%, #ffdd6c 90%);
   background-image: -moz-linear-gradient(#ffe89f 10%, #ffdd6c 90%);
-  background-image: -o-linear-gradient(#ffe89f 10%, #ffdd6c 90%);
+  background-image: -webkit-linear-gradient(#ffe89f 10%, #ffdd6c 90%);
   background-image: linear-gradient(#ffe89f 10%, #ffdd6c 90%);
-  -webkit-box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.05);
   -moz-box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.05);
+  -webkit-box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.05); }
 
 .single-event-date {
@@ -184,95 +190,99 @@
   color: #4d4d4d !important;
   font-weight: normal;
   margin-bottom: 0.4375em;
-  padding: 0.4em 0.75em 0.35em;
+  padding: .4em .75em .35em;
   text-align: left;
   white-space: nowrap;
   text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.3);
   background-color: #cccccc;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFD9D9D9', endColorstr='#FFCCCCCC');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNkOWQ5ZDkiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2NjY2NjYyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #d9d9d9), color-stop(90%, #cccccc));
-  background-image: -webkit-linear-gradient(#d9d9d9 10%, #cccccc 90%);
   background-image: -moz-linear-gradient(#d9d9d9 10%, #cccccc 90%);
-  background-image: -o-linear-gradient(#d9d9d9 10%, #cccccc 90%);
+  background-image: -webkit-linear-gradient(#d9d9d9 10%, #cccccc 90%);
   background-image: linear-gradient(#d9d9d9 10%, #cccccc 90%);
   border-top: 1px solid #caccce;
   border-right: 1px solid #caccce;
-  border-bottom: 1px solid #999999;
+  border-bottom: 1px solid #999;
   border-left: 1px solid #caccce;
-  -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
-  -ms-border-radius: 6px;
-  -o-border-radius: 6px;
+  -webkit-border-radius: 6px;
   border-radius: 6px;
-  -webkit-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05), inset 0 0 5px rgba(255, 255, 255, 0.5);
   -moz-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05), inset 0 0 5px rgba(255, 255, 255, 0.5);
+  -webkit-box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05), inset 0 0 5px rgba(255, 255, 255, 0.5);
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05), inset 0 0 5px rgba(255, 255, 255, 0.5); }
-  .donate-button:hover, .header-banner .button:hover, .header-banner a.button:hover, a.delete:hover, form.deletion-form button[type="submit"]:hover, .search-button:hover, #dive-into-python .flex-control-paging a:hover, .text form button:hover, .text form input[type=submit]:hover,
+  .donate-button:hover, a.delete:hover, form.deletion-form button[type="submit"]:hover, .search-button:hover, #dive-into-python .flex-control-paging a:hover, .text form button:hover, .text form input[type=submit]:hover,
   .sidebar-widget form button:hover,
-  .sidebar-widget form input[type=submit]:hover, input[type=submit]:hover, input[type=reset]:hover, button:hover, .button:hover, .donate-button:focus, .header-banner .button:focus, .header-banner a.button:focus, a.delete:focus, form.deletion-form button[type="submit"]:focus, .search-button:focus, #dive-into-python .flex-control-paging a:focus, .text form button:focus, .text form input[type=submit]:focus,
+  .sidebar-widget form input[type=submit]:hover, input[type=submit]:hover, input[type=reset]:hover, button:hover, .button:hover, .donate-button:focus, a.delete:focus, form.deletion-form button[type="submit"]:focus, .search-button:focus, #dive-into-python .flex-control-paging a:focus, .text form button:focus, .text form input[type=submit]:focus,
   .sidebar-widget form button:focus,
-  .sidebar-widget form input[type=submit]:focus, input[type=submit]:focus, input[type=reset]:focus, button:focus, .button:focus, .donate-button:active, .header-banner .button:active, .header-banner a.button:active, a.delete:active, form.deletion-form button[type="submit"]:active, .search-button:active, #dive-into-python .flex-control-paging a:active, .text form button:active, .text form input[type=submit]:active,
+  .sidebar-widget form input[type=submit]:focus, input[type=submit]:focus, input[type=reset]:focus, button:focus, .button:focus, .donate-button:active, a.delete:active, form.deletion-form button[type="submit"]:active, .search-button:active, #dive-into-python .flex-control-paging a:active, .text form button:active, .text form input[type=submit]:active,
   .sidebar-widget form button:active,
   .sidebar-widget form input[type=submit]:active, input[type=submit]:active, input[type=reset]:active, button:active, .button:active {
     color: #1a1a1a !important;
     background-color: #d9d9d9;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFE6E6E6', endColorstr='#FFD9D9D9');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNlNmU2ZTYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2Q5ZDlkOSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #e6e6e6), color-stop(90%, #d9d9d9));
-    background-image: -webkit-linear-gradient(#e6e6e6 10%, #d9d9d9 90%);
     background-image: -moz-linear-gradient(#e6e6e6 10%, #d9d9d9 90%);
-    background-image: -o-linear-gradient(#e6e6e6 10%, #d9d9d9 90%);
+    background-image: -webkit-linear-gradient(#e6e6e6 10%, #d9d9d9 90%);
     background-image: linear-gradient(#e6e6e6 10%, #d9d9d9 90%); }
 
 .psf-widget .button, .python-needs-you-widget .button, .donate-button, .header-banner .button, .header-banner a.button {
   background-color: #ffd343;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFDF76', endColorstr='#FFFFD343');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmRmNzYiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZmZDM0MyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffdf76), color-stop(90%, #ffd343));
-  background-image: -webkit-linear-gradient(#ffdf76 10%, #ffd343 90%);
   background-image: -moz-linear-gradient(#ffdf76 10%, #ffd343 90%);
-  background-image: -o-linear-gradient(#ffdf76 10%, #ffd343 90%);
+  background-image: -webkit-linear-gradient(#ffdf76 10%, #ffd343 90%);
   background-image: linear-gradient(#ffdf76 10%, #ffd343 90%);
   border-top: 1px solid #dca900;
   border-right: 1px solid #dca900;
   border-bottom: 1px solid #dca900;
   border-left: 1px solid #dca900; }
-  .psf-widget .button:hover, .python-needs-you-widget .button:hover, .donate-button:hover, .header-banner .button:hover, .header-banner a.button:hover, .psf-widget .button:active, .python-needs-you-widget .button:active, .donate-button:active, .header-banner .button:active, .header-banner a.button:active {
+  .psf-widget .button:hover, .python-needs-you-widget .button:hover, .donate-button:hover, .header-banner .button:hover, .psf-widget .button:active, .python-needs-you-widget .button:active, .donate-button:active, .header-banner .button:active {
     background-color: inherit;
     background-color: #ffd343;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFEBA9', endColorstr='#FFFFD343');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmViYTkiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZmZDM0MyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffeba9), color-stop(90%, #ffd343));
-    background-image: -webkit-linear-gradient(#ffeba9 10%, #ffd343 90%);
     background-image: -moz-linear-gradient(#ffeba9 10%, #ffd343 90%);
-    background-image: -o-linear-gradient(#ffeba9 10%, #ffd343 90%);
+    background-image: -webkit-linear-gradient(#ffeba9 10%, #ffd343 90%);
     background-image: linear-gradient(#ffeba9 10%, #ffd343 90%); }
 
 a.delete, form.deletion-form button[type="submit"] {
   background-color: #b55863;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFC57B84', endColorstr='#FFB55863');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNjNTdiODQiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2I1NTg2MyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #c57b84), color-stop(90%, #b55863));
-  background-image: -webkit-linear-gradient(#c57b84 10%, #b55863 90%);
   background-image: -moz-linear-gradient(#c57b84 10%, #b55863 90%);
-  background-image: -o-linear-gradient(#c57b84 10%, #b55863 90%);
+  background-image: -webkit-linear-gradient(#c57b84 10%, #b55863 90%);
   background-image: linear-gradient(#c57b84 10%, #b55863 90%);
   border-top: 1px solid #74333b;
   border-right: 1px solid #74333b;
   border-bottom: 1px solid #74333b;
   border-left: 1px solid #74333b;
-  color: white !important; }
+  color: #fff !important; }
   a.delete:hover, form.deletion-form button[type="submit"]:hover, a.delete:active, form.deletion-form button[type="submit"]:active {
     background-color: inherit;
-    color: white !important;
+    color: #fff !important;
     background-color: #b55863;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFD49FA5', endColorstr='#FFB55863');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNkNDlmYTUiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2I1NTg2MyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #d49fa5), color-stop(90%, #b55863));
-    background-image: -webkit-linear-gradient(#d49fa5 10%, #b55863 90%);
     background-image: -moz-linear-gradient(#d49fa5 10%, #b55863 90%);
-    background-image: -o-linear-gradient(#d49fa5 10%, #b55863 90%);
+    background-image: -webkit-linear-gradient(#d49fa5 10%, #b55863 90%);
     background-image: linear-gradient(#d49fa5 10%, #b55863 90%); }
 
 button[type=submit], .search-button, #dive-into-python .flex-control-paging a, .text form button, .text form input[type=submit],
@@ -283,17 +293,18 @@ button[type=submit], .search-button, #dive-into-python .flex-control-paging a, .
   background-color: #2b5b84;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF3776AB', endColorstr='#FF2B5B84');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMzNzc2YWIiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzJiNWI4NCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #3776ab), color-stop(90%, #2b5b84));
-  background-image: -webkit-linear-gradient(#3776ab 10%, #2b5b84 90%);
   background-image: -moz-linear-gradient(#3776ab 10%, #2b5b84 90%);
-  background-image: -o-linear-gradient(#3776ab 10%, #2b5b84 90%);
+  background-image: -webkit-linear-gradient(#3776ab 10%, #2b5b84 90%);
   background-image: linear-gradient(#3776ab 10%, #2b5b84 90%);
   border-top: 1px solid #3d83be;
   border-right: 1px solid #3776ab;
   border-bottom: 1px solid #3776ab;
   border-left: 1px solid #3d83be;
-  -webkit-box-shadow: inset 0 0 5px rgba(55, 118, 171, 0.2);
   -moz-box-shadow: inset 0 0 5px rgba(55, 118, 171, 0.2);
+  -webkit-box-shadow: inset 0 0 5px rgba(55, 118, 171, 0.2);
   box-shadow: inset 0 0 5px rgba(55, 118, 171, 0.2); }
   button[type=submit]:hover, .search-button:hover, #dive-into-python .flex-control-paging a:hover, .text form button:hover, .text form input[type=submit]:hover,
   .sidebar-widget form button:hover,
@@ -305,10 +316,11 @@ button[type=submit], .search-button, #dive-into-python .flex-control-paging a, .
     background-color: #244e71;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF316998', endColorstr='#FF244E71');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMzMTY5OTgiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzI0NGU3MSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #316998), color-stop(90%, #244e71));
-    background-image: -webkit-linear-gradient(#316998 10%, #244e71 90%);
     background-image: -moz-linear-gradient(#316998 10%, #244e71 90%);
-    background-image: -o-linear-gradient(#316998 10%, #244e71 90%);
+    background-image: -webkit-linear-gradient(#316998 10%, #244e71 90%);
     background-image: linear-gradient(#316998 10%, #244e71 90%); }
 
 .header-banner a:not(.button), .header-banner a:not(.readmore), .text a:not(.button),
@@ -336,8 +348,8 @@ button[type=submit], .search-button, #dive-into-python .flex-control-paging a, .
 .pagination a {
   /* Used in the pagination UL anchors, and in the Previous Next pattern */
   display: block;
-  color: #999999;
-  padding: 0.5em 0.75em 0.4em;
+  color: #999;
+  padding: .5em .75em .4em;
   border: 1px solid #caccce;
   background-color: transparent; }
 
@@ -393,7 +405,7 @@ form, .header-banner, .success-stories-widget .quote-from {
 .slides,
 .flex-control-nav,
 .flex-direction-nav {margin: 0; padding: 0; list-style: none;} */
-                                                                               /* FlexSlider Necessary Styles 
+/* FlexSlider Necessary Styles 
 .flexslider {margin: 0; padding: 0;}
 .flexslider .slides > li {display: none; -webkit-backface-visibility: hidden;} /* Hide the slides before the JS is loaded. Avoids image jumping 
 .flexslider .slides img {width: 100%; display: block;}
@@ -479,14 +491,14 @@ q q:after {
   content: "’"; }
 
 ins {
-  background-color: #dddddd;
-  color: #222222;
+  background-color: #ddd;
+  color: #222;
   text-decoration: none; }
 
 mark {
   display: inline-block;
-  padding: 0 0.25em;
-  margin: 0 -0.125em;
+  padding: 0 .25em;
+  margin: 0 -.125em;
   background-color: #ffb;
   /* light yellow */ }
 
@@ -585,7 +597,7 @@ sub {
   bottom: -0.25em; }
 
 pre, code, kbd, samp, var {
-  font-family: Consolas, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, sans-serif; }
+  font-family: Consolas, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Courier New', monospace, sans-serif; }
 
 pre {
   /* Get spaces to display for PRE tags but dont let long lines break out of containers */
@@ -662,7 +674,6 @@ abbr.truncation {
 /* Stupid IE: http://timkadlec.com/2012/10/ie10-snap-mode-and-responsive-design/ */
 @-ms-viewport {
   width: device-width; }
-
 canvas {
   -ms-touch-action: double-tap-zoom; }
 
@@ -701,20 +712,20 @@ html {
   font: normal 100%/1.625 SourceSansProRegular, Arial, sans-serif; }
 
 body {
-  color: #444444;
-  background-color: white;
+  color: #444;
+  background-color: #fff;
   /* Label the body with our media query parameters. Then check with JS to coordinate @media changes */ }
   body:after {
     content: 'small';
     display: none; }
 
 body, input, textarea, select, button {
-  color: #444444;
+  color: #444;
   font: normal 100%/1.625 SourceSansProRegular, Arial, sans-serif; }
 
 * {
-  -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
   box-sizing: border-box; }
 
 a, a:active, a:visited, a:hover, a:visited:hover {
@@ -726,7 +737,7 @@ a:hover, a:focus {
 
 /*modernizr*/
 .touch a[href^="tel:"] {
-  border-bottom: 1px dotted #444444; }
+  border-bottom: 1px dotted #444; }
 
 a img {
   display: block;
@@ -778,34 +789,34 @@ h1, .alpha {
   margin-bottom: 0.4375em; }
 
 h2, .beta {
-  color: #999999;
+  color: #999;
   font-family: SourceSansProRegular, Arial, sans-serif;
   font-size: 1.5em;
   margin-top: 1.3125em;
   margin-bottom: 0.32813em; }
 
 h3, .chi {
-  color: #222222;
+  color: #222;
   font-size: 1.3125em;
   margin-top: 1.75em;
   margin-bottom: 0.4375em; }
 
 h4, .delta {
-  color: #222222;
+  color: #222;
   font-family: SourceSansProBold, Arial, sans-serif;
   font-size: 1.125em;
   margin-top: 1.3125em;
   margin-bottom: 0.4375em; }
 
 h5, .epsilon {
-  color: #222222;
+  color: #222;
   font-family: SourceSansProBold, Arial, sans-serif;
   text-transform: uppercase;
   letter-spacing: 0.0625em;
   margin-top: 1.75em; }
 
 h6, .gamma {
-  color: #222222;
+  color: #222;
   font-family: SourceSansProBold, Arial, sans-serif;
   margin-top: 1.75em; }
 
@@ -856,7 +867,7 @@ dl {
 
 label {
   display: block;
-  color: #999999;
+  color: #999;
   font-weight: bold;
   margin-top: 0.875em;
   margin-top: 0.21875em; }
@@ -867,10 +878,8 @@ input, textarea {
   width: 100%;
   padding: .65em;
   border: 1px solid #caccce;
-  -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
-  -ms-border-radius: 6px;
-  -o-border-radius: 6px;
+  -webkit-border-radius: 6px;
   border-radius: 6px; }
 
 input, textarea, select {
@@ -887,22 +896,22 @@ input[type=radio] {
 input {
   /*modernizr*/ }
   .no-touch input:focus {
-    -webkit-box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2);
     -moz-box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2);
+    -webkit-box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2);
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2); }
   input[required=required] {
     border-color: #b55863; }
   input[required=required]:focus {
-    -webkit-box-shadow: 0px 0px 10px rgba(255, 0, 0, 0.5);
     -moz-box-shadow: 0px 0px 10px rgba(255, 0, 0, 0.5);
+    -webkit-box-shadow: 0px 0px 10px rgba(255, 0, 0, 0.5);
     box-shadow: 0px 0px 10px rgba(255, 0, 0, 0.5); }
 
 ::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   font-style: italic; }
 
 input:-moz-placeholder {
-  color: #999999;
+  color: #999;
   font-style: italic; }
 
 /* Not a mistake... I repeat a.button and .button so I do not need to add !important to the color declaration */
@@ -910,27 +919,29 @@ input[type=submit], input[type=reset], button, a.button, .button {
   display: block; }
 
 input[type=reset], button.secondaryAction[type=submit] {
-  background-color: #999999;
+  background-color: #999;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFB3B3B3', endColorstr='#FF999999');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNiM2IzYjMiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzk5OTk5OSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #b3b3b3), color-stop(90%, #999999));
-  background-image: -webkit-linear-gradient(#b3b3b3 10%, #999999 90%);
   background-image: -moz-linear-gradient(#b3b3b3 10%, #999999 90%);
-  background-image: -o-linear-gradient(#b3b3b3 10%, #999999 90%);
+  background-image: -webkit-linear-gradient(#b3b3b3 10%, #999999 90%);
   background-image: linear-gradient(#b3b3b3 10%, #999999 90%);
   border-top: 1px solid #caccce;
-  border-right: 1px solid #999999;
+  border-right: 1px solid #999;
   border-bottom: 1px solid gray;
-  border-left: 1px solid #999999; }
+  border-left: 1px solid #999; }
   input[type=reset]:hover, input[type=reset]:focus, input[type=reset]:active, button.secondaryAction[type=submit]:hover, button.secondaryAction[type=submit]:focus, button.secondaryAction[type=submit]:active {
-    color: white;
+    color: #fff;
     background-color: #b3b3b3;
     *zoom: 1;
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF999999', endColorstr='#FFB3B3B3');
+    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiM5OTk5OTkiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2IzYjNiMyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+    background-size: 100%;
     background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #999999), color-stop(90%, #b3b3b3));
-    background-image: -webkit-linear-gradient(#999999 10%, #b3b3b3 90%);
     background-image: -moz-linear-gradient(#999999 10%, #b3b3b3 90%);
-    background-image: -o-linear-gradient(#999999 10%, #b3b3b3 90%);
+    background-image: -webkit-linear-gradient(#999999 10%, #b3b3b3 90%);
     background-image: linear-gradient(#999999 10%, #b3b3b3 90%); }
 
 /* Reset for a special case */
@@ -999,14 +1010,15 @@ h2.not-column {
 
 /* ! ===== MAJOR PAGE ELEMENTS ===== */
 .top-bar a:hover, .top-bar a:focus, .python .top-bar .python-meta a, .psf .top-bar .psf-meta a, .docs .top-bar .docs-meta a, .pypi .top-bar .pypi-meta a, .jobs .top-bar .jobs-meta a, .shop .top-bar .shop-meta a {
-  color: white;
+  color: #fff;
   background-color: #1f2a32;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF13191E', endColorstr='#FF1F2A32');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMxMzE5MWUiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzFmMmEzMiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #13191e), color-stop(90%, #1f2a32));
-  background-image: -webkit-linear-gradient(#13191e 10%, #1f2a32 90%);
   background-image: -moz-linear-gradient(#13191e 10%, #1f2a32 90%);
-  background-image: -o-linear-gradient(#13191e 10%, #1f2a32 90%);
+  background-image: -webkit-linear-gradient(#13191e 10%, #1f2a32 90%);
   background-image: linear-gradient(#13191e 10%, #1f2a32 90%); }
   .top-bar a:hover:before, .top-bar a:focus:before, .python .top-bar .python-meta a:before, .psf .top-bar .psf-meta a:before, .docs .top-bar .docs-meta a:before, .pypi .top-bar .pypi-meta a:before, .jobs .top-bar .jobs-meta a:before, .shop .top-bar .shop-meta a:before {
     left: 50%; }
@@ -1018,10 +1030,10 @@ h2.not-column {
   .top-bar a {
     position: relative;
     display: block;
-    color: #999999;
+    color: #999;
     background: transparent;
     text-align: center;
-    padding: 0.5em 0.75em 0.4em;
+    padding: .5em .75em .4em;
     font-size: 1em;
     line-height: 1.75em;
     /* no fallback for .no-generatedcontent. This is a progressive enhancement */ }
@@ -1070,14 +1082,14 @@ h2.not-column {
 /* Used in both the main-header and the header-banner */
 .main-header {
   border-top: 1px solid #191919;
-  border-bottom: 1px solid #444444; }
+  border-bottom: 1px solid #444; }
   .main-header .container {
     text-align: center;
-    padding: 0.75em 1em; }
+    padding: .75em 1em; }
 
 /*h1*/
 .site-headline {
-  color: white;
+  color: #fff;
   margin: 0.15em auto 0.2em; }
   .site-headline a {
     display: block;
@@ -1101,16 +1113,14 @@ h2.not-column {
 
 .options-bar {
   width: 100%;
-  color: #bbbbbb;
+  color: #bbb;
   margin-bottom: 1.3125em;
   border-top: 1px solid #2d3e4d;
   border-bottom: 1px solid #070a0c;
   background-color: #1e2933;
   line-height: 1em;
-  -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
-  -ms-border-radius: 6px;
-  -o-border-radius: 6px;
+  -webkit-border-radius: 6px;
   border-radius: 6px; }
   .options-bar form {
     padding: 0.35em 0.2em 0.3em; }
@@ -1162,24 +1172,24 @@ input#s,
   border-right: 1px solid #070a0c; }
 
 #site-map-link {
-  color: #bbbbbb; }
+  color: #bbb; }
   #site-map-link:hover, #site-map-link:focus {
-    color: white; }
+    color: #fff; }
   .no-touch #site-map-link {
     display: none; }
 
 .menu-icon {
   display: inline-block;
   font-size: 1.25em;
-  margin: -0.125em -0.125em 0 0; }
+  margin: -.125em -.125em 0 0; }
 
 /*form*/
 .search-the-site {
   text-align: left;
-  padding: 0.35em 0.2em 0.3em; }
+  padding: .35em .2em .3em; }
   .search-the-site .icon-search:before {
     font-size: 1.75em;
-    margin: 0 0.125em 0 0.25em; }
+    margin: 0 .125em 0 .25em; }
   .search-the-site .no-touch {
     border-left: 0; }
 
@@ -1187,30 +1197,28 @@ input#s,
 .search-field {
   width: 4.5em;
   margin-bottom: 0;
-  color: #bbbbbb;
+  color: #bbb;
   background-color: transparent;
   border: none;
-  margin: 0.125em 0;
-  padding: 0.4em 0 0.3em;
-  -webkit-border-radius: 0px;
+  margin: .125em 0;
+  padding: .4em 0 .3em;
   -moz-border-radius: 0px;
-  -ms-border-radius: 0px;
-  -o-border-radius: 0px;
+  -webkit-border-radius: 0px;
   border-radius: 0px; }
   .search-field::-webkit-input-placeholder {
-    color: #bbbbbb;
+    color: #bbb;
     font-style: normal; }
   .search-field:-moz-placeholder {
-    color: #bbbbbb;
+    color: #bbb;
     font-style: normal; }
   .search-field:focus {
-    background-color: white;
-    color: #444444;
-    padding: 0.4em 0.5em 0.3em;
+    background-color: #fff;
+    color: #444;
+    padding: .4em .5em .3em;
     /* removed this line because it was making the height fluctuate on focus:
     @include pe-border( $color-top: darken( $darkerblue, 12% ), $color-bottom: lighten( $darkerblue, 8% ) ); */ }
   .search-field:blur {
-    color: #bbbbbb; }
+    color: #bbb; }
 
 .search-button {
   margin-right: 0.2em;
@@ -1269,7 +1277,7 @@ input#s,
     .account-signin .tier-1 > a,
     .account-signin .tier-2 > a {
       display: block;
-      padding: 0.5em 1.5em 0.4em 1em;
+      padding: .5em 1.5em .4em 1em;
       position: relative; }
   .adjust-font-size .tier-1,
   .winkwink-nudgenudge .tier-1,
@@ -1343,9 +1351,9 @@ input#s,
     .account-signin .subnav {
       min-width: 100%;
       display: none;
-      -webkit-transition: all 0s ease;
       -moz-transition: all 0s ease;
       -o-transition: all 0s ease;
+      -webkit-transition: all 0s ease;
       transition: all 0s ease; }
     .touch .adjust-font-size .subnav, .touch
     .winkwink-nudgenudge .subnav, .touch
@@ -1353,12 +1361,12 @@ input#s,
       top: 120%;
       display: none;
       opacity: 0;
-      -webkit-transition: opacity 0.25s ease-in-out;
       -moz-transition: opacity 0.25s ease-in-out;
       -o-transition: opacity 0.25s ease-in-out;
+      -webkit-transition: opacity 0.25s ease-in-out;
       transition: opacity 0.25s ease-in-out;
-      -webkit-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
       -moz-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
+      -webkit-box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6);
       box-shadow: 0 0.25em 0.75em rgba(0, 0, 0, 0.6); }
       .touch .adjust-font-size .subnav:before, .touch
       .winkwink-nudgenudge .subnav:before, .touch
@@ -1391,9 +1399,9 @@ input#s,
   .account-signin .element-4:focus .subnav {
     left: 0;
     display: initial;
-    -webkit-transition-delay: 0.25s;
     -moz-transition-delay: 0.25s;
     -o-transition-delay: 0.25s;
+    -webkit-transition-delay: 0.25s;
     transition-delay: 0.25s; }
   .no-touch .adjust-font-size .element-5:hover .subnav, .no-touch .adjust-font-size .element-5:focus .subnav, .no-touch .adjust-font-size .element-6:hover .subnav, .no-touch .adjust-font-size .element-6:focus .subnav, .no-touch .adjust-font-size .element-7:hover .subnav, .no-touch .adjust-font-size .element-7:focus .subnav, .no-touch .adjust-font-size .element-8:hover .subnav, .no-touch .adjust-font-size .element-8:focus .subnav, .no-touch .adjust-font-size .last:hover .subnav, .no-touch .adjust-font-size .last:focus .subnav, .no-touch
   .winkwink-nudgenudge .element-5:hover .subnav, .no-touch
@@ -1418,9 +1426,9 @@ input#s,
   .account-signin .last:focus .subnav {
     right: 0;
     display: initial;
-    -webkit-transition-delay: 0.25s;
     -moz-transition-delay: 0.25s;
     -o-transition-delay: 0.25s;
+    -webkit-transition-delay: 0.25s;
     transition-delay: 0.25s; }
   .touch .adjust-font-size .element-1, .touch .adjust-font-size .element-2, .touch .adjust-font-size .element-3, .touch .adjust-font-size .element-4, .touch
   .winkwink-nudgenudge .element-1, .touch
@@ -1523,7 +1531,7 @@ input#s,
   .adjust-font-size a,
   .winkwink-nudgenudge a,
   .account-signin a {
-    color: #bbbbbb;
+    color: #bbb;
     background-color: transparent; }
   .adjust-font-size .tier-1,
   .winkwink-nudgenudge .tier-1,
@@ -1549,7 +1557,7 @@ input#s,
       .account-signin .subnav a:hover,
       .account-signin .subnav a:focus {
         color: #e6e8ea;
-        background-color: #999999; }
+        background-color: #999; }
       .touch .adjust-font-size .subnav a .tier-2, .touch
       .winkwink-nudgenudge .subnav a .tier-2, .touch
       .account-signin .subnav a .tier-2 {
@@ -1563,12 +1571,12 @@ input#s,
     .winkwink-nudgenudge .subnav, .touch
     .account-signin .subnav {
       top: 135%;
-      border: 3px solid #666666; }
+      border: 3px solid #666; }
       .touch .adjust-font-size .subnav:before, .touch
       .winkwink-nudgenudge .subnav:before, .touch
       .account-signin .subnav:before {
         top: -1.6em;
-        border-color: transparent transparent #666666 transparent; }
+        border-color: transparent transparent #666 transparent; }
   .adjust-font-size :hover .subnav,
   .winkwink-nudgenudge :hover .subnav,
   .account-signin :hover .subnav {
@@ -1587,7 +1595,7 @@ input#s,
 .adjust-font-size .tier-1 > a,
 .winkwink-nudgenudge .tier-1 > a,
 .account-signin .tier-1 > a {
-  padding: 1em 1em 0.875em; }
+  padding: 1em 1em .875em; }
 
 /* ! ===== Main navigation – In _layout.scss and _mixins.scss, as we don't display it here ===== */
 .main-navigation {
@@ -1614,8 +1622,8 @@ input#s,
   margin: 0 auto;
   max-width: 61.25em;
   background: #1e2933;
-  -webkit-box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.6);
   -moz-box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.6);
+  -webkit-box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.6);
   box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.6); }
 
 .slide-code,
@@ -1629,9 +1637,9 @@ input#s,
     display: inline-block;
     color: #11a611; }
     .slide-code code .comment {
-      color: #666666; }
+      color: #666; }
     .slide-code code .output {
-      color: #dddddd; }
+      color: #ddd; }
 
 .js .launch-shell, .no-js .launch-shell {
   display: none; }
@@ -1657,11 +1665,11 @@ input#s,
     filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=70);
     opacity: 0.7; }
     #dive-into-python .flex-control-paging a:hover, #dive-into-python .flex-control-paging a:focus {
-      filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+      filter: progid:DXImageTransform.Microsoft.Alpha(enabled=false);
       opacity: 1; }
   #dive-into-python .flex-control-paging .flex-active {
     color: #ffd343 !important;
-    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+    filter: progid:DXImageTransform.Microsoft.Alpha(enabled=false);
     opacity: 1; }
 
 .introduction {
@@ -1678,7 +1686,7 @@ input#s,
     color: #ffd343;
     text-decoration: underline; }
     .introduction a:hover, .introduction a:focus, .introduction a:link:hover, .introduction a:link:focus, .introduction a:visited:hover, .introduction a:visited:focus {
-      color: white; }
+      color: #fff; }
   .introduction .breaker {
     display: none; }
 
@@ -1709,10 +1717,11 @@ input#s,
   background-color: #f9f9f9;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFCFCFC', endColorstr='#FFF9F9F9');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmY2ZjZmMiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2Y5ZjlmOSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #fcfcfc), color-stop(90%, #f9f9f9));
-  background-image: -webkit-linear-gradient(#fcfcfc 10%, #f9f9f9 90%);
   background-image: -moz-linear-gradient(#fcfcfc 10%, #f9f9f9 90%);
-  background-image: -o-linear-gradient(#fcfcfc 10%, #f9f9f9 90%);
+  background-image: -webkit-linear-gradient(#fcfcfc 10%, #f9f9f9 90%);
   background-image: linear-gradient(#fcfcfc 10%, #f9f9f9 90%); }
   .content-wrapper .container {
     padding: 0.25em; }
@@ -1725,7 +1734,7 @@ input#s,
     padding-bottom: 1.75em; }
 
 .page-title {
-  color: #666666;
+  color: #666;
   word-spacing: .15em;
   font-size: 2em; }
   .fontface .page-title {
@@ -1853,7 +1862,7 @@ input#s,
     .sidebar-widget form button,
     .sidebar-widget form input[type=submit] {
       font-size: 1.125em;
-      padding: 0.4em 1em 0.35em; }
+      padding: .4em 1em .35em; }
   .text a:not(.button),
   .sidebar-widget a:not(.button) {
     display: inline;
@@ -1937,7 +1946,7 @@ input#s,
     letter-spacing: 0.125em; }
   .text var,
   .sidebar-widget var {
-    color: #222222;
+    color: #222;
     font-size: 104%;
     font-weight: 700; }
   .text code, .text kbd, .text samp,
@@ -1953,59 +1962,55 @@ input#s,
   .sidebar-widget samp {
     border-bottom: 1px solid #caccce;
     background-color: #e6e8ea;
-    padding: 0.125em 0.375em 0;
-    margin: 0 0.25em; }
+    padding: .125em .375em 0;
+    margin: 0 .25em; }
   .text code, .text kbd,
   .sidebar-widget code,
   .sidebar-widget kbd {
-    padding: 0.125em 0.375em 0;
-    margin: 0 -0.0625em;
+    padding: .125em .375em 0;
+    margin: 0 -.0625em;
     background: #e6e8ea;
     background: rgba(230, 232, 234, 0.5);
-    -webkit-box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset;
     -moz-box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset;
+    -webkit-box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset;
     box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset;
-    -webkit-border-radius: 6px;
     -moz-border-radius: 6px;
-    -ms-border-radius: 6px;
-    -o-border-radius: 6px;
+    -webkit-border-radius: 6px;
     border-radius: 6px; }
   .text pre,
   .sidebar-widget pre {
     padding: .5em;
     border-left: 5px solid #11a611;
     background: #e6e8ea;
-    -webkit-box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset;
     -moz-box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset;
+    -webkit-box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset;
     box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset; }
   .text pre code,
   .sidebar-widget pre code {
     display: block;
     padding: 0;
     margin: 0;
-    -webkit-box-shadow: 0;
     -moz-box-shadow: 0;
+    -webkit-box-shadow: 0;
     box-shadow: 0;
-    -webkit-border-radius: 0;
     -moz-border-radius: 0;
-    -ms-border-radius: 0;
-    -o-border-radius: 0;
+    -webkit-border-radius: 0;
     border-radius: 0; }
   .text s, .text strike, .text del,
   .sidebar-widget s,
   .sidebar-widget strike,
   .sidebar-widget del {
-    color: #999999; }
+    color: #999; }
 
 /* Prettier tables if authors use the correct elements */
 table caption {
   caption-side: top;
-  color: #444444;
+  color: #444;
   font-size: 1.125em;
   text-align: left;
   margin-bottom: 1.75em; }
 table thead, table tfoot {
-  border-bottom: 1px solid #dddddd; }
+  border-bottom: 1px solid #ddd; }
 table tr {
   background-color: #f6f6f6; }
   table tr th {
@@ -2013,49 +2018,49 @@ table tr {
 table tr:nth-of-type(even), table tr.even {
   background-color: #f0f0f0; }
 table th, table td {
-  padding: 0.25em 0.5em 0.2em;
-  border-left: 2px solid white; }
+  padding: .25em .5em .2em;
+  border-left: 2px solid #fff; }
   table th:first-child, table td:first-child {
     border-left: none; }
 table tfoot {
-  border-top: 1px solid #dddddd; }
+  border-top: 1px solid #ddd; }
 
 .row-title {
   border-top: 5px solid #d4dbe1;
   padding: 0.75em 1em 0.5em; }
 
 /* ! ===== Widget Styles ===== */
-.small-widget, .download-list-widget, .most-recent-events, .triple-widget, .most-recent-posts,
+.small-widget, .download-list-widget, .active-release-list-widget, .most-recent-events, .triple-widget, .most-recent-posts,
 .medium-widget,
 .sidebar-widget {
   border-top: 5px solid #e6e8ea;
   padding: 1.25em; }
-  .small-widget h4, .download-list-widget h4, .most-recent-events h4, .triple-widget h4, .most-recent-posts h4,
+  .small-widget h4, .download-list-widget h4, .active-release-list-widget h4, .most-recent-events h4, .triple-widget h4, .most-recent-posts h4,
   .medium-widget h4,
   .sidebar-widget h4 {
     border-top: 1px solid #e6e8ea;
     margin-top: 1.75em;
     padding-top: 0.5em; }
-  .small-widget p, .download-list-widget p, .most-recent-events p, .triple-widget p, .most-recent-posts p,
+  .small-widget p, .download-list-widget p, .active-release-list-widget p, .most-recent-events p, .triple-widget p, .most-recent-posts p,
   .medium-widget p,
-  .sidebar-widget p, .small-widget ul, .download-list-widget ul, .most-recent-events ul, .triple-widget ul, .most-recent-posts ul,
+  .sidebar-widget p, .small-widget ul, .download-list-widget ul, .active-release-list-widget ul, .most-recent-events ul, .triple-widget ul, .most-recent-posts ul,
   .medium-widget ul,
   .sidebar-widget ul {
     margin-bottom: 0.875em; }
-    .small-widget p:last-child, .download-list-widget p:last-child, .most-recent-events p:last-child, .triple-widget p:last-child, .most-recent-posts p:last-child,
+    .small-widget p:last-child, .download-list-widget p:last-child, .active-release-list-widget p:last-child, .most-recent-events p:last-child, .triple-widget p:last-child, .most-recent-posts p:last-child,
     .medium-widget p:last-child,
-    .sidebar-widget p:last-child, .small-widget ul:last-child, .download-list-widget ul:last-child, .most-recent-events ul:last-child, .triple-widget ul:last-child, .most-recent-posts ul:last-child,
+    .sidebar-widget p:last-child, .small-widget ul:last-child, .download-list-widget ul:last-child, .active-release-list-widget ul:last-child, .most-recent-events ul:last-child, .triple-widget ul:last-child, .most-recent-posts ul:last-child,
     .medium-widget ul:last-child,
     .sidebar-widget ul:last-child {
       margin-bottom: 0; }
-  .small-widget li > a, .download-list-widget li > a, .most-recent-events li > a, .triple-widget li > a, .most-recent-posts li > a,
+  .small-widget li > a, .download-list-widget li > a, .active-release-list-widget li > a, .most-recent-events li > a, .triple-widget li > a, .most-recent-posts li > a,
   .medium-widget li > a,
   .sidebar-widget li > a {
     display: inline-block; }
 
 .widget-title,
 .listing-company {
-  color: #444444;
+  color: #444;
   line-height: 1.25em;
   margin: 0 0 0.1em;
   font-family: Flux-Regular, SourceSansProRegular, Arial, sans-serif;
@@ -2078,30 +2083,30 @@ table tfoot {
     margin-right: .25em; }
   .widget-title > span:before,
   .listing-company > span:before {
-    color: #999999; }
+    color: #999; }
 
 /* ! ===== Section Specific Widget Colorways ===== */
-.python .small-widget, .python .download-list-widget, .python .most-recent-events, .python .triple-widget, .python .most-recent-posts, .python
+.python .small-widget, .python .download-list-widget, .python .active-release-list-widget, .python .most-recent-events, .python .triple-widget, .python .most-recent-posts, .python
 .medium-widget, .python
 .sidebar-widget {
   border-top: 4px solid #75a8d3; }
-.psf-home .small-widget, .psf-home .download-list-widget, .psf-home .most-recent-events, .psf-home .triple-widget, .psf-home .most-recent-posts, .psf-home
+.psf-home .small-widget, .psf-home .download-list-widget, .psf-home .active-release-list-widget, .psf-home .most-recent-events, .psf-home .triple-widget, .psf-home .most-recent-posts, .psf-home
 .medium-widget, .psf-home
 .sidebar-widget {
   border-top: 5px solid #caccce; }
-.docs .small-widget, .docs .download-list-widget, .docs .most-recent-events, .docs .triple-widget, .docs .most-recent-posts, .docs
+.docs .small-widget, .docs .download-list-widget, .docs .active-release-list-widget, .docs .most-recent-events, .docs .triple-widget, .docs .most-recent-posts, .docs
 .medium-widget, .docs
 .sidebar-widget {
   border-top: 5px solid #ffd343; }
-.pypl .small-widget, .pypl .download-list-widget, .pypl .most-recent-events, .pypl .triple-widget, .pypl .most-recent-posts, .pypl
+.pypl .small-widget, .pypl .download-list-widget, .pypl .active-release-list-widget, .pypl .most-recent-events, .pypl .triple-widget, .pypl .most-recent-posts, .pypl
 .medium-widget, .pypl
 .sidebar-widget {
   border-top: 5px solid #82b043; }
-.jobs .small-widget, .jobs .download-list-widget, .jobs .most-recent-events, .jobs .triple-widget, .jobs .most-recent-posts, .jobs
+.jobs .small-widget, .jobs .download-list-widget, .jobs .active-release-list-widget, .jobs .most-recent-events, .jobs .triple-widget, .jobs .most-recent-posts, .jobs
 .medium-widget, .jobs
 .sidebar-widget {
   border-top: 5px solid #c9abcd; }
-.shop .small-widget, .shop .download-list-widget, .shop .most-recent-events, .shop .triple-widget, .shop .most-recent-posts, .shop
+.shop .small-widget, .shop .download-list-widget, .shop .active-release-list-widget, .shop .most-recent-events, .shop .triple-widget, .shop .most-recent-posts, .shop
 .medium-widget, .shop
 .sidebar-widget {
   border-top: 5px solid #b55863; }
@@ -2147,24 +2152,23 @@ table tfoot {
   letter-spacing: 0.01em; }
 
 .success-stories-widget blockquote {
-  color: #666666;
-  background-color: #ffe58f;
+  color: #666;
+  background-color: #ffe590;
   padding: 0.7em 1em 0.875em;
   margin-bottom: 0.4375em;
   font-size: 1em;
   line-height: 1.75em;
   background-color: #ffdf76;
   *zoom: 1;
-  filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFE58F', endColorstr='#FFFFDF76');
-  background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffe58f), color-stop(90%, #ffdf76));
-  background-image: -webkit-linear-gradient(#ffe58f 10%, #ffdf76 90%);
-  background-image: -moz-linear-gradient(#ffe58f 10%, #ffdf76 90%);
-  background-image: -o-linear-gradient(#ffe58f 10%, #ffdf76 90%);
-  background-image: linear-gradient(#ffe58f 10%, #ffdf76 90%);
-  -webkit-border-radius: 6px;
+  filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFE590', endColorstr='#FFFFDF76');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNmZmU1OTAiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iI2ZmZGY3NiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
+  background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffe590), color-stop(90%, #ffdf76));
+  background-image: -moz-linear-gradient(#ffe590 10%, #ffdf76 90%);
+  background-image: -webkit-linear-gradient(#ffe590 10%, #ffdf76 90%);
+  background-image: linear-gradient(#ffe590 10%, #ffdf76 90%);
   -moz-border-radius: 6px;
-  -ms-border-radius: 6px;
-  -o-border-radius: 6px;
+  -webkit-border-radius: 6px;
   border-radius: 6px; }
   .success-stories-widget blockquote:after {
     position: absolute;
@@ -2178,7 +2182,7 @@ table tfoot {
     bottom: -2.875em;
     border-top-color: #ffdf76; }
   .success-stories-widget blockquote a {
-    color: #666666; }
+    color: #666; }
     .success-stories-widget blockquote a:hover, .success-stories-widget blockquote a:focus, .success-stories-widget blockquote a:active {
       color: #3776ab; }
 .success-stories-widget .quote-from td {
@@ -2221,7 +2225,7 @@ table tfoot {
   .applications-widget ul {
     border-top: 1px solid #caccce; }
   .applications-widget li {
-    padding: 0.5em 0 0.4em;
+    padding: .5em 0 .4em;
     border-bottom: 1px solid #caccce; }
 
 .shrubbery {
@@ -2233,9 +2237,9 @@ table tfoot {
     top: .25em;
     right: .25em; }
     .shrubbery .give-me-more a {
-      color: #999999; }
+      color: #999; }
       .shrubbery .give-me-more a:hover, .shrubbery .give-me-more a:active {
-        color: #666666; }
+        color: #666; }
 
 /* ! ===== PSF Board Meeting Minutes ===== */
 .draft-preview {
@@ -2258,7 +2262,7 @@ table tfoot {
       .pep-widget .widget-title a:hover, .pep-widget .widget-title a:active {
         color: #1f3b47; }
   .pep-widget .pep-number {
-    color: #666666;
+    color: #666;
     font-family: SourceSansProBold, Arial, sans-serif;
     display: inline-block;
     width: 3em; }
@@ -2275,9 +2279,9 @@ table tfoot {
       color: #3776ab;
       background-color: #f2f4f6;
       border-bottom: 1px solid #e6eaee;
-      padding: 0.6em 0.75em 0.5em; }
+      padding: .6em .75em .5em; }
       .pep-list li a:hover, .pep-list li a:focus, .pep-list li a:active {
-        color: #222222;
+        color: #222;
         background-color: #fefefe; }
 
 .rss-link {
@@ -2317,10 +2321,10 @@ table tfoot {
     display: inline-block;
     color: #3776ab; }
     .pep-index-list a:hover, .pep-index-list a:focus, .pep-index-list a:active {
-      color: #222222; }
+      color: #222; }
 
 .pep-type, .pep-num, .pep-title, .pep-owner {
-  padding: 0.5em 0.5em 0.4em;
+  padding: .5em .5em .4em;
   border-bottom: 1px solid #e3e7ec; }
 
 .footnote .label {
@@ -2330,7 +2334,7 @@ table tfoot {
 .info-key dt, .info-key dd {
   display: block;
   float: left;
-  padding: 0.5em 0.5em 0.4em; }
+  padding: .5em .5em .4em; }
 .info-key dt {
   width: 25%; }
 .info-key dd {
@@ -2348,14 +2352,14 @@ table tfoot {
         </li>
     </ul> */
 .pep-owner-header {
-  margin: 0 -0.5em;
+  margin: 0 -.5em;
   overflow: hidden;
   *zoom: 1; }
   .pep-owner-header .label {
     font-family: SourceSansProBold, Arial, sans-serif;
     float: left;
     width: 50%;
-    padding: 0.25em 0.5em 0.2em; }
+    padding: .25em .5em .2em; }
 
 .pep-owner-list li {
   background-color: #f2f4f6;
@@ -2367,12 +2371,12 @@ table tfoot {
 .pep-owner-list .owner-name, .pep-owner-list .owner-email {
   float: left;
   width: 50%;
-  padding: 0.5em 0.5em 0.4em; }
+  padding: .5em .5em .4em; }
 
 /* ! ===== Success Stories landing page ===== */
 .featured-success-story {
   padding: 1.3125em 0;
-  background: center -230px no-repeat url('../img/success-glow2.png?1543670309') transparent;
+  background: center -230px no-repeat url('../img/success-glow2.png?1576869008') transparent;
   /*blockquote*/ }
   .featured-success-story img {
     padding: 10px 30px; }
@@ -2454,7 +2458,7 @@ p.quote-by-organization {
 .latest-blog-post .readmore, .featured-event .readmore {
   color: #ffd343; }
   .latest-blog-post .readmore:hover, .latest-blog-post .readmore:focus, .featured-event .readmore:hover, .featured-event .readmore:focus {
-    color: white; }
+    color: #fff; }
 
 .most-recent-posts li time {
   position: relative; }
@@ -2466,10 +2470,10 @@ p.quote-by-organization {
   margin-top: 1.3125em; }
 
 .list-recent-events, .list-recent-posts {
-  border-top: 1px solid #dddddd; }
+  border-top: 1px solid #ddd; }
   .list-recent-events li, .list-recent-posts li {
     position: relative;
-    border-bottom: 1px solid #dddddd;
+    border-bottom: 1px solid #ddd;
     padding: 0 0 0.75em; }
     .list-recent-events li .date-start,
     .list-recent-events li .date-end,
@@ -2494,7 +2498,7 @@ p.quote-by-organization {
   /* resets as this is an H3 element and it behaves differently */
   margin-top: .75em;
   margin-bottom: 1.25em;
-  padding: 0.5em 0.75em; }
+  padding: .5em .75em; }
 
 .event-description {
   padding: 1.3125em 0; }
@@ -2505,19 +2509,17 @@ p.quote-by-organization {
 /* ! ===== Community landing page ===== */
 .community-success-stories blockquote {
   padding: 0;
-  color: #666666;
+  color: #666;
   line-height: 1.5; }
   .community-success-stories blockquote:before {
     content: ''; }
 
 .python-weekly {
   background-color: #f2f4f6;
-  -webkit-border-radius: 0 0 8px 8px;
   -moz-border-radius: 0 0 8px 8px;
-  -ms-border-radius: 0 0 8px 8px;
-  -o-border-radius: 0 0 8px 8px;
+  -webkit-border-radius: 0;
   border-radius: 0 0 8px 8px;
-  padding: 0.75em 1em; }
+  padding: .75em 1em; }
 
 /*ul*/
 .twitter-stream li {
@@ -2545,15 +2547,15 @@ p.quote-by-organization {
   /*a*/ }
   .tag-wrapper .tag {
     white-space: nowrap;
-    color: #666666;
+    color: #666;
     font-size: 0.875em;
     vertical-align: baseline;
-    padding: 0.2em 0.4em 0.1em;
+    padding: .2em .4em .1em;
     background-color: #e6e8ea;
     border-top: 1px solid #f2f4f6;
     border-bottom: 1px solid #caccce; }
     .tag-wrapper .tag:hover, .tag-wrapper .tag:focus {
-      color: #444444;
+      color: #444;
       background-color: #d0d4d7;
       border-top: 1px solid #dae0e5;
       border-bottom: 1px solid #b5b8ba; }
@@ -2571,13 +2573,13 @@ p.quote-by-organization {
 /* ! ===== Stylized lists of items, used on Downloads and others ===== */
 .list-row-headings {
   font-family: SourceSansProBold, Arial, sans-serif;
-  padding: 0.5em 0.5em 0.4em 0.75em;
+  padding: .5em .5em .4em .75em;
   margin-right: 1.25em; }
 
 .list-row-container {
   border: 1px solid #caccce; }
   .list-row-container li {
-    padding: 0.5em 0.5em 0.4em 0.75em;
+    padding: .5em .5em .4em .75em;
     margin-right: 0; }
     .list-row-container li:nth-child(odd) {
       background-color: #f2f4f6; }
@@ -2607,7 +2609,7 @@ p.quote-by-organization {
     zoom: 1;
     display: inline; }
 .pagination a:hover, .pagination a:focus {
-  color: #333333;
+  color: #333;
   background-color: #ffd343; }
 .pagination a.active {
   color: #e6e8ea;
@@ -2642,12 +2644,12 @@ p.quote-by-organization {
   .previous-next .prev-button,
   .previous-next .next-button {
     display: block;
-    padding: 0.5em 0.75em 0.4em;
+    padding: .5em .75em .4em;
     margin-bottom: 0.875em; }
     .previous-next .prev-button:not(.disabled):hover, .previous-next .prev-button:not(.disabled):focus,
     .previous-next .next-button:not(.disabled):hover,
     .previous-next .next-button:not(.disabled):focus {
-      color: #333333;
+      color: #333;
       background-color: #ffd343; }
   .previous-next .prev-button-text,
   .previous-next .next-button-text {
@@ -2678,6 +2680,22 @@ p.quote-by-organization {
 .release-number {
   font-family: SourceSansProBold, Arial, sans-serif; }
 
+.release-version,
+.release-status,
+.release-start,
+.release-end,
+.release-pep {
+  display: block; }
+
+.release-version {
+  font-family: SourceSansProBold, Arial, sans-serif; }
+
+.active-release-list-widget .list-row-headings,
+.active-release-list-widget .list-row-container li {
+  font-size: 0.875em; }
+.active-release-list-widget .list-row-container {
+  margin-bottom: .5em; }
+
 .download-list-widget {
   /*modernizr*/ }
   .download-list-widget .list-row-headings,
@@ -2695,7 +2713,7 @@ p.quote-by-organization {
   .main-content .psf-widget a:not(.button), .main-content .python-needs-you-widget a:not(.button) {
     color: #ffd343; }
     .main-content .psf-widget a:not(.button):hover, .main-content .psf-widget a:not(.button):focus, .main-content .python-needs-you-widget a:not(.button):hover, .main-content .python-needs-you-widget a:not(.button):focus {
-      color: #fff1c2; }
+      color: #fff1c3; }
   .psf-widget .widget-title, .psf-widget .readmore, .psf-widget .readmore:before, .python-needs-you-widget .widget-title, .python-needs-you-widget .readmore, .python-needs-you-widget .readmore:before {
     color: #ffd343; }
     .psf-widget .widget-title:hover, .psf-widget .widget-title:focus, .psf-widget .readmore:hover, .psf-widget .readmore:focus, .psf-widget .readmore:before:hover, .psf-widget .readmore:before:focus, .python-needs-you-widget .widget-title:hover, .python-needs-you-widget .widget-title:focus, .python-needs-you-widget .readmore:hover, .python-needs-you-widget .readmore:focus, .python-needs-you-widget .readmore:before:hover, .python-needs-you-widget .readmore:before:focus {
@@ -2710,19 +2728,17 @@ p.quote-by-organization {
         <p role="alert">Can’t find what you’re looking for? <a href="#">Try our comprehensive Help section</a></p>
     </div>*/
 .user-feedback {
-  padding: 0.75em 1em 0.65em;
+  padding: .75em 1em .65em;
   margin-bottom: 1.3125em;
-  -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
-  -ms-border-radius: 6px;
-  -o-border-radius: 6px;
+  -webkit-border-radius: 6px;
   border-radius: 6px; }
   .user-feedback p {
     margin-bottom: 0; }
   .user-feedback a {
     text-decoration: underline; }
     .user-feedback a:hover, .user-feedback a:focus {
-      color: #222222; }
+      color: #222; }
 
 /* A helpful tip */
 .level-general {
@@ -2772,24 +2788,24 @@ p.quote-by-organization {
 /*h2*/
 .listing-company .listing-new {
   display: inline-block;
-  color: white;
+  color: #fff;
   background-color: #b55863;
   font-size: 0.58333em;
   text-transform: uppercase;
   letter-spacing: .0625em;
-  padding: 0.45em 0.5em 0;
+  padding: .45em .5em 0;
   margin-right: .25em; }
 .listing-company .listing-removed {
   display: inline-block;
-  color: white;
-  background-color: #666666;
+  color: #fff;
+  background-color: #666;
   font-size: 0.58333em;
   text-transform: uppercase;
   letter-spacing: .0625em;
-  padding: 0.45em 0.5em 0;
+  padding: .45em .5em 0;
   margin-right: .25em; }
 .listing-company .listing-location a {
-  color: #999999; }
+  color: #999; }
   .listing-company .listing-location a:hover, .listing-company .listing-location a:focus {
     color: #3776ab; }
 
@@ -2820,7 +2836,7 @@ p.quote-by-organization {
 
 /* ! ===== Inner pages ===== */
 .breadcrumbs {
-  padding: 0.5em 0;
+  padding: .5em 0;
   border-bottom: 1px solid #caccce; }
   .breadcrumbs li {
     display: -moz-inline-stack;
@@ -2844,17 +2860,18 @@ p.quote-by-organization {
 
 .section-nav a {
   display: block;
-  padding: 0.3em 0 0.2em; }
+  padding: .3em 0 .2em; }
 
 .psf-sidebar-widget {
   color: #f2f4f6;
   background-color: #3776ab;
   *zoom: 1;
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FF2B5B84', endColorstr='#FF3776AB');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMyYjViODQiLz48c3RvcCBvZmZzZXQ9IjkwJSIgc3RvcC1jb2xvcj0iIzM3NzZhYiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-size: 100%;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #2b5b84), color-stop(90%, #3776ab));
-  background-image: -webkit-linear-gradient(#2b5b84 10%, #3776ab 90%);
   background-image: -moz-linear-gradient(#2b5b84 10%, #3776ab 90%);
-  background-image: -o-linear-gradient(#2b5b84 10%, #3776ab 90%);
+  background-image: -webkit-linear-gradient(#2b5b84 10%, #3776ab 90%);
   background-image: linear-gradient(#2b5b84 10%, #3776ab 90%); }
   .psf-sidebar-widget .widget-title {
     color: #ffd343;
@@ -2862,7 +2879,7 @@ p.quote-by-organization {
     .psf-sidebar-widget .widget-title a {
       color: #ffd343; }
       .psf-sidebar-widget .widget-title a:hover, .psf-sidebar-widget .widget-title a:focus {
-        color: white; }
+        color: #fff; }
 
 /* ! ===== User profile pages and sign up forms ===== */
 .user-profile-controls {
@@ -2894,15 +2911,15 @@ p.quote-by-organization {
   width: 25%; }
 
 .profile-label {
-  color: #999999; }
+  color: #999; }
 
 .psf-codeofconduct {
   font-size: 0.875em;
-  padding: 0.5em 1em;
+  padding: .5em 1em;
   margin-bottom: 1em;
-  background-color: white;
-  -webkit-box-shadow: 0.25em 0.25em 0.75em rgba(0, 0, 0, 0.15);
+  background-color: #fff;
   -moz-box-shadow: 0.25em 0.25em 0.75em rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 0.25em 0.25em 0.75em rgba(0, 0, 0, 0.15);
   box-shadow: 0.25em 0.25em 0.75em rgba(0, 0, 0, 0.15); }
 
 /*p*/
@@ -2925,23 +2942,23 @@ p.quote-by-organization {
 .main-footer .jump-link, .sitemap a, .footer-links a {
   display: block;
   text-align: center;
-  padding: 0.5em 0.75em 0.4em; }
+  padding: .5em .75em .4em; }
 
 .main-footer {
   clear: both;
-  color: #666666;
+  color: #666;
   background-color: #e6e8ea;
   border-top: 1px solid #d8dbde; }
   .main-footer .container {
-    padding: 0 0.75em 0.75em; }
+    padding: 0 .75em .75em; }
   .main-footer a {
-    color: #666666; }
+    color: #666; }
     .main-footer a:hover, .main-footer a:focus {
-      color: #444444; }
+      color: #444; }
   .main-footer .jump-link {
     background-color: #e0e3e5; }
   .main-footer a.jump-link {
-    margin: 0.75em 0;
+    margin: .75em 0;
     border-top: 1px solid #e6e8ea;
     border-bottom: 1px solid #dbdee1; }
     .main-footer a.jump-link:hover, .main-footer a.jump-link:focus {
@@ -2955,13 +2972,13 @@ p.quote-by-organization {
     margin-bottom: 1.3125em; }
     .sitemap .tier-1 > a {
       color: #3776ab;
-      padding: 0.4em 0.5em 0.3em;
+      padding: .4em .5em .3em;
       font-family: Flux-Bold, SourceSansProBold, Arial, sans-serif;
       font-size: 1.25em;
       margin-top: 0.875em;
       margin-bottom: 0em; }
       .sitemap .tier-1 > a:hover, .sitemap .tier-1 > a:focus {
-        color: #222222; }
+        color: #222; }
   .sitemap .subnav {
     font-size: 1em;
     margin-bottom: 0;
@@ -2974,7 +2991,7 @@ p.quote-by-organization {
       background-color: #ecedef; }
 
 .site-base {
-  border-top: 1px solid #111111; }
+  border-top: 1px solid #111; }
   .site-base .container {
     padding: 1em; }
 
@@ -3002,7 +3019,7 @@ p.quote-by-organization {
     border-bottom: 1px dotted #4f90c6;
     color: #75a8d3; }
     .copyright a:hover, .copyright a:focus {
-      color: white;
+      color: #fff;
       text-decoration: none; }
 
 #python-status-indicator {
@@ -3028,7 +3045,7 @@ p.quote-by-organization {
 
 div.note {
   background-color: #eee;
-  border: 1px solid #cccccc;
+  border: 1px solid #ccc;
   padding: 0.3125em 0.625em;
   margin-bottom: 1.5625em; }
   div.note > p {
@@ -3042,7 +3059,7 @@ p.admonition-title:after {
 
 div.warning, form.deletion-form {
   background-color: #ffe4e4;
-  border: 1px solid #ff6666;
+  border: 1px solid #f66;
   padding: 0.3125em 0.625em;
   margin-bottom: 1.5625em; }
   div.warning > p, form.deletion-form > p {
@@ -3058,7 +3075,7 @@ form.deletion-form {
 
 div.sidebar {
   margin: 0 0 0.5em 1em;
-  border: 1px solid #ddddbb;
+  border: 1px solid #ddb;
   padding: 0.4375em 0.4375em 0 0.4375em;
   background-color: #ffe;
   width: 40%;
@@ -3142,17 +3159,17 @@ span.highlighted {
     color: #888;
     margin-left: .5em; }
     .flex-control-nav a:hover, .flex-control-nav a:focus {
-      color: #444444;
+      color: #444;
       background-color: #ccc;
       border-color: #bbb; }
     .text .flex-control-nav a {
       text-decoration: none; }
   .flex-control-nav .flex-active {
-    color: #666666;
-    background-color: white; }
+    color: #666;
+    background-color: #fff; }
   .touch .flex-control-nav a {
     /* Larger touch target */
-    padding: 0.5em 0.75em; }
+    padding: .5em .75em; }
 
 /*<ul class="flex-direction-nav">
     <li>
@@ -3172,9 +3189,9 @@ span.highlighted {
     font-size: 1.25em;
     font-weight: bold;
     line-height: 1em;
-    color: #999999; }
+    color: #999; }
     .flex-direction-nav .flex-prev:hover, .flex-direction-nav .flex-prev:focus, .flex-direction-nav .flex-next:hover, .flex-direction-nav .flex-next:focus {
-      filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+      filter: progid:DXImageTransform.Microsoft.Alpha(enabled=false);
       opacity: 1; }
     .text .flex-direction-nav .flex-prev, .text .flex-direction-nav .flex-next {
       text-decoration: none; }
@@ -3188,7 +3205,7 @@ span.highlighted {
     filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=70);
     opacity: 0.7; }
     .home-slideshow .flex-direction-nav .flex-prev:hover, .home-slideshow .flex-direction-nav .flex-prev:focus, .home-slideshow .flex-direction-nav .flex-next:hover, .home-slideshow .flex-direction-nav .flex-next:focus {
-      filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+      filter: progid:DXImageTransform.Microsoft.Alpha(enabled=false);
       opacity: 1; }
   .home-slideshow .flex-direction-nav .flex-prev {
     left: .75em; }
@@ -3204,7 +3221,7 @@ span.highlighted {
     display: none; } }
 /* ! ==== No JS warning message... more of a suggestion, really ==== */
 #nojs, #oldie-warning {
-  padding: 0.75em 0.75em 0.65em;
+  padding: .75em .75em .65em;
   text-align: center;
   background-color: #c33; }
   #nojs p, #oldie-warning p {
@@ -3273,7 +3290,7 @@ span.highlighted {
 @media print {
   *, *:before, *:after {
     background: transparent !important;
-    color: black !important;
+    color: #000 !important;
     /* Black prints faster: h5bp.com/s */
     box-shadow: none !important;
     text-shadow: none !important; }
@@ -3297,7 +3314,7 @@ span.highlighted {
     content: ""; }
 
   pre, blockquote {
-    border: 1px solid #999999;
+    border: 1px solid #999;
     page-break-inside: avoid; }
 
   thead {
@@ -3312,7 +3329,6 @@ span.highlighted {
 
   @page {
     margin: 0.5cm; }
-
   p, h2, h3 {
     orphans: 3;
     widows: 3; }
@@ -3345,11 +3361,11 @@ span.highlighted {
     .python .site-headline a:before {
       width: 290px;
       height: 82px;
-      content: url('../img/python-logo_print.png?1543670309'); }
+      content: url('../img/python-logo_print.png?1576869008'); }
     .psf .site-headline a:before {
       width: 334px;
       height: 82px;
-      content: url('../img/psf-logo_print.png?1543670309'); } }
+      content: url('../img/psf-logo_print.png?1576869008'); } }
 /*
  * When we want to review the markup for W3 and similar errors, turn some of these on
  * Uses :not selectors a bunch, so only modern browsers will support them
@@ -3383,13 +3399,11 @@ span.highlighted {
 @font-face {
   font-family: 'Pythonicon';
   src: url("../fonts/Pythonicon.eot"); }
-
 @font-face {
   font-family: 'Pythonicon';
   src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMg6v81EAAAC8AAAAYGNtYXCyYwFRAAABHAAAAFxnYXNwAAAAEAAAAXgAAAAIZ2x5ZobYFk4AAAGAAAAxlGhlYWQAPUVrAAAzFAAAADZoaGVhB8MD6QAAM0wAAAAkaG10eKIMAoAAADNwAAAAqGxvY2H4mupyAAA0GAAAAFZtYXhwADkCzAAANHAAAAAgbmFtZY9a7EIAADSQAAABXXBvc3QAAwAAAAA18AAAACAAAwQAAZAABQAAApkCzAAAAI8CmQLMAAAB6wAzAQkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAACDmJwPA/8D/wAPAAEAAAAAAAAAAAAAAAAAAAAAgAAAAAAACAAAAAwAAABQAAwABAAAAFAAEAEgAAAAOAAgAAgAGACAAPwBY5gbmDOYn//8AAAAgAD8AWOYA5gjmDv///+H/w/+rGgQaAxoCAAEAAAAAAAAAAAAAAAAAAAABAAH//wAPAAEAAAAAAAAAAAACAAA3OQEAAAAAAwAA/8AEAAPAABgAHQBxAAABISIOAhURFB4CMyEyPgI1ETQuAiMDIzUzFRMOAwcOAwcOAxUjNTQ+Ajc+Azc+Azc+AzU0LgInLgMjIg4CBw4DByc+Azc+AzMyHgIXHgMVFA4CBwMF/fc0W0QoKERbNAIJNFtEKChEWzS0ubmcBREWHBEMEw8LAwMFAwKyAQMEAwMGCAkFBREXHRIJDgkFAgQGBAQKDA0ICA8ODAUFCQcFArUCCxIZEBAoMTkhGi4pJBAVIBULAwUIBgPAKERbNP33NFtEKChEWzQCCTRbRCj8f76+AecJFRcZDQkRDw0GBhQXFwknCxUSEAcHDg0MBgYQFRkPCA8ODgYGCwoJBAQFBAIDBQgFBQ8TFw4WGS0oIw8PFw8IBQsQCw4iJisYChQTEwkAAAAAAv/+/8ID/gPCABgAJQAAASEiDgIVERQeAjMhMj4CNRE0LgIjEwcnByc3JzcXNxcHFwMC/fc0W0QoKERbNAIJNFtEKChEWzQ3m6Cgm6Cgm6Cgm6CgA8IoRFs0/fc0W0QoKERbNAIJNFtEKP1fm6Cgm6Cgm6Cgm6CgAAAAAAUAAAACBAADgAAqAGcAiQCYANUAAAE0LgIjOAMxIzAOAgcOAxUUHgIXHgMxMzgDMTI+AjUDIi4CJy4DJy4DNTQ+Ajc+Azc+AzMyHgIXHgMXHgMVFA4CBw4DBw4DIwE0PgI3DgMjKgMxBxUXMDoCMzIeAhcuAzUXJxMeAz8BPgImLwElIi4CJy4DJy4DNTQ+Ajc+Azc+AzMyHgIXHgMXHgMVFA4CBw4DBw4DIwQAFSQwG1NGfq9pAwUEAgIEBQNpr35GUxswJBWfBAcHBgIFCQkIBAkNCQUFCQ0JBAgJCQUCBgcHBAQHBwYCBQkJCAQJDQkFBQkNCQQICQkFAgYHBwT9mwEDBAMSIiIjExkbDQI3NwINGxkTIyIiEgMEAwF0gFICBwoMBncGCAQBA3sB8QEDAwIBAgQDAwIDBQQCAgQFAwIDAwQCAQIDAwEBAwMCAQIEAwMCAwUEAgIEBQMCAwMEAgECAwMBAhNLhWM6MEJFFhElKCwXFywoJREWRUIwOmOFS/7KAwUFAgUNEBIKFzU7PyEhPzs1FwoSEA0FAgUFAwMFBQIFDRASChc1Oz8hIT87NRcKEhANBQIFBQMBNhMmJSQRAgQDAV9YXwEDBAIRJCUmE9UZ/r4GCQUBAi8CCQsMBuVdAQICAQIFBgcECRUXGA0NGBcVCQQHBgUCAQICAQECAgECBQYHBAkVFxgNDRgXFQkEBwYFAgECAgEAAAAEABr/7gPjA9MANQBKAHsAkAAAAS4DIyIOAgcOAx0BMxUhIg4CBw4BFBYXHgM7ATU0PgI7ATI+Aj0BNC4CJwciLgI1ND4CMzIeAhUUDgIjBS4DKwEVFA4CKwEiDgIdARQeAhceAjY3PgM9ASM1ITI+Ajc+ATQmJwEyHgIVFA4CIyIuAjU0PgIzAm0PHx8fDw8eHRsNJi8aCe7+uRowJx0HCAgICQYWHykaUhgpNh7uGSsgExMhKxjhCRAMBwcMEAkJEAwHBwwQCQJXBhMcJxpZGCk2Hu4YKyATEyErGBw4Oj4iFishFO4BZRolGxQJCQkJCf6OCRAMBwcMEAkJEAwHBwwQCQPJAwQCAQECBAIHFR4oGlseDx4tHiI5ODsjGiwgEm0dNikYEyEsGeMYKiAWBJoHDBAJCREMBwcMEQkJEAwH5RosIBJqHzcpGBMhLBjjGCceFQcICQEJCgYUHScaWx4RICwbHDg7QCT+OwcMEAkJEQwHBwwRCQkQDAcAAAAH//7/2AP+A9gAGAAnACwAOwBAAEUASgAAASEiDgIVERQeAjMhMj4CNRE0LgIjExQOAiMhIi4CPQEhFTUhNSEVESE1ND4CMyEyHgIdASUhNSEVASEVITURIRUhNQMC/fc0W0QoKERbNAIJNFtEKChEWzS8ITdGJf4KJEY3IgN9/IMDffyDITdGJQH2JUY3If3CAQX++wEF/vsBBf77AQUD2ChEWzT99zRbRCgoRFs0Agk0W0Qo/QImRzYhITZHJkFBf/7+ATs8JEY3IiI3RiQ8YT4+/wA+Pv7CPj4ACAAA/8MD/gPDABoAMQA2ADsAQABFAEoATwAAAREUDgIxMDQYATUFERQeAjMhMj4CNREjAzAOAiMwKgIjIi4CNTwDMSERAzUhFSEFIRUhNREhFSE1NSEVITUVIRUhNSU1IREhA74UGBT8gihEWzQCBzRbRChAfgoSGxGIraIbIkY4JAL9Pf2DAn39gwE7/sUCe/2FATv+xQE7/sUCff78AQQDA/3BJDEeDekBMQEnPgH8/DRbRCgoRFs0AkT9GgcJByE2RSQk5PXA/JwC9S9+f0JC/oJCQv5CQn5CQgL7/sAAAAAABQBCAAgDtwN9ABQAIQA4AE8AXAAAASIOAhUUHgIzMj4CNTQuAiMBJz4DNxcOAwcTIi4CNTQ+Aj8BFx4DFRQOAiMRIg4CByc+AzMyHgIXBy4DIwUuAyc3HgMXBwH8XKF4RkZ4oVxcoXhGRnihXP6oFggZICcXIhQmIyAO9RQjGg8IDxQMKy0LEg0HDxojFAkREREIJhYxNDccDRsaGQxUDh0eHxABQwwiKzMdVTFUPycFnQN9RnihXFyheEZGeKFcXKF4Rv6aFhw1MCsSgAYRFRkO/qwPGiMUDhoWEgbGygYRFRgNFCMaDwG5AQIDAo4OFg8IAgQFA8oFCAUD2R42LiYOzRNAU2Q3QQAAAAYAA//BBAIDwAAYADIAPwCOAKQAuQAAATIeAhURFA4CIyEiLgI1ETQ+AjMhNSEiDgIVERQeAjMhMj4CNRE0LgIjMQE1IxUjETMVMzUzESMXIi4CNTQ+AjcnND4CNy4DNTQ+AjMyHgIXHgMzMj4CNxcOAyMeAxUUDgIHIg4CFRQeAh8BHgMVFA4CIzcnDgMVFB4CMzI+AjU0LgInAyIOAhUUHgIzMj4CNTQuAiMDVwkQDAcHDBAJ/VcJEAwHBwwQCQKp/VcjPi8bGy8+IwKpIz4vGxsvPiP+T3dBQXdCQvQdLiARChAUCx4GCQsGChALBg8bJxgGCgkIAwQJCQoFBgwKCQMJAgYICAQCBAMCDhomGAgMCQUBAwQDPxMeFQsRIC4cGCkMEw4HCBEZERAZEAgFCg8KGwoSDQcHDRIKChINCAcNEgsDQAcMEAn9VwkQDAcHDBAJAqkJEAwHgBsvPiP9VyM+LxsbLz4jAqkjPi8b/VbNzQHRy8v+L50SHyoZEyAYEQQgCA8NCgMHEhYbEBgoHRABAQIBAQIBAQIDBAI0AQMCAQQLDQ8IFigeEgECBQcFAgQEBAEWBxQbIxUXKB0RqAwBChEXDg0YEgsKERULChMQCwMBFQkRFg0NFhAJCRAWDQ0WEQkAAwAB/8IEAQOCACUAYwCEAAABBRUUDgIjIi4CPQElIi4CMREUHgIzITI+AjURMA4CIxEjNTQuAicuAysBIg4CBw4DHQEjIg4CHQEUHgIzBRUUHgIzMj4CPQElMj4CPQE0LgIjJTQ+Ajc+AzsBMh4CFx4DFRwDFSM8AzUDg/7dERsiEREiGxH+3BouIhQUIi4aAwUaLiIUFCIuGsIECQ0JCRUYGg2CDRoYFQkJDQkEwBouIhQUIi4aAVMHDREKChENBwFTGi4iFBQiLhr9/gIEBQMDCQsOCYIJDgsJAwMFBAL+ARkyHREeFg0NFh4RHTIUGBT+5houIhQUIi4aARoUGBQBqEIOGhgVCQkNCAQECA0JCRUYGg5CFCIuGoAaLiIUODQKEQ0ICA0RCjQ4FCIuGoAaLiIUQgkOCwgDAwUEAgIEBQMDCAsOCQgREREICBEREQgAAAUAAP/CBAADwgAeADgAUQCcAKkAAAEiDgIVFB4CMzI+AjU8AS4BJy4DJy4DIwMmDgIXHgMXMDoCMTI+AicuAyclISIOAhURFB4CMyEyPgI1ETQuAiMBFA4CBw4DFRQeAhceAxUUDgIjIi4CNTQ+AjM6AzMuAzU0PgI3KgMjIi4CNTQ+AjMxMwcjHgMVBSMVIzUjNTM1MxUzFQFEHzksGhUmNR8sPCUQAQEBAw8WHREGDQ4OBxwVIhcKBAQWICgVAQEBFCEWCQQEFiAoFQHd/fc0W0QoKERbNAIJNFtEKChEWzT+6AkQFw0NEAkDDBIUBxUdEggcNk8zLVE9JCE5Ti0FCQkJBQYLCAUCAwQCAgUFBQMlPSsYIDVEJNkxRREaEgkBqIUxhYUxhQFKEh8pFxgqIBIRHikYAwYGBgMNFRMTDAIDAgEBlgETIi8cGzElFgEUIy8bHDAkFQHiKERbNP33NFtEKChEWzQCCTRbRCj+nREgHRkLCg8ODgkHExMRBQ8eIScYHTgsGxIhLx0eOCwaBg0PEAkFCwoKBRkrOSEgOiwaIwcZIScUFoWFMYWFMQAAAAAC////wgP/A4EABgAYAAATCQEjESERBQcnIRUUHgIzITI+Aj0BIYEBfwF8vv6CAaDg4f7gKERbNAIJNFtEKP7iAkD+gQF/AUD+wPzh4Yc0W0QoKERbNIcABgAA/8IEAAPCAA4AJwA8AFEAZgB1AAABBycDFzcXARcHFz8CASchIg4CFREUHgIzITI+AjURNC4CIwEiLgI1ND4CMzIeAhUUDgIjNSIuAjU0PgIzMh4CFRQOAiM1Ii4CNTQ+AjMyHgIVFA4CIwEUDgIHJREhMh4CFREC2xlbuiihM/61CiQGHyQ0AX45/fc0W0QoKERbNAIJNFtEKChEWzT9XwoRDQcHDREKChENBwcNEQoKEQ0HBw0RCgoRDQcHDREKChENBwcNEQoKEQ0HBw0RCgNYIjtPLf3hAh8tTzsiAyonOv7bGf0g/fczOh8IOQ0CWNcoRFs0/fc0W0QoKERbNAIJNFtEKPzSCA0RCgoSDQgIDRIKChENCP4IDREKChINCAgNEgoKEQ0I/ggNEQoKEg0ICA0SCgoRDQj+US1PPCMBAgN3IjtPLf49AAAABwB4/8MDiAO+ABQAKQA8AFEAZAByAJcAAAEyPgI1NC4CIyIOAhUUHgIzFzI+AjU0LgIjIg4CFRQeAjMXIg4CBx4DHQEzNTQuAiMlMj4CNTQuAiMiDgIVFB4CMwciDgIdATM1ND4CNy4DIyUiDgIdASE1NC4CIwE0LgIjIg4CFRQeAhcHNx4DMxc3Mj4CNxcnPgM1AgEWJhwQEBwmFhYmHBAQHCYW+xEeFg0NFh4RER4WDQ0WHhEWDxsYFQgDBQMCyRMgKxj98xEeFg0NFh4RER4WDQ0WHhEWGCsgE8kCAwUDCBUYGw8BEyA4KhgBMhgqOCABezxnik9Oimc8GCw+JhFgChQUFAoxMQsVFRQKYBEmPiwYARUQHCYWFiYcEBAcJhYWJhwQHA0WHhERHhYNDRYeEREeFg0lBgwRCgYNDg4HbmQXKB4RJQ0WHhERHhYNDRYeEREeFg0lER4oF2RuBw4ODQYKEQwGIhcnNB6ioh40JxcCSRouIhQUIi4aER8bFwmtoAECAgHCwgECAgGgrQkXGx8RAAAABAAA/8AEAAPAABgAHwAkACsAAAEhIg4CFREUHgIzITI+AjURNC4CIwEHFxUnNxUTIxM3Azc1Nyc1FwcDBf33NFtEKChEWzQCCTRbRCgoRFs0/jd9ff//kUyrTavud3f5+QPAKERbNP33NFtEKChEWzQCCTRbRCj+bmxscNzccP5ZAncB/YhjcGdncNjYAAAADgAA/8IEAAPCABgALQBCAFcAZgBrAHAAdQB6AH8AhACMAJEAlgAAASEiDgIVERQeAjMhMj4CNRE0LgIjBzIeAhUUDgIjIi4CNTQ+AjMjMh4CFRQOAiMiLgI1ND4CMyMyHgIVFA4CIyIuAjU0PgIzASEiLgInEyERFA4CIwMzFSM1OwEVIzUFMxUjNTsBFSM1OwEVIzU7ARUjNQE1IxQeAjM3MxUjNTsBFSM1AwX99zRbRCgoRFs0Agk0W0QoKERbNAcKEg0ICA0SCgoRDQgIDREK/goSDQgIDRIKChENCAgNEQr+ChINCAgNEgoKEQ0ICA0RCgHa/j0tTzwjAQIDdyI7Ty3Hl5fMl5f9nJeXzJeXzJeXzJeX/jKXHCw1GTaXl8yXlwPCKERbNP33NFtEKChEWzQCCTRbRChVBw0RCgoRDQcHDREKChENBwcNEQoKEQ0HBw0RCgoRDQcHDREKChENBwcNEQoKEQ0H/JkiO08tAd/+IS1POyICeZOTk5PVk5OTk5OTk5P+mJMfNigXk5OTk5MAAAAABQBCAAgDtwN9ABQAIQA9AFQAYQAAASIOAhUUHgIzMj4CNTQuAiMBJz4DNxcOAwcTIi4CNTQ+AjcnFz4DMzIeAhUUDgIjESIOAgcnPgMzMh4CFwcuAyMFLgMnNx4DFwcB/FyheEZGeKFcXKF4RkZ4oVz+qBYIGSAnFyIUJiMgDvUUIxoPAQECAW+uAwcHBwQUIxoPDxojFAkREREIJhYxNDccDRsaGQxUDh0eHxABQwwiKzMdVTFUPycFnQN9RnihXFyheEZGeKFcXKF4Rv6aFhw1MCsSgAYRFRkO/qwPGiMUBAcHBwOtbgECAQEPGiMUFCMaDwG5AQIDAo4OFg8IAgQFA8oFCAUD2R42LiYOzRNAU2Q3QQAAAAUAQgAIA7cDfQAUACsAOABUAGEAAAEiDgIVFB4CMzI+AjU0LgIjFTIeAhcHLgMjIg4CByc+AzMBJz4DNxcOAwcFHgIUFRQOAiMiLgI1ND4CMzIeAhc3BzcuAyc3HgMXBwH8XKF4RkZ4oVxcoXhGRnihXA0bGhkMVA4dHh8QCREREQgmFjE0Nxz+qBYIGSAnFyIUJiMgDgFSAQEBDxojFBQjGg8PGiMUBQkJCQSqcOYMIiszHVUxVD8nBZ0DfUZ4oVxcoXhGRnihXFyheEY9AgQFA8oFCAUDAQIDAo4OFg8I/tcWHDUwKxKABhEVGQ7fAwUFBQMUIxoPDxojFBQjGg8BAgMCbrFrHjYuJg7NE0BTZDdBAAMAAP/CBAADwgAYACYAMAAAASEiDgIVERQeAjMhMj4CNRE0LgIjBSE1MxUhFSEVIzUhJzcBIREjESE1IRcHAwX99zRbRCgoRFs0Agk0W0QoKERbNP3AARdHAR7+4kf+6WdnAnP+60f+5wJ1Z2cDwihEWzT99zRbRCgoRFs0Agk0W0QowD09wz4+YGP+AP8AAQDCYWAAAAAABP/+/8AD/gPAABQAIQA6AGoAABMOARQWFx4BMjY3PgE0JicuASIGBxc0LgIjNTIeAhUjASEiDgIVERQeAjMhMj4CNRE0LgIjEwcOASImLwEuATQ2PwEnDgEuAScuATQ2Nz4BMhYXHgIGBxc3PgEyFh8BHgEUBge/HR0dHR1KTUodHR0dHR1KTUod+xUlMhwiOywaGwFI/fc0W0QoKERbNAIJNFtEKChEWzSuaQYPDw8G/QYGBgYcPidcXlkkJycnJydiZmInJCcGGx4+HAYPDw8G/QYGBgYDAh1KTUodHR0dHR1KTUodHR0dHagcMiUVGxosOyIBZihEWzT99zRbRCgoRFs0Agk0W0Qo/LppBgYGBv0GDw8PBhw+HhsGJyQnYmZiJycnJyckWV5cJz4cBgYGBv0GDw8PBgAAAAMAkQARA7ADMAAUACEAUQAAEw4BFBYXHgEyNjc+ATQmJy4BIgYHFzQuAiM1Mh4CFSMBBw4BIiYvAS4BNDY/AScOAS4BJy4BNDY3PgEyFhceAgYHFzc+ATIWHwEeARQGB78dHR0dHUpNSh0dHR0dHUpNSh37FSUyHCI7LBobAfZpBg8PDwb9BgYGBhw+J1xeWSQnJycnJ2JmYickJwYbHj4cBg8PDwb9BgYGBgMCHUpNSh0dHR0dHUpNSh0dHR0dqBwyJRUbGiw7Iv4gaQYGBgb9Bg8PDwYcPh4bBickJ2JmYicnJycnJFleXCc+HAYGBgb9Bg8PDwYABQAA/8IEAAPCABQAKQBCAHgAqQAAJTI+AjU0LgIjIg4CFRQeAjMDIg4CFRQeAjMyPgI1NC4CIyUhIg4CFREUHgIzITI+AjURNC4CIwEVIyIuAicuATQ2Nz4DMyE1IzU0PgI3PgMzMh4CFx4DHQEUDgIrASIOAhUFDgMjIRUzFRQOAgcOAS4BJy4DPQE0PgI7ATI+Aj0BMzIeAhceARQGBwJgCA0KBgYKDQgIDQoGBgoNCL4IDQoGBgoNCAgNCgYGCg0IAWL99zRbRCgoRFs0Agk0W0QoKERbNP4ZQxUiGhIFBwcHBwYYICcVAQ7EBxUmHwsXGBkNDRoaGg0UJBsQDxskFMQZLSIUAnQHEBYeFf7axBEcIxMcMzAuFxMkGxAQGyQUxBgsIhRKFSAXEAUHCAcIYAYKDggIDgoGBgoOCAgOCgYCyAYKDggIDgoGBgoOCAgOCgaaKERbNP33NFtEKChEWzQCCTRbRCj9nFoPGiUWHTEuLxwYJRkNGUsVIRkRBgIDAgEBAgMCAxIbIhS7FSQbEBQiLBgFFiUaDhlLFSAYEQUIBwEIBwYSGSAUuxQkGxAUIi0ZVw8bJBUeNDEuFwAAAAAEAAD/wAQAA8AAFAApAEIBIQAAASIOAhUUHgIzMj4CNTQuAiMhIg4CFRQeAjMyPgI1NC4CIwEhIg4CFREUHgIzITI+AjURNC4CIxMUDgIPAQ4DDwEOAw8BFx4DFxUUHgIXLgM9ATQuAiMwIjgBMQcVMBwCFRQeAhcuAzUwPAI1NC4CIyIOAhUcAzEUDgIjPgM9AQcwDgIdARQOAgc+Az0BIyIuAiceAxc6AzEzNz4DPwEnLgMvAS4DLwEuAzU8AzU0PgI/AScuAzU0PgI3HgMfATc+AzMyHgIfATc+AzceAxUcAQ4BBxUXHgMVMBwCMQKODBUQCQkQFQwMFRAJCRAVDP78DBUQCQkQFQwMFRAJCRAVDAF8/fc0W0QoKERbNAIJNFtEKChEWzRRAgMFAwMBAQEBAQQNJjI+JAwIBwsHBAECBAUDDRYQCQYHBgEBBQECBAMOFA0GAwQFAgIFBAIJDxUMAgMCAQcGBwYIDhQNAgQDATooLB0bFxUhIiccERYNBQYBAQYKDgkMDyhCNSkOBQEBAQEBBAQGBAIGDhYPAgECAwIBAQMEAxEjIyQSAgMPHh4eDw8fHx8PAwIQISMlEwMFAwIBAQECDhcQCQJLCRAWDAwWEAkJEBYMDBYQCQkQFgwMFhAJCRAWDAwWEAkBdShEWzT99zRbRCgoRFs0Agk0W0Qo/nEMFxUUCQkCAwMDAgkZKB4UBgIJCBAREQmsBQkICAMBBgkNCI8HCAQBAQUwPTYGBAgIBwMBBwsOCC45MgMDBQMCAgMFAwM0PDEJDAgEAwYHCAS0AQEECAeTBw0LBwEDBwgIBXcgLjMTAxwfGgEGChIREAcKAgUTHScZCQEDAwMCCQoVFxgNAQEBAQEWKSckEAMDCA8PDwgJExMTCQEHDRIMAQEDBQMCAgMFAwECCxENCAILFhYWCwUKCgoFAwIRJiswGwEBAQAAAAACACL/wgPgA7oAFgBBAAABMj4CNRE0LgIjIg4CFREUHgIzExUeAxUUDgIjIi4CNTQ+Ajc1DgMVFB4CMzI+AjU0LgInAgANFhAKChAWDQ0WEAoKEBYNwCQ7Khc3X39ISIBfNxcpOiQ/aUwqS4KuY2OugksqTGo/AX4JEBcPAb4PFxAJCRAXD/5CDxcQCQHakhc/S1UuSH9fNzdff0guVUs/F5IcWXKHSmOugktLgq5jSodyWRwAAAAABP/+/8AD/gPAABgALQBOAG8AAAEhIg4CFREUHgIzITI+AjURNC4CIwEiLgI1ND4CMzIeAhUUDgIjJSM+AzU0LgIjIg4CBzU+AzMyHgIVFA4CBzMjPgM1NC4CIyIOAgc1PgMzMh4CFRQOAgcDAv33NFtEKChEWzQCCTRbRCgoRFs0/ikYKyATEyArGBgrIBMTICsYATiRBwsIBB81SCkPHRsZDA0aGxwORHhZNAIEBgTnlQMFBAJAb5VVDhwbGg0NGxsbDnPKllcBAgQCA8AoRFs0/fc0W0QoKERbNAIJNFtEKPy2EyArGBgrIBMTICsYGCsgEw4LGBobDilINR8ECAwIkwQHBQM0WXhEDhsaGQwMGRoaDVWVb0ACBAYElQMEAwFXlspzDRoaGg0AAgAA/8IEAAPCABgAMQAAASEiDgIVERQeAjMhMj4CNRE0LgIjAyMRIxEjNTM1ND4COwEVIyIOAh0BMwcDBf33NFtEKChEWzQCCTRbRCgoRFs0X2meT08SKEEvaUISFQoDdw4DwihEWzT99zRbRCgoRFs0Agk0W0Qo/gL+ggF+hE8oQCwXhAcNFA1ChAAE//4AhgP+AwQADwATABcAJwAAASEiDgIdAQUBNTQuAiMTNQcXJRU3JwUnBRQeAjMhMj4CNSUHA4D8+xouIhQB/gICFCIuGn79/fwA+fkB/sD+wxQiLhoDBRotIhT+v8EDBBQiLhoF/QEAAxouIhT+Qfx+fvr4fHz9YJ4aLiIUEyItGp9gAAAAAv/+/8ID/gPCABgAIAAAASEiDgIVERQeAjMhMj4CNRE0LgIjAxEhESMJASMDAv33NFtEKChEWzQCCTRbRCgoRFs0Qf6CvgF8AX+/A8IoRFs0/fc0W0QoKERbNAIJNFtEKP4C/sABQAF//oEAAv/+/8ID/gPCABgAIAAAASEiDgIVERQeAjMhMj4CNRE0LgIjATUhESE1CQEDAv33NFtEKChEWzQCCTRbRCgoRFs0/v3+wAFAAX/+gQPCKERbNP33NFtEKChEWzQCCTRbRCj8fb8Bfr7+hP6BAAAAAAL//v/CA/4DwgAYACAAAAEhIg4CFREUHgIzITI+AjURNC4CIxMhFQkBFSERAwL99zRbRCgoRFs0Agk0W0QoKERbNDr+wP6BAX8BQAPCKERbNP33NFtEKChEWzQCCTRbRCj9Rr4BfAF/v/6CAAL//v/CA/4DwgAYACAAAAEhIg4CFREUHgIzITI+AjURNC4CIwkBMxEhETMBAwL99zRbRCgoRFs0Agk0W0QoKERbNP74/oG/AX6+/oQDwihEWzT99zRbRCgoRFs0Agk0W0Qo/H8BfwFA/sD+gQAAAAAEAAD/wgQAA8IAGABDAG4AmQAAASEiDgIVERQeAjMhMj4CNRE0LgIjASIuAjU0PgIzMh4CFwcuAiIjIg4CFRQeAjMyPgI3Mw4DIxMUHgIXBy4DNTQ+AjMyHgIVFA4CByc+AzU0LgIjIg4CFQEiLgInMx4DMzI+AjU0LgIjKgEOAQcnPgMzMh4CFRQOAiMDBf33NFtEKChEWzQCCTRbRCgoRFs0/jElQjEcHDFCJQoUExIJNwMFBQYDDxoUCwsUGg8NGBMNAm0CHjA/JIEDBQcFNxEbEwocMUIlJUIxHAoTGxE3BQcFAwsUGg8PGhQLAQ4kPzAeAm0CDRMYDQ8aFAsLFBoPAgUFBQI3CBITEwolQjEcHDFCJQPCKERbNP33NFtEKChEWzQCCTRbRCj8wxwxQiUlQjEcAgQGBF8BAQELFBoPDxoUCwkQFg0jPS0aAggHDg0LBV8MICUqFiVCMRwcMUIlFiolIAxfBQsNDgcPGhQLCxQaD/34Gi09Iw0WEAkLFBoPDxoUCwEBAV8EBgQCHDFCJSVCMRwAAAAAAwAo/8AD3wN1ABIAFwAeAAAlAS4BDgEHAQ4BHgEzITI+ASYnBSM1MxUTByMnNTMVA9/+sBZNUkgR/qccAi1YPgJsPlgtARz+gbm5AiJ7Ib7EArAnJAImIv1ONV5GKSlHXzZ/vr4B+/39wMAAAwA+AEYDvgNCAAMACQAPAAATJQ0BFSUHBSUnASUHBSUnPgHCAb7+Qv7XmQHCAb6X/tr+15kBwgG+lwKGu7u+Qn1Avr5A/sN9QL6+QAAAAAADAAD/wgQAA8IAFAAtAHkAAAEiDgIVFB4CMzI+AjU0LgIjEyEiDgIVERQeAjMhMj4CNRE0LgIjExYOAiMiLgInFj4CNy4DJx4BPgE3LgM3HgMzLgI2Nx4DFyY+AjMyHgIXPgM3DgMHNhYyNjcOAwcCsQkQDAcHDBAJCRAMBwcMEAlU/fc0W0QoKERbNAIJNFtEKChEWzQsBDt4snMjQ0A8GyFBPjoaGzEoHggKExMSCR4xIxMBCBITFAobIw0JEB5LVmAzCRItQygSIh8bCw4oKSYMBRshIw0NISIgCwgbHx8MAqIHDBEJCRAMBwcMEAkJEQwHASEoRFs0/fc0W0QoKERbNAIJNFtEKP52V6qHUwoTGxIEBREdFAERHikZAgEBAwIGHyw2HQUHBQMSNDs+HCU9LRoDJ0k4IgcOEwwDFBkZBw4qKSMIAQECBQwTEQ8JAAAABP/+/8AD/gPAABgAQACcALEAAAEhIg4CFREUHgIzITI+AjURNC4CIwEOASoBKwEqAS4BJy4BPgE9ATQmPgE3PgEyFjsBMjYeARcTDgMHJR4BDgEHHgEOAQcOAiYjIg4BIicuAycDPgM3PgM3PgM3PgM3NiY0Njc+AxceAxcWDgIHDgMHDgMHFjYeARcWDgIHHgEUBgcFIg4CFRQeAjMyPgI1NC4CIwMC/fc0W0QoKERbNAIJNFtEKChEWzT+fAQMDxAIcw0ZFA4DAgEBAQIDCgwECw0NBjARIR0XByIBAwQFAwHbDQgGEQwHBgEHBRFAT1YnCRIRDwYGCgkJBCMCBAQDAQgREhQLBgwNDgcJFBINAQEBAQICCg4QCAkPDAgBAQEEBwUFCgoIAwMEAwIBHkdDNgwHAQoRCRAQEA/9qQoRDQcHDREKChENBwcNEQoDwChEWzT99zRbRCgoRFs0Agk0W0Qo/LsCAgQKCQgXGRgJtBAkHxcEAQEBAgIHCP6TAwYFBAHRCB8gGwQGEhQSBhQRBAMBAQEBBAUGAwF5BAgHBgINGRgWCQUIBwgFBhUaHA0FDg4NBQQKBwMCAxAVGAsLFxYTCAgMCwoGBgsMDgkCAgQRFAseHRcEBh8jIAY6CA0SCgoRDQgIDREKChINCAAAAAAE//7/wAP+A8AAGABAAJwAsQAAFyEyPgI1ETQuAiMhIg4CFREUHgIzAT4BOgE7AToBHgEXHgEOAR0BFBYOAQcOASImKwEiBi4BJwM+AzcFLgE+ATcuAT4BNz4CFjMyPgEyFx4DFxMOAwcOAwcOAwcOAwcGFhQGBw4DJy4DJyY+Ajc+Azc+AzcmBi4BJyY+AjcuATQ2NwUyPgI1NC4CIyIOAhUUHgIz+QIJNFtEKChEWzT99zRbRCgoRFs0AYQEDA8QCHMNGRQOAwIBAQECAwoMBAsNDQYwESEdFwciAQMEBQP+JQ0IBhEMBwYBBwURQE9WJwkSEQ8GBgoJCQQjAgQEAwEIERIUCwYMDQ4HCRQSDQEBAQECAgoOEAgJDwwIAQEBBAcFBQoKCAMDBAMCAR5HQzYMBwEKEQkQEBAPAlcKEQ0HBw0RCgoRDQcHDREKQChEWzQCCTRbRCgoRFs0/fc0W0QoA0UCAgQKCQgXGRgJtBAkHxcEAQEBAgIHCAFtAwYFBAHRCB8gGwQGEhQSBhQRBAMBAQEBBAUGA/6HBAgHBgINGRgWCQUIBwgFBhUaHA0FDg4NBQQKBwMCAxAVGAsLFxYTCAgMCwoGBgsMDgkCAgQRFAseHRcEBh8jIAZ1CA0SCgoRDQgIDREKChINCAAABQAA/8AEAAPAAAMABwAgACkAMgAAATMnBwUzJwcBISIOAhURFB4CMyEyPgI1ETQuAiMBJyMHIxMzEyMFJyMHIxMzEyMCdn0+P/5yQCAgAh399zRbRCgoRFs0Agk0W0QoKERbNP5UHGseWIhIhFcB2ya2KGS2YbFiAaXr6zmTkwJUKERbNP33NFtEKChEWzQCCTRbRCj9BWBgAaf+WQGBgQI5/ccAAAAAAwAC/9QD/wO9AAoBaQLJAAABNyMnByMXBzcXJwMiLgInNjQuAScuAycOAhYXHgMXLgMnPgM3Ni4CJw4DBw4BHgEXLgMnPgM3PgImJw4DBw4DFS4DNTwDNRY+Ajc+AzcuASIGBw4DBz4DNx4CNjc+AzcuAwcOAwc+AzceAzMyPgI3NC4CJyYiDgEHPgM3PgMnLgMHDgMHPgM3PgMnDgMHDgIWFw4DBz4DNz4BLgEnDgMHBh4CFw4DBy4DJy4DJw4CFhceAxccAxUUHgIXLgMnLgIiBxQeAhceAT4BNx4DFy4DJyYOAgceAxcWPgI3MC4CMR4DFyIOAgcOAwceAjY3PgM3HgMzOAMxMj4CNTQuAiMBDgMHPgM1PAM1PgM3PgEuAScOAwcOAwcuAyc+AycuAycOAhYXHgMXLgMnPgEuAScuAycGHgIXHgMXLgMnJg4CBwYeAhceAxcuAiIHDgMVHgMzMj4CNx4DFy4DJyYOAgceAxceAT4BNx4DFy4DJy4BIgYHHgMXHgM3HAMVFA4CBzQuAicuAycOAR4BFx4DFw4DBz4CJicuAycOAxceAxcOAwc+Azc+AS4BJw4DBw4CFBcOAyMiDgIVFB4CMzgDOQEyPgI3HgMXHgE+ATcuAycuAyM+AzcwDgIxHgM3PgM3LgMHDgMHPgM3HgI2Nz4DNSYiDgEHAlGBmDovmIE7gYEvcgUJCQkFAwUJBgYNDhAJBwsFAQUCBQcIBBAeHBsMCQ4LBwICAQUJBgsVEQwDAQEBAgIIDw4NBgsTEQ4FBgYCAgMLFhQRBwQGAwEFCAYDChQTEggIDQoGAgkTFBQKBQgHBgMDCQsNCAcQEhMKCxQSEQgEDBAUDAYMDAwFCRQWFwwECw8TCwwaGxwPBw4VDgcODg8HChUVFgsDBQMBAQEEBQYDCRISEQkEBwcHAwwRCQIEFSciHAoJCQMDBAwWFRQJAgQEAwEEBAIHBg8ZFA0DAgIHCwcIDQsJBAECAgMCBAsOEQoHCQMEBQUOEBIKAgQGBAMGBgcEChYWFwsHDRIMCxcXFgoIExYYDQgREhQLDhsaGAoHFBkdEBAcGRUIAQEBESUnKhYKExMTCg4aFRAFDyMkJBAQFw8IAQUJCQkFAwYEAwIEBgMBxwQHBgYDBAYEAgoSEA4FBQQDCQcKEQ4LBAIDAgIBBAkLDQgHCwcCAgMNFBkPBgcCBAQBAwQEAgkUFRYMBAMDCQkKHCInFQQCCREMAwcHBwQJERISCQMGBQQBAQEDBQMLFhUVCgcPDg4HDhUOBw8cGxoMCxMPCwQMFxYUCQULDAwGDBQQDAQIERIUCwoTEhAHCA0LCQMDBgcIBQoUFBMJAgYKDQgIEhMUCgMGCAUBAwYEBxEUFgsDAgIGBgUOERMLBg0ODwgCAgEBAQMMERULBgkFAQICBwsOCQwbHB4QBAgHBQIFAQULBwkQDg0GBgkFAwUJCQkFAwYEAgMEBgMFCQkJBQEIDxcQECQkIw8FEBUaDgoTExMKFionJREBAQEIFRkcEBAdGRQHChgaGw4LFBIRCA0YFhMIChYXFwsMEg0HCxcWFgoB416MjF6kaWmk/nsBAQIBESEgHg0NEw0HAQ4eHx8PBgsKCQQGDxETCwsZGhoNDhcTEAYIExcaDwYNDAwGChQVFgwFDhEUCwsWFRQKAQcMEQwHDxAQCA8fICERAgUFBQIBAgYKBwgRExULBQUHBwMICQoGDx4dHA0GCAMBAwMKDRAJCA0JAwIBBAUHBAwWFBMIBwoHBAQHCQUHDQsHAQEBAwIFCAcGAgEEBQYDAwUDAQECBQUGAwMFBQUDCREQDwcDCxAUCwoTEQ8GCBETFAsECQkJBQ0YFREHCRgbHQ8OFxMPBQ0cHR4PBgsLCwUNFhELAw8iISAODRMMBwEDBwcHAw8eHR0OBAcHBgMJDAYEEiIeGQgIBwEHBhEgHhwNBgoIBQECAggOChAcFQwBAQkRFw0BAQEPGhYSBwMFCAUIFBgcDwoLAggKCRkdIBABAgEBAgQFAwMGBQMBKQMGBwcEDh0dHg8DBwcHAwEHDBMNDiAhIg8DCxEWDQULCwsGDx4dHA0FDxMXDg8dGxgJBxEVGA0FCQkJBAsUExEIBg8REwoLFBALAwcPEBEJAwUFBQMDBgUFAgEBAwUDAwYFBAECBgcIBQIDAQEBBwsNBwUJBwQEBwoHCBMUFgwEBwUEAQIDCQ0ICRANCgMDAQMIBg0cHR4PBgoJCAMHBwUFCxUTEQgHCgYCAQIFBQUCESEgHw8IEBAPBwwRDAcBChQVFgsLFBEOBQwWFRQKBgwMDQYPGhcTCAYQExcODRoaGQsLExEPBgQJCgsGDx8fHg4BBw0TDQ0eICERAQIBAQMFBgMDBQQCAQECARAgHRkJCggCCwoPHBgUCAUIBQMHEhYaDwEBAQ0XEQkBAQwVHBAKDggCAgEFCAoGDRweIBEGBwEHCAgZHiISBAYMCQAAAAUAIP/BA94DvgAEABEAFgAbACAAABMzESMREyEyPgI3IR4DMxMzESMRFzMRIxETMxEjEXyFhX4CCSNBOC4Q/EIQLjhBI1aFhdWFhdWFhQH+/n4Bgv3CEiIvHBwvIhIDOv2CAn5+/gACAAFC/L4DQgAIAAD/wgQAA8IAGAAdACIAJwAsADUAOgA/AAABISIOAhURFB4CMyEyPgI1ETQuAiMNAQclNwcFByU3BwUHJTcHIRUhNQUhETMRIREzEQsBNxMHNwM3EwcDBf33NFtEKChEWzQCCTRbRCgoRFs0/nMBDSX+7ylRATMT/soVIwE/B/7ACAgBQf6/Ab79xUIBuj8us0CsOUEYTQ9EA8IoRFs0/fc0W0QoKERbNAIJNFtEKP2vOqhBmV1CVUqTJEQcTYFNTdIBX/7dASP+oQHXAQsq/vElKAFABf6/BAAAAQAAAAEAAEniMg5fDzz1AAsEAAAAAADOjwBrAAAAAM6PAGv//v/ABAID2AAAAAgAAgAAAAAAAAABAAADwP/AAAAEAP/+//4EAgABAAAAAAAAAAAAAAAAAAAAKgAAAAACAAAABAAAAAQA//4EAAAABAAAGgQA//4EAAAABAAAQgQAAAMEAAABBAAAAAQA//8EAAAABAAAeAQAAAAEAAAABAAAQgQAAEIEAAAABAD//gQAAJEEAAAABAAAAAQAACIEAP/+BAAAAAQA//4EAP/+BAD//gQA//4EAP/+BAAAAAQAACgEAAA+BAAAAAQA//4EAP/+BAAAAAQAAAIEAAAgBAAAAAAAAAAACgCmAOQB9AK0AyIDlAQaBQ4FuAaSBr4HZggyCHoJRgnSClwKqAtGC8IMpA4MDmgO/g9ED4gPvg/2ECwQZBEyEWgRkBI6EzQULBSAGCQYXBjKAAAAAQAAACoCygAOAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAA4ArgABAAAAAAABABYAAAABAAAAAAACAA4AYwABAAAAAAADABYALAABAAAAAAAEABYAcQABAAAAAAAFABYAFgABAAAAAAAGAAsAQgABAAAAAAAKACgAhwADAAEECQABABYAAAADAAEECQACAA4AYwADAAEECQADABYALAADAAEECQAEABYAcQADAAEECQAFABYAFgADAAEECQAGABYATQADAAEECQAKACgAhwBwAHkAdABoAG8AbgBpAGMAbwBuAHMAVgBlAHIAcwBpAG8AbgAgADAALgAwAHAAeQB0AGgAbwBuAGkAYwBvAG4Ac3B5dGhvbmljb25zAHAAeQB0AGgAbwBuAGkAYwBvAG4AcwBSAGUAZwB1AGwAYQByAHAAeQB0AGgAbwBuAGkAYwBvAG4AcwBHAGUAbgBlAHIAYQB0AGUAZAAgAGIAeQAgAEkAYwBvAE0AbwBvAG4AAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==) format("truetype"), url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAADZcAAsAAAAANhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAABCAAAAGAAAABgDq/zUWNtYXAAAAFoAAAAXAAAAFyyYwFRZ2FzcAAAAcQAAAAIAAAACAAAABBnbHlmAAABzAAAMZQAADGUhtgWTmhlYWQAADNgAAAANgAAADYAPUVraGhlYQAAM5gAAAAkAAAAJAfDA+lobXR4AAAzvAAAAKgAAACoogwCgGxvY2EAADRkAAAAVgAAAFb4mupybWF4cAAANLwAAAAgAAAAIAA5AsxuYW1lAAA03AAAAV0AAAFdj1rsQnBvc3QAADY8AAAAIAAAACAAAwAAAAMEAAGQAAUAAAKZAswAAACPApkCzAAAAesAMwEJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAg5icDwP/A/8ADwABAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAgAAAAMAAAAUAAMAAQAAABQABABIAAAADgAIAAIABgAgAD8AWOYG5gzmJ///AAAAIAA/AFjmAOYI5g7////h/8P/qxoEGgMaAgABAAAAAAAAAAAAAAAAAAAAAQAB//8ADwABAAAAAAAAAAAAAgAANzkBAAAAAAMAAP/ABAADwAAYAB0AcQAAASEiDgIVERQeAjMhMj4CNRE0LgIjAyM1MxUTDgMHDgMHDgMVIzU0PgI3PgM3PgM3PgM1NC4CJy4DIyIOAgcOAwcnPgM3PgMzMh4CFx4DFRQOAgcDBf33NFtEKChEWzQCCTRbRCgoRFs0tLm5nAURFhwRDBMPCwMDBQMCsgEDBAMDBggJBQURFx0SCQ4JBQIEBgQECgwNCAgPDgwFBQkHBQK1AgsSGRAQKDE5IRouKSQQFSAVCwMFCAYDwChEWzT99zRbRCgoRFs0Agk0W0Qo/H++vgHnCRUXGQ0JEQ8NBgYUFxcJJwsVEhAHBw4NDAYGEBUZDwgPDg4GBgsKCQQEBQQCAwUIBQUPExcOFhktKCMPDxcPCAULEAsOIiYrGAoUExMJAAAAAAL//v/CA/4DwgAYACUAAAEhIg4CFREUHgIzITI+AjURNC4CIxMHJwcnNyc3FzcXBxcDAv33NFtEKChEWzQCCTRbRCgoRFs0N5ugoJugoJugoJugoAPCKERbNP33NFtEKChEWzQCCTRbRCj9X5ugoJugoJugoJugoAAAAAAFAAAAAgQAA4AAKgBnAIkAmADVAAABNC4CIzgDMSMwDgIHDgMVFB4CFx4DMTM4AzEyPgI1AyIuAicuAycuAzU0PgI3PgM3PgMzMh4CFx4DFx4DFRQOAgcOAwcOAyMBND4CNw4DIyoDMQcVFzA6AjMyHgIXLgM1FycTHgM/AT4CJi8BJSIuAicuAycuAzU0PgI3PgM3PgMzMh4CFx4DFx4DFRQOAgcOAwcOAyMEABUkMBtTRn6vaQMFBAICBAUDaa9+RlMbMCQVnwQHBwYCBQkJCAQJDQkFBQkNCQQICQkFAgYHBwQEBwcGAgUJCQgECQ0JBQUJDQkECAkJBQIGBwcE/ZsBAwQDEiIiIxMZGw0CNzcCDRsZEyMiIhIDBAMBdIBSAgcKDAZ3BggEAQN7AfEBAwMCAQIEAwMCAwUEAgIEBQMCAwMEAgECAwMBAQMDAgECBAMDAgMFBAICBAUDAgMDBAIBAgMDAQITS4VjOjBCRRYRJSgsFxcsKCURFkVCMDpjhUv+ygMFBQIFDRASChc1Oz8hIT87NRcKEhANBQIFBQMDBQUCBQ0QEgoXNTs/ISE/OzUXChIQDQUCBQUDATYTJiUkEQIEAwFfWF8BAwQCESQlJhPVGf6+BgkFAQIvAgkLDAblXQECAgECBQYHBAkVFxgNDRgXFQkEBwYFAgECAgEBAgIBAgUGBwQJFRcYDQ0YFxUJBAcGBQIBAgIBAAAABAAa/+4D4wPTADUASgB7AJAAAAEuAyMiDgIHDgMdATMVISIOAgcOARQWFx4DOwE1ND4COwEyPgI9ATQuAicHIi4CNTQ+AjMyHgIVFA4CIwUuAysBFRQOAisBIg4CHQEUHgIXHgI2Nz4DPQEjNSEyPgI3PgE0JicBMh4CFRQOAiMiLgI1ND4CMwJtDx8fHw8PHh0bDSYvGgnu/rkaMCcdBwgICAkGFh8pGlIYKTYe7hkrIBMTISsY4QkQDAcHDBAJCRAMBwcMEAkCVwYTHCcaWRgpNh7uGCsgExMhKxgcODo+IhYrIRTuAWUaJRsUCQkJCQn+jgkQDAcHDBAJCRAMBwcMEAkDyQMEAgEBAgQCBxUeKBpbHg8eLR4iOTg7IxosIBJtHTYpGBMhLBnjGCogFgSaBwwQCQkRDAcHDBEJCRAMB+UaLCASah83KRgTISwY4xgnHhUHCAkBCQoGFB0nGlseESAsGxw4O0Ak/jsHDBAJCREMBwcMEQkJEAwHAAAAB//+/9gD/gPYABgAJwAsADsAQABFAEoAAAEhIg4CFREUHgIzITI+AjURNC4CIxMUDgIjISIuAj0BIRU1ITUhFREhNTQ+AjMhMh4CHQElITUhFQEhFSE1ESEVITUDAv33NFtEKChEWzQCCTRbRCgoRFs0vCE3RiX+CiRGNyIDffyDA338gyE3RiUB9iVGNyH9wgEF/vsBBf77AQX++wEFA9goRFs0/fc0W0QoKERbNAIJNFtEKP0CJkc2ISE2RyZBQX/+/gE7PCRGNyIiN0YkPGE+Pv8APj7+wj4+AAgAAP/DA/4DwwAaADEANgA7AEAARQBKAE8AAAERFA4CMTA0GAE1BREUHgIzITI+AjURIwMwDgIjMCoCIyIuAjU8AzEhEQM1IRUhBSEVITURIRUhNTUhFSE1FSEVITUlNSERIQO+FBgU/IIoRFs0Agc0W0QoQH4KEhsRiK2iGyJGOCQC/T39gwJ9/YMBO/7FAnv9hQE7/sUBO/7FAn3+/AEEAwP9wSQxHg3pATEBJz4B/Pw0W0QoKERbNAJE/RoHCQchNkUkJOT1wPycAvUvfn9CQv6CQkL+QkJ+QkIC+/7AAAAAAAUAQgAIA7cDfQAUACEAOABPAFwAAAEiDgIVFB4CMzI+AjU0LgIjASc+AzcXDgMHEyIuAjU0PgI/ARceAxUUDgIjESIOAgcnPgMzMh4CFwcuAyMFLgMnNx4DFwcB/FyheEZGeKFcXKF4RkZ4oVz+qBYIGSAnFyIUJiMgDvUUIxoPCA8UDCstCxINBw8aIxQJERERCCYWMTQ3HA0bGhkMVA4dHh8QAUMMIiszHVUxVD8nBZ0DfUZ4oVxcoXhGRnihXFyheEb+mhYcNTArEoAGERUZDv6sDxojFA4aFhIGxsoGERUYDRQjGg8BuQECAwKODhYPCAIEBQPKBQgFA9keNi4mDs0TQFNkN0EAAAAGAAP/wQQCA8AAGAAyAD8AjgCkALkAAAEyHgIVERQOAiMhIi4CNRE0PgIzITUhIg4CFREUHgIzITI+AjURNC4CIzEBNSMVIxEzFTM1MxEjFyIuAjU0PgI3JzQ+AjcuAzU0PgIzMh4CFx4DMzI+AjcXDgMjHgMVFA4CByIOAhUUHgIfAR4DFRQOAiM3Jw4DFRQeAjMyPgI1NC4CJwMiDgIVFB4CMzI+AjU0LgIjA1cJEAwHBwwQCf1XCRAMBwcMEAkCqf1XIz4vGxsvPiMCqSM+LxsbLz4j/k93QUF3QkL0HS4gEQoQFAseBgkLBgoQCwYPGycYBgoJCAMECQkKBQYMCgkDCQIGCAgEAgQDAg4aJhgIDAkFAQMEAz8THhULESAuHBgpDBMOBwgRGREQGRAIBQoPChsKEg0HBw0SCgoSDQgHDRILA0AHDBAJ/VcJEAwHBwwQCQKpCRAMB4AbLz4j/VcjPi8bGy8+IwKpIz4vG/1Wzc0B0cvL/i+dEh8qGRMgGBEEIAgPDQoDBxIWGxAYKB0QAQECAQECAQECAwQCNAEDAgEECw0PCBYoHhIBAgUHBQIEBAQBFgcUGyMVFygdEagMAQoRFw4NGBILChEVCwoTEAsDARUJERYNDRYQCQkQFg0NFhEJAAMAAf/CBAEDggAlAGMAhAAAAQUVFA4CIyIuAj0BJSIuAjERFB4CMyEyPgI1ETAOAiMRIzU0LgInLgMrASIOAgcOAx0BIyIOAh0BFB4CMwUVFB4CMzI+Aj0BJTI+Aj0BNC4CIyU0PgI3PgM7ATIeAhceAxUcAxUjPAM1A4P+3REbIhERIhsR/twaLiIUFCIuGgMFGi4iFBQiLhrCBAkNCQkVGBoNgg0aGBUJCQ0JBMAaLiIUFCIuGgFTBw0RCgoRDQcBUxouIhQUIi4a/f4CBAUDAwkLDgmCCQ4LCQMDBQQC/gEZMh0RHhYNDRYeER0yFBgU/uYaLiIUFCIuGgEaFBgUAahCDhoYFQkJDQgEBAgNCQkVGBoOQhQiLhqAGi4iFDg0ChENCAgNEQo0OBQiLhqAGi4iFEIJDgsIAwMFBAICBAUDAwgLDgkIERERCAgREREIAAAFAAD/wgQAA8IAHgA4AFEAnACpAAABIg4CFRQeAjMyPgI1PAEuAScuAycuAyMDJg4CFx4DFzA6AjEyPgInLgMnJSEiDgIVERQeAjMhMj4CNRE0LgIjARQOAgcOAxUUHgIXHgMVFA4CIyIuAjU0PgIzOgMzLgM1ND4CNyoDIyIuAjU0PgIzMTMHIx4DFQUjFSM1IzUzNTMVMxUBRB85LBoVJjUfLDwlEAEBAQMPFh0RBg0ODgccFSIXCgQEFiAoFQEBARQhFgkEBBYgKBUB3f33NFtEKChEWzQCCTRbRCgoRFs0/ugJEBcNDRAJAwwSFAcVHRIIHDZPMy1RPSQhOU4tBQkJCQUGCwgFAgMEAgIFBQUDJT0rGCA1RCTZMUURGhIJAaiFMYWFMYUBShIfKRcYKiASER4pGAMGBgYDDRUTEwwCAwIBAZYBEyIvHBsxJRYBFCMvGxwwJBUB4ihEWzT99zRbRCgoRFs0Agk0W0Qo/p0RIB0ZCwoPDg4JBxMTEQUPHiEnGB04LBsSIS8dHjgsGgYNDxAJBQsKCgUZKzkhIDosGiMHGSEnFBaFhTGFhTEAAAAAAv///8ID/wOBAAYAGAAAEwkBIxEhEQUHJyEVFB4CMyEyPgI9ASGBAX8BfL7+ggGg4OH+4ChEWzQCCTRbRCj+4gJA/oEBfwFA/sD84eGHNFtEKChEWzSHAAYAAP/CBAADwgAOACcAPABRAGYAdQAAAQcnAxc3FwEXBxc/AgEnISIOAhURFB4CMyEyPgI1ETQuAiMBIi4CNTQ+AjMyHgIVFA4CIzUiLgI1ND4CMzIeAhUUDgIjNSIuAjU0PgIzMh4CFRQOAiMBFA4CByURITIeAhURAtsZW7oooTP+tQokBh8kNAF+Of33NFtEKChEWzQCCTRbRCgoRFs0/V8KEQ0HBw0RCgoRDQcHDREKChENBwcNEQoKEQ0HBw0RCgoRDQcHDREKChENBwcNEQoDWCI7Ty394QIfLU87IgMqJzr+2xn9IP33MzofCDkNAljXKERbNP33NFtEKChEWzQCCTRbRCj80ggNEQoKEg0ICA0SCgoRDQj+CA0RCgoSDQgIDRIKChENCP4IDREKChINCAgNEgoKEQ0I/lEtTzwjAQIDdyI7Ty3+PQAAAAcAeP/DA4gDvgAUACkAPABRAGQAcgCXAAABMj4CNTQuAiMiDgIVFB4CMxcyPgI1NC4CIyIOAhUUHgIzFyIOAgceAx0BMzU0LgIjJTI+AjU0LgIjIg4CFRQeAjMHIg4CHQEzNTQ+AjcuAyMlIg4CHQEhNTQuAiMBNC4CIyIOAhUUHgIXBzceAzMXNzI+AjcXJz4DNQIBFiYcEBAcJhYWJhwQEBwmFvsRHhYNDRYeEREeFg0NFh4RFg8bGBUIAwUDAskTICsY/fMRHhYNDRYeEREeFg0NFh4RFhgrIBPJAgMFAwgVGBsPARMgOCoYATIYKjggAXs8Z4pPTopnPBgsPiYRYAoUFBQKMTELFRUUCmARJj4sGAEVEBwmFhYmHBAQHCYWFiYcEBwNFh4RER4WDQ0WHhERHhYNJQYMEQoGDQ4OB25kFygeESUNFh4RER4WDQ0WHhERHhYNJREeKBdkbgcODg0GChEMBiIXJzQeoqIeNCcXAkkaLiIUFCIuGhEfGxcJraABAgIBwsIBAgIBoK0JFxsfEQAAAAQAAP/ABAADwAAYAB8AJAArAAABISIOAhURFB4CMyEyPgI1ETQuAiMBBxcVJzcVEyMTNwM3NTcnNRcHAwX99zRbRCgoRFs0Agk0W0QoKERbNP43fX3//5FMq02r7nd3+fkDwChEWzT99zRbRCgoRFs0Agk0W0Qo/m5sbHDc3HD+WQJ3Af2IY3BnZ3DY2AAAAA4AAP/CBAADwgAYAC0AQgBXAGYAawBwAHUAegB/AIQAjACRAJYAAAEhIg4CFREUHgIzITI+AjURNC4CIwcyHgIVFA4CIyIuAjU0PgIzIzIeAhUUDgIjIi4CNTQ+AjMjMh4CFRQOAiMiLgI1ND4CMwEhIi4CJxMhERQOAiMDMxUjNTsBFSM1BTMVIzU7ARUjNTsBFSM1OwEVIzUBNSMUHgIzNzMVIzU7ARUjNQMF/fc0W0QoKERbNAIJNFtEKChEWzQHChINCAgNEgoKEQ0ICA0RCv4KEg0ICA0SCgoRDQgIDREK/goSDQgIDRIKChENCAgNEQoB2v49LU88IwECA3ciO08tx5eXzJeX/ZyXl8yXl8yXl8yXl/4ylxwsNRk2l5fMl5cDwihEWzT99zRbRCgoRFs0Agk0W0QoVQcNEQoKEQ0HBw0RCgoRDQcHDREKChENBwcNEQoKEQ0HBw0RCgoRDQcHDREKChENB/yZIjtPLQHf/iEtTzsiAnmTk5OT1ZOTk5OTk5OT/piTHzYoF5OTk5OTAAAAAAUAQgAIA7cDfQAUACEAPQBUAGEAAAEiDgIVFB4CMzI+AjU0LgIjASc+AzcXDgMHEyIuAjU0PgI3Jxc+AzMyHgIVFA4CIxEiDgIHJz4DMzIeAhcHLgMjBS4DJzceAxcHAfxcoXhGRnihXFyheEZGeKFc/qgWCBkgJxciFCYjIA71FCMaDwEBAgFvrgMHBwcEFCMaDw8aIxQJERERCCYWMTQ3HA0bGhkMVA4dHh8QAUMMIiszHVUxVD8nBZ0DfUZ4oVxcoXhGRnihXFyheEb+mhYcNTArEoAGERUZDv6sDxojFAQHBwcDrW4BAgEBDxojFBQjGg8BuQECAwKODhYPCAIEBQPKBQgFA9keNi4mDs0TQFNkN0EAAAAFAEIACAO3A30AFAArADgAVABhAAABIg4CFRQeAjMyPgI1NC4CIxUyHgIXBy4DIyIOAgcnPgMzASc+AzcXDgMHBR4CFBUUDgIjIi4CNTQ+AjMyHgIXNwc3LgMnNx4DFwcB/FyheEZGeKFcXKF4RkZ4oVwNGxoZDFQOHR4fEAkREREIJhYxNDcc/qgWCBkgJxciFCYjIA4BUgEBAQ8aIxQUIxoPDxojFAUJCQkEqnDmDCIrMx1VMVQ/JwWdA31GeKFcXKF4RkZ4oVxcoXhGPQIEBQPKBQgFAwECAwKODhYPCP7XFhw1MCsSgAYRFRkO3wMFBQUDFCMaDw8aIxQUIxoPAQIDAm6xax42LiYOzRNAU2Q3QQADAAD/wgQAA8IAGAAmADAAAAEhIg4CFREUHgIzITI+AjURNC4CIwUhNTMVIRUhFSM1ISc3ASERIxEhNSEXBwMF/fc0W0QoKERbNAIJNFtEKChEWzT9wAEXRwEe/uJH/ulnZwJz/utH/ucCdWdnA8IoRFs0/fc0W0QoKERbNAIJNFtEKMA9PcM+PmBj/gD/AAEAwmFgAAAAAAT//v/AA/4DwAAUACEAOgBqAAATDgEUFhceATI2Nz4BNCYnLgEiBgcXNC4CIzUyHgIVIwEhIg4CFREUHgIzITI+AjURNC4CIxMHDgEiJi8BLgE0Nj8BJw4BLgEnLgE0Njc+ATIWFx4CBgcXNz4BMhYfAR4BFAYHvx0dHR0dSk1KHR0dHR0dSk1KHfsVJTIcIjssGhsBSP33NFtEKChEWzQCCTRbRCgoRFs0rmkGDw8PBv0GBgYGHD4nXF5ZJCcnJycnYmZiJyQnBhsePhwGDw8PBv0GBgYGAwIdSk1KHR0dHR0dSk1KHR0dHR2oHDIlFRsaLDsiAWYoRFs0/fc0W0QoKERbNAIJNFtEKPy6aQYGBgb9Bg8PDwYcPh4bBickJ2JmYicnJycnJFleXCc+HAYGBgb9Bg8PDwYAAAADAJEAEQOwAzAAFAAhAFEAABMOARQWFx4BMjY3PgE0JicuASIGBxc0LgIjNTIeAhUjAQcOASImLwEuATQ2PwEnDgEuAScuATQ2Nz4BMhYXHgIGBxc3PgEyFh8BHgEUBge/HR0dHR1KTUodHR0dHR1KTUod+xUlMhwiOywaGwH2aQYPDw8G/QYGBgYcPidcXlkkJycnJydiZmInJCcGGx4+HAYPDw8G/QYGBgYDAh1KTUodHR0dHR1KTUodHR0dHagcMiUVGxosOyL+IGkGBgYG/QYPDw8GHD4eGwYnJCdiZmInJycnJyRZXlwnPhwGBgYG/QYPDw8GAAUAAP/CBAADwgAUACkAQgB4AKkAACUyPgI1NC4CIyIOAhUUHgIzAyIOAhUUHgIzMj4CNTQuAiMlISIOAhURFB4CMyEyPgI1ETQuAiMBFSMiLgInLgE0Njc+AzMhNSM1ND4CNz4DMzIeAhceAx0BFA4CKwEiDgIVBQ4DIyEVMxUUDgIHDgEuAScuAz0BND4COwEyPgI9ATMyHgIXHgEUBgcCYAgNCgYGCg0ICA0KBgYKDQi+CA0KBgYKDQgIDQoGBgoNCAFi/fc0W0QoKERbNAIJNFtEKChEWzT+GUMVIhoSBQcHBwcGGCAnFQEOxAcVJh8LFxgZDQ0aGhoNFCQbEA8bJBTEGS0iFAJ0BxAWHhX+2sQRHCMTHDMwLhcTJBsQEBskFMQYLCIUShUgFxAFBwgHCGAGCg4ICA4KBgYKDggIDgoGAsgGCg4ICA4KBgYKDggIDgoGmihEWzT99zRbRCgoRFs0Agk0W0Qo/ZxaDxolFh0xLi8cGCUZDRlLFSEZEQYCAwIBAQIDAgMSGyIUuxUkGxAUIiwYBRYlGg4ZSxUgGBEFCAcBCAcGEhkgFLsUJBsQFCItGVcPGyQVHjQxLhcAAAAABAAA/8AEAAPAABQAKQBCASEAAAEiDgIVFB4CMzI+AjU0LgIjISIOAhUUHgIzMj4CNTQuAiMBISIOAhURFB4CMyEyPgI1ETQuAiMTFA4CDwEOAw8BDgMPARceAxcVFB4CFy4DPQE0LgIjMCI4ATEHFTAcAhUUHgIXLgM1MDwCNTQuAiMiDgIVHAMxFA4CIz4DPQEHMA4CHQEUDgIHPgM9ASMiLgInHgMXOgMxMzc+Az8BJy4DLwEuAy8BLgM1PAM1ND4CPwEnLgM1ND4CNx4DHwE3PgMzMh4CHwE3PgM3HgMVHAEOAQcVFx4DFTAcAjECjgwVEAkJEBUMDBUQCQkQFQz+/AwVEAkJEBUMDBUQCQkQFQwBfP33NFtEKChEWzQCCTRbRCgoRFs0UQIDBQMDAQEBAQEEDSYyPiQMCAcLBwQBAgQFAw0WEAkGBwYBAQUBAgQDDhQNBgMEBQICBQQCCQ8VDAIDAgEHBgcGCA4UDQIEAwE6KCwdGxcVISInHBEWDQUGAQEGCg4JDA8oQjUpDgUBAQEBAQQEBgQCBg4WDwIBAgMCAQEDBAMRIyMkEgIDDx4eHg8PHx8fDwMCECEjJRMDBQMCAQEBAg4XEAkCSwkQFgwMFhAJCRAWDAwWEAkJEBYMDBYQCQkQFgwMFhAJAXUoRFs0/fc0W0QoKERbNAIJNFtEKP5xDBcVFAkJAgMDAwIJGSgeFAYCCQgQEREJrAUJCAgDAQYJDQiPBwgEAQEFMD02BgQICAcDAQcLDgguOTIDAwUDAgIDBQMDNDwxCQwIBAMGBwgEtAEBBAgHkwcNCwcBAwcICAV3IC4zEwMcHxoBBgoSERAHCgIFEx0nGQkBAwMDAgkKFRcYDQEBAQEBFiknJBADAwgPDw8ICRMTEwkBBw0SDAEBAwUDAgIDBQMBAgsRDQgCCxYWFgsFCgoKBQMCESYrMBsBAQEAAAAAAgAi/8ID4AO6ABYAQQAAATI+AjURNC4CIyIOAhURFB4CMxMVHgMVFA4CIyIuAjU0PgI3NQ4DFRQeAjMyPgI1NC4CJwIADRYQCgoQFg0NFhAKChAWDcAkOyoXN19/SEiAXzcXKTokP2lMKkuCrmNjroJLKkxqPwF+CRAXDwG+DxcQCQkQFw/+Qg8XEAkB2pIXP0tVLkh/Xzc3X39ILlVLPxeSHFlyh0pjroJLS4KuY0qHclkcAAAAAAT//v/AA/4DwAAYAC0ATgBvAAABISIOAhURFB4CMyEyPgI1ETQuAiMBIi4CNTQ+AjMyHgIVFA4CIyUjPgM1NC4CIyIOAgc1PgMzMh4CFRQOAgczIz4DNTQuAiMiDgIHNT4DMzIeAhUUDgIHAwL99zRbRCgoRFs0Agk0W0QoKERbNP4pGCsgExMgKxgYKyATEyArGAE4kQcLCAQfNUgpDx0bGQwNGhscDkR4WTQCBAYE55UDBQQCQG+VVQ4cGxoNDRsbGw5zypZXAQIEAgPAKERbNP33NFtEKChEWzQCCTRbRCj8thMgKxgYKyATEyArGBgrIBMOCxgaGw4pSDUfBAgMCJMEBwUDNFl4RA4bGhkMDBkaGg1VlW9AAgQGBJUDBAMBV5bKcw0aGhoNAAIAAP/CBAADwgAYADEAAAEhIg4CFREUHgIzITI+AjURNC4CIwMjESMRIzUzNTQ+AjsBFSMiDgIdATMHAwX99zRbRCgoRFs0Agk0W0QoKERbNF9pnk9PEihBL2lCEhUKA3cOA8IoRFs0/fc0W0QoKERbNAIJNFtEKP4C/oIBfoRPKEAsF4QHDRQNQoQABP/+AIYD/gMEAA8AEwAXACcAAAEhIg4CHQEFATU0LgIjEzUHFyUVNycFJwUUHgIzITI+AjUlBwOA/PsaLiIUAf4CAhQiLhp+/f38APn5Af7A/sMUIi4aAwUaLSIU/r/BAwQUIi4aBf0BAAMaLiIU/kH8fn76+Hx8/WCeGi4iFBMiLRqfYAAAAAL//v/CA/4DwgAYACAAAAEhIg4CFREUHgIzITI+AjURNC4CIwMRIREjCQEjAwL99zRbRCgoRFs0Agk0W0QoKERbNEH+gr4BfAF/vwPCKERbNP33NFtEKChEWzQCCTRbRCj+Av7AAUABf/6BAAL//v/CA/4DwgAYACAAAAEhIg4CFREUHgIzITI+AjURNC4CIwE1IREhNQkBAwL99zRbRCgoRFs0Agk0W0QoKERbNP79/sABQAF//oEDwihEWzT99zRbRCgoRFs0Agk0W0Qo/H2/AX6+/oT+gQAAAAAC//7/wgP+A8IAGAAgAAABISIOAhURFB4CMyEyPgI1ETQuAiMTIRUJARUhEQMC/fc0W0QoKERbNAIJNFtEKChEWzQ6/sD+gQF/AUADwihEWzT99zRbRCgoRFs0Agk0W0Qo/Ua+AXwBf7/+ggAC//7/wgP+A8IAGAAgAAABISIOAhURFB4CMyEyPgI1ETQuAiMJATMRIREzAQMC/fc0W0QoKERbNAIJNFtEKChEWzT++P6BvwF+vv6EA8IoRFs0/fc0W0QoKERbNAIJNFtEKPx/AX8BQP7A/oEAAAAABAAA/8IEAAPCABgAQwBuAJkAAAEhIg4CFREUHgIzITI+AjURNC4CIwEiLgI1ND4CMzIeAhcHLgIiIyIOAhUUHgIzMj4CNzMOAyMTFB4CFwcuAzU0PgIzMh4CFRQOAgcnPgM1NC4CIyIOAhUBIi4CJzMeAzMyPgI1NC4CIyoBDgEHJz4DMzIeAhUUDgIjAwX99zRbRCgoRFs0Agk0W0QoKERbNP4xJUIxHBwxQiUKFBMSCTcDBQUGAw8aFAsLFBoPDRgTDQJtAh4wPySBAwUHBTcRGxMKHDFCJSVCMRwKExsRNwUHBQMLFBoPDxoUCwEOJD8wHgJtAg0TGA0PGhQLCxQaDwIFBQUCNwgSExMKJUIxHBwxQiUDwihEWzT99zRbRCgoRFs0Agk0W0Qo/MMcMUIlJUIxHAIEBgRfAQEBCxQaDw8aFAsJEBYNIz0tGgIIBw4NCwVfDCAlKhYlQjEcHDFCJRYqJSAMXwULDQ4HDxoUCwsUGg/9+BotPSMNFhAJCxQaDw8aFAsBAQFfBAYEAhwxQiUlQjEcAAAAAAMAKP/AA98DdQASABcAHgAAJQEuAQ4BBwEOAR4BMyEyPgEmJwUjNTMVEwcjJzUzFQPf/rAWTVJIEf6nHAItWD4CbD5YLQEc/oG5uQIieyG+xAKwJyQCJiL9TjVeRikpR182f76+Afv9/cDAAAMAPgBGA74DQgADAAkADwAAEyUNARUlBwUlJwElBwUlJz4BwgG+/kL+15kBwgG+l/7a/teZAcIBvpcChru7vkJ9QL6+QP7DfUC+vkAAAAAAAwAA/8IEAAPCABQALQB5AAABIg4CFRQeAjMyPgI1NC4CIxMhIg4CFREUHgIzITI+AjURNC4CIxMWDgIjIi4CJxY+AjcuAyceAT4BNy4DNx4DMy4CNjceAxcmPgIzMh4CFz4DNw4DBzYWMjY3DgMHArEJEAwHBwwQCQkQDAcHDBAJVP33NFtEKChEWzQCCTRbRCgoRFs0LAQ7eLJzI0NAPBshQT46GhsxKB4IChMTEgkeMSMTAQgSExQKGyMNCRAeS1ZgMwkSLUMoEiIfGwsOKCkmDAUbISMNDSEiIAsIGx8fDAKiBwwRCQkQDAcHDBAJCREMBwEhKERbNP33NFtEKChEWzQCCTRbRCj+dleqh1MKExsSBAURHRQBER4pGQIBAQMCBh8sNh0FBwUDEjQ7PhwlPS0aAydJOCIHDhMMAxQZGQcOKikjCAEBAgUMExEPCQAAAAT//v/AA/4DwAAYAEAAnACxAAABISIOAhURFB4CMyEyPgI1ETQuAiMBDgEqASsBKgEuAScuAT4BPQE0Jj4BNz4BMhY7ATI2HgEXEw4DByUeAQ4BBx4BDgEHDgImIyIOASInLgMnAz4DNz4DNz4DNz4DNzYmNDY3PgMXHgMXFg4CBw4DBw4DBxY2HgEXFg4CBx4BFAYHBSIOAhUUHgIzMj4CNTQuAiMDAv33NFtEKChEWzQCCTRbRCgoRFs0/nwEDA8QCHMNGRQOAwIBAQECAwoMBAsNDQYwESEdFwciAQMEBQMB2w0IBhEMBwYBBwURQE9WJwkSEQ8GBgoJCQQjAgQEAwEIERIUCwYMDQ4HCRQSDQEBAQECAgoOEAgJDwwIAQEBBAcFBQoKCAMDBAMCAR5HQzYMBwEKEQkQEBAP/akKEQ0HBw0RCgoRDQcHDREKA8AoRFs0/fc0W0QoKERbNAIJNFtEKPy7AgIECgkIFxkYCbQQJB8XBAEBAQICBwj+kwMGBQQB0QgfIBsEBhIUEgYUEQQDAQEBAQQFBgMBeQQIBwYCDRkYFgkFCAcIBQYVGhwNBQ4ODQUECgcDAgMQFRgLCxcWEwgIDAsKBgYLDA4JAgIEERQLHh0XBAYfIyAGOggNEgoKEQ0ICA0RCgoSDQgAAAAABP/+/8AD/gPAABgAQACcALEAABchMj4CNRE0LgIjISIOAhURFB4CMwE+AToBOwE6AR4BFx4BDgEdARQWDgEHDgEiJisBIgYuAScDPgM3BS4BPgE3LgE+ATc+AhYzMj4BMhceAxcTDgMHDgMHDgMHDgMHBhYUBgcOAycuAycmPgI3PgM3PgM3JgYuAScmPgI3LgE0NjcFMj4CNTQuAiMiDgIVFB4CM/kCCTRbRCgoRFs0/fc0W0QoKERbNAGEBAwPEAhzDRkUDgMCAQEBAgMKDAQLDQ0GMBEhHRcHIgEDBAUD/iUNCAYRDAcGAQcFEUBPVicJEhEPBgYKCQkEIwIEBAMBCBESFAsGDA0OBwkUEg0BAQEBAgIKDhAICQ8MCAEBAQQHBQUKCggDAwQDAgEeR0M2DAcBChEJEBAQDwJXChENBwcNEQoKEQ0HBw0RCkAoRFs0Agk0W0QoKERbNP33NFtEKANFAgIECgkIFxkYCbQQJB8XBAEBAQICBwgBbQMGBQQB0QgfIBsEBhIUEgYUEQQDAQEBAQQFBgP+hwQIBwYCDRkYFgkFCAcIBQYVGhwNBQ4ODQUECgcDAgMQFRgLCxcWEwgIDAsKBgYLDA4JAgIEERQLHh0XBAYfIyAGdQgNEgoKEQ0ICA0RCgoSDQgAAAUAAP/ABAADwAADAAcAIAApADIAAAEzJwcFMycHASEiDgIVERQeAjMhMj4CNRE0LgIjAScjByMTMxMjBScjByMTMxMjAnZ9Pj/+ckAgIAId/fc0W0QoKERbNAIJNFtEKChEWzT+VBxrHliISIRXAdsmtihktmGxYgGl6+s5k5MCVChEWzT99zRbRCgoRFs0Agk0W0Qo/QVgYAGn/lkBgYECOf3HAAAAAAMAAv/UA/8DvQAKAWkCyQAAATcjJwcjFwc3FycDIi4CJzY0LgEnLgMnDgIWFx4DFy4DJz4DNzYuAicOAwcOAR4BFy4DJz4DNz4CJicOAwcOAxUuAzU8AzUWPgI3PgM3LgEiBgcOAwc+AzceAjY3PgM3LgMHDgMHPgM3HgMzMj4CNzQuAicmIg4BBz4DNz4DJy4DBw4DBz4DNz4DJw4DBw4CFhcOAwc+Azc+AS4BJw4DBwYeAhcOAwcuAycuAycOAhYXHgMXHAMVFB4CFy4DJy4CIgcUHgIXHgE+ATceAxcuAycmDgIHHgMXFj4CNzAuAjEeAxciDgIHDgMHHgI2Nz4DNx4DMzgDMTI+AjU0LgIjAQ4DBz4DNTwDNT4DNz4BLgEnDgMHDgMHLgMnPgMnLgMnDgIWFx4DFy4DJz4BLgEnLgMnBh4CFx4DFy4DJyYOAgcGHgIXHgMXLgIiBw4DFR4DMzI+AjceAxcuAycmDgIHHgMXHgE+ATceAxcuAycuASIGBx4DFx4DNxwDFRQOAgc0LgInLgMnDgEeARceAxcOAwc+AiYnLgMnDgMXHgMXDgMHPgM3PgEuAScOAwcOAhQXDgMjIg4CFRQeAjM4AzkBMj4CNx4DFx4BPgE3LgMnLgMjPgM3MA4CMR4DNz4DNy4DBw4DBz4DNx4CNjc+AzUmIg4BBwJRgZg6L5iBO4GBL3IFCQkJBQMFCQYGDQ4QCQcLBQEFAgUHCAQQHhwbDAkOCwcCAgEFCQYLFREMAwEBAQICCA8ODQYLExEOBQYGAgIDCxYUEQcEBgMBBQgGAwoUExIICA0KBgIJExQUCgUIBwYDAwkLDQgHEBITCgsUEhEIBAwQFAwGDAwMBQkUFhcMBAsPEwsMGhscDwcOFQ4HDg4PBwoVFRYLAwUDAQEBBAUGAwkSEhEJBAcHBwMMEQkCBBUnIhwKCQkDAwQMFhUUCQIEBAMBBAQCBwYPGRQNAwICBwsHCA0LCQQBAgIDAgQLDhEKBwkDBAUFDhASCgIEBgQDBgYHBAoWFhcLBw0SDAsXFxYKCBMWGA0IERIUCw4bGhgKBxQZHRAQHBkVCAEBARElJyoWChMTEwoOGhUQBQ8jJCQQEBcPCAEFCQkJBQMGBAMCBAYDAccEBwYGAwQGBAIKEhAOBQUEAwkHChEOCwQCAwICAQQJCw0IBwsHAgIDDRQZDwYHAgQEAQMEBAIJFBUWDAQDAwkJChwiJxUEAgkRDAMHBwcECRESEgkDBgUEAQEBAwUDCxYVFQoHDw4OBw4VDgcPHBsaDAsTDwsEDBcWFAkFCwwMBgwUEAwECBESFAsKExIQBwgNCwkDAwYHCAUKFBQTCQIGCg0ICBITFAoDBggFAQMGBAcRFBYLAwICBgYFDhETCwYNDg8IAgIBAQEDDBEVCwYJBQECAgcLDgkMGxweEAQIBwUCBQEFCwcJEA4NBgYJBQMFCQkJBQMGBAIDBAYDBQkJCQUBCA8XEBAkJCMPBRAVGg4KExMTChYqJyURAQEBCBUZHBAQHRkUBwoYGhsOCxQSEQgNGBYTCAoWFxcLDBINBwsXFhYKAeNejIxepGlppP57AQECAREhIB4NDRMNBwEOHh8fDwYLCgkEBg8REwsLGRoaDQ4XExAGCBMXGg8GDQwMBgoUFRYMBQ4RFAsLFhUUCgEHDBEMBw8QEAgPHyAhEQIFBQUCAQIGCgcIERMVCwUFBwcDCAkKBg8eHRwNBggDAQMDCg0QCQgNCQMCAQQFBwQMFhQTCAcKBwQEBwkFBw0LBwEBAQMCBQgHBgIBBAUGAwMFAwEBAgUFBgMDBQUFAwkREA8HAwsQFAsKExEPBggRExQLBAkJCQUNGBURBwkYGx0PDhcTDwUNHB0eDwYLCwsFDRYRCwMPIiEgDg0TDAcBAwcHBwMPHh0dDgQHBwYDCQwGBBIiHhkICAcBBwYRIB4cDQYKCAUBAgIIDgoQHBUMAQEJERcNAQEBDxoWEgcDBQgFCBQYHA8KCwIICgkZHSAQAQIBAQIEBQMDBgUDASkDBgcHBA4dHR4PAwcHBwMBBwwTDQ4gISIPAwsRFg0FCwsLBg8eHRwNBQ8TFw4PHRsYCQcRFRgNBQkJCQQLFBMRCAYPERMKCxQQCwMHDxARCQMFBQUDAwYFBQIBAQMFAwMGBQQBAgYHCAUCAwEBAQcLDQcFCQcEBAcKBwgTFBYMBAcFBAECAwkNCAkQDQoDAwEDCAYNHB0eDwYKCQgDBwcFBQsVExEIBwoGAgECBQUFAhEhIB8PCBAQDwcMEQwHAQoUFRYLCxQRDgUMFhUUCgYMDA0GDxoXEwgGEBMXDg0aGhkLCxMRDwYECQoLBg8fHx4OAQcNEw0NHiAhEQECAQEDBQYDAwUEAgEBAgEQIB0ZCQoIAgsKDxwYFAgFCAUDBxIWGg8BAQENFxEJAQEMFRwQCg4IAgIBBQgKBg0cHiARBgcBBwgIGR4iEgQGDAkAAAAFACD/wQPeA74ABAARABYAGwAgAAATMxEjERMhMj4CNyEeAzMTMxEjERczESMREzMRIxF8hYV+AgkjQTguEPxCEC44QSNWhYXVhYXVhYUB/v5+AYL9whIiLxwcLyISAzr9ggJ+fv4AAgABQvy+A0IACAAA/8IEAAPCABgAHQAiACcALAA1ADoAPwAAASEiDgIVERQeAjMhMj4CNRE0LgIjDQEHJTcHBQclNwcFByU3ByEVITUFIREzESERMxELATcTBzcDNxMHAwX99zRbRCgoRFs0Agk0W0QoKERbNP5zAQ0l/u8pUQEzE/7KFSMBPwf+wAgIAUH+vwG+/cVCAbo/LrNArDlBGE0PRAPCKERbNP33NFtEKChEWzQCCTRbRCj9rzqoQZldQlVKkyREHE2BTU3SAV/+3QEj/qEB1wELKv7xJSgBQAX+vwQAAAEAAAABAABJ4jIOXw889QALBAAAAAAAzo8AawAAAADOjwBr//7/wAQCA9gAAAAIAAIAAAAAAAAAAQAAA8D/wAAABAD//v/+BAIAAQAAAAAAAAAAAAAAAAAAACoAAAAAAgAAAAQAAAAEAP/+BAAAAAQAABoEAP/+BAAAAAQAAEIEAAADBAAAAQQAAAAEAP//BAAAAAQAAHgEAAAABAAAAAQAAEIEAABCBAAAAAQA//4EAACRBAAAAAQAAAAEAAAiBAD//gQAAAAEAP/+BAD//gQA//4EAP/+BAD//gQAAAAEAAAoBAAAPgQAAAAEAP/+BAD//gQAAAAEAAACBAAAIAQAAAAAAAAAAAoApgDkAfQCtAMiA5QEGgUOBbgGkga+B2YIMgh6CUYJ0gpcCqgLRgvCDKQODA5oDv4PRA+ID74P9hAsEGQRMhFoEZASOhM0FCwUgBgkGFwYygAAAAEAAAAqAsoADgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAOAK4AAQAAAAAAAQAWAAAAAQAAAAAAAgAOAGMAAQAAAAAAAwAWACwAAQAAAAAABAAWAHEAAQAAAAAABQAWABYAAQAAAAAABgALAEIAAQAAAAAACgAoAIcAAwABBAkAAQAWAAAAAwABBAkAAgAOAGMAAwABBAkAAwAWACwAAwABBAkABAAWAHEAAwABBAkABQAWABYAAwABBAkABgAWAE0AAwABBAkACgAoAIcAcAB5AHQAaABvAG4AaQBjAG8AbgBzAFYAZQByAHMAaQBvAG4AIAAwAC4AMABwAHkAdABoAG8AbgBpAGMAbwBuAHNweXRob25pY29ucwBwAHkAdABoAG8AbgBpAGMAbwBuAHMAUgBlAGcAdQBsAGEAcgBwAHkAdABoAG8AbgBpAGMAbwBuAHMARwBlAG4AZQByAGEAdABlAGQAIABiAHkAIABJAGMAbwBNAG8AbwBuAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=) format("woff");
   font-weight: normal;
   font-style: normal; }
-
 .icon-megaphone:before {
   content: "\e600"; }
 
@@ -3474,7 +3488,7 @@ span.highlighted {
 .icon-arrow-left:before {
   content: "\e61c"; }
 
-.icon-arrow-down:before, .errorlist:before:before {
+.icon-arrow-down:before, .errorlist:before {
   content: "\e61d"; }
 
 .icon-freenode:before {
@@ -3515,14 +3529,14 @@ span.highlighted {
 /*modernizr*/
 .no-fontface .icon-megaphone, .no-fontface .icon-python-alt, .no-fontface .icon-pypi, .no-fontface .icon-news, .no-fontface .icon-moderate, .no-fontface .icon-mercurial, .no-fontface .icon-jobs, .no-fontface .icon-help, .no-fontface .icon-download, .no-fontface .icon-documentation, .no-fontface .icon-community, .no-fontface .icon-code, .no-fontface .icon-close, .no-fontface .icon-calendar, .no-fontface .icon-beginner, .no-fontface .icon-advanced, .no-fontface .icon-sitemap, .no-fontface .icon-search, .no-fontface .icon-search-alt, .no-fontface .icon-python, .no-fontface .icon-github, .no-fontface .icon-get-started, .no-fontface .icon-feed, .no-fontface .icon-facebook, .no-fontface .icon-email, .no-fontface .icon-arrow-up, .no-fontface .icon-arrow-right, .no-fontface .icon-arrow-left, .no-fontface .icon-arrow-down, .no-fontface .errorlist:before, .no-fontface .icon-freenode, .no-fontface .icon-alert, .no-fontface .icon-versions, .no-fontface .icon-twitter, .no-fontface .icon-thumbs-up, .no-fontface .icon-thumbs-down, .no-fontface .icon-text-resize, .no-fontface .icon-success-stories, .no-fontface .icon-statistics, .no-fontface .icon-stack-overflow, .no-svg .icon-megaphone, .no-svg .icon-python-alt, .no-svg .icon-pypi, .no-svg .icon-news, .no-svg .icon-moderate, .no-svg .icon-mercurial, .no-svg .icon-jobs, .no-svg .icon-help, .no-svg .icon-download, .no-svg .icon-documentation, .no-svg .icon-community, .no-svg .icon-code, .no-svg .icon-close, .no-svg .icon-calendar, .no-svg .icon-beginner, .no-svg .icon-advanced, .no-svg .icon-sitemap, .no-svg .icon-search, .no-svg .icon-search-alt, .no-svg .icon-python, .no-svg .icon-github, .no-svg .icon-get-started, .no-svg .icon-feed, .no-svg .icon-facebook, .no-svg .icon-email, .no-svg .icon-arrow-up, .no-svg .icon-arrow-right, .no-svg .icon-arrow-left, .no-svg .icon-arrow-down, .no-svg .errorlist:before, .no-svg .icon-freenode, .no-svg .icon-alert, .no-svg .icon-versions, .no-svg .icon-twitter, .no-svg .icon-thumbs-up, .no-svg .icon-thumbs-down, .no-svg .icon-text-resize, .no-svg .icon-success-stories, .no-svg .icon-statistics, .no-svg .icon-stack-overflow, .no-generatedcontent .icon-megaphone, .no-generatedcontent .icon-python-alt, .no-generatedcontent .icon-pypi, .no-generatedcontent .icon-news, .no-generatedcontent .icon-moderate, .no-generatedcontent .icon-mercurial, .no-generatedcontent .icon-jobs, .no-generatedcontent .icon-help, .no-generatedcontent .icon-download, .no-generatedcontent .icon-documentation, .no-generatedcontent .icon-community, .no-generatedcontent .icon-code, .no-generatedcontent .icon-close, .no-generatedcontent .icon-calendar, .no-generatedcontent .icon-beginner, .no-generatedcontent .icon-advanced, .no-generatedcontent .icon-sitemap, .no-generatedcontent .icon-search, .no-generatedcontent .icon-search-alt, .no-generatedcontent .icon-python, .no-generatedcontent .icon-github, .no-generatedcontent .icon-get-started, .no-generatedcontent .icon-feed, .no-generatedcontent .icon-facebook, .no-generatedcontent .icon-email, .no-generatedcontent .icon-arrow-up, .no-generatedcontent .icon-arrow-right, .no-generatedcontent .icon-arrow-left, .no-generatedcontent .icon-arrow-down, .no-generatedcontent .errorlist:before, .no-generatedcontent .icon-freenode, .no-generatedcontent .icon-alert, .no-generatedcontent .icon-versions, .no-generatedcontent .icon-twitter, .no-generatedcontent .icon-thumbs-up, .no-generatedcontent .icon-thumbs-down, .no-generatedcontent .icon-text-resize, .no-generatedcontent .icon-success-stories, .no-generatedcontent .icon-statistics, .no-generatedcontent .icon-stack-overflow {
   /* Show a unicode character back up if it exists */ }
-  .no-fontface .icon-megaphone:before, .no-fontface .icon-python-alt:before, .no-fontface .icon-pypi:before, .no-fontface .icon-news:before, .no-fontface .icon-moderate:before, .no-fontface .icon-mercurial:before, .no-fontface .icon-jobs:before, .no-fontface .icon-help:before, .no-fontface .icon-download:before, .no-fontface .icon-documentation:before, .no-fontface .icon-community:before, .no-fontface .icon-code:before, .no-fontface .icon-close:before, .no-fontface .icon-calendar:before, .no-fontface .icon-beginner:before, .no-fontface .icon-advanced:before, .no-fontface .icon-sitemap:before, .no-fontface .icon-search:before, .no-fontface .icon-search-alt:before, .no-fontface .icon-python:before, .no-fontface .icon-github:before, .no-fontface .icon-get-started:before, .no-fontface .icon-feed:before, .no-fontface .icon-facebook:before, .no-fontface .icon-email:before, .no-fontface .icon-arrow-up:before, .no-fontface .icon-arrow-right:before, .no-fontface .icon-arrow-left:before, .no-fontface .icon-arrow-down:before, .no-fontface .errorlist:before:before, .no-fontface .icon-freenode:before, .no-fontface .icon-alert:before, .no-fontface .icon-versions:before, .no-fontface .icon-twitter:before, .no-fontface .icon-thumbs-up:before, .no-fontface .icon-thumbs-down:before, .no-fontface .icon-text-resize:before, .no-fontface .icon-success-stories:before, .no-fontface .icon-statistics:before, .no-fontface .icon-stack-overflow:before, .no-svg .icon-megaphone:before, .no-svg .icon-python-alt:before, .no-svg .icon-pypi:before, .no-svg .icon-news:before, .no-svg .icon-moderate:before, .no-svg .icon-mercurial:before, .no-svg .icon-jobs:before, .no-svg .icon-help:before, .no-svg .icon-download:before, .no-svg .icon-documentation:before, .no-svg .icon-community:before, .no-svg .icon-code:before, .no-svg .icon-close:before, .no-svg .icon-calendar:before, .no-svg .icon-beginner:before, .no-svg .icon-advanced:before, .no-svg .icon-sitemap:before, .no-svg .icon-search:before, .no-svg .icon-search-alt:before, .no-svg .icon-python:before, .no-svg .icon-github:before, .no-svg .icon-get-started:before, .no-svg .icon-feed:before, .no-svg .icon-facebook:before, .no-svg .icon-email:before, .no-svg .icon-arrow-up:before, .no-svg .icon-arrow-right:before, .no-svg .icon-arrow-left:before, .no-svg .icon-arrow-down:before, .no-svg .errorlist:before:before, .no-svg .icon-freenode:before, .no-svg .icon-alert:before, .no-svg .icon-versions:before, .no-svg .icon-twitter:before, .no-svg .icon-thumbs-up:before, .no-svg .icon-thumbs-down:before, .no-svg .icon-text-resize:before, .no-svg .icon-success-stories:before, .no-svg .icon-statistics:before, .no-svg .icon-stack-overflow:before, .no-generatedcontent .icon-megaphone:before, .no-generatedcontent .icon-python-alt:before, .no-generatedcontent .icon-pypi:before, .no-generatedcontent .icon-news:before, .no-generatedcontent .icon-moderate:before, .no-generatedcontent .icon-mercurial:before, .no-generatedcontent .icon-jobs:before, .no-generatedcontent .icon-help:before, .no-generatedcontent .icon-download:before, .no-generatedcontent .icon-documentation:before, .no-generatedcontent .icon-community:before, .no-generatedcontent .icon-code:before, .no-generatedcontent .icon-close:before, .no-generatedcontent .icon-calendar:before, .no-generatedcontent .icon-beginner:before, .no-generatedcontent .icon-advanced:before, .no-generatedcontent .icon-sitemap:before, .no-generatedcontent .icon-search:before, .no-generatedcontent .icon-search-alt:before, .no-generatedcontent .icon-python:before, .no-generatedcontent .icon-github:before, .no-generatedcontent .icon-get-started:before, .no-generatedcontent .icon-feed:before, .no-generatedcontent .icon-facebook:before, .no-generatedcontent .icon-email:before, .no-generatedcontent .icon-arrow-up:before, .no-generatedcontent .icon-arrow-right:before, .no-generatedcontent .icon-arrow-left:before, .no-generatedcontent .icon-arrow-down:before, .no-generatedcontent .errorlist:before:before, .no-generatedcontent .icon-freenode:before, .no-generatedcontent .icon-alert:before, .no-generatedcontent .icon-versions:before, .no-generatedcontent .icon-twitter:before, .no-generatedcontent .icon-thumbs-up:before, .no-generatedcontent .icon-thumbs-down:before, .no-generatedcontent .icon-text-resize:before, .no-generatedcontent .icon-success-stories:before, .no-generatedcontent .icon-statistics:before, .no-generatedcontent .icon-stack-overflow:before {
+  .no-fontface .icon-megaphone:before, .no-fontface .icon-python-alt:before, .no-fontface .icon-pypi:before, .no-fontface .icon-news:before, .no-fontface .icon-moderate:before, .no-fontface .icon-mercurial:before, .no-fontface .icon-jobs:before, .no-fontface .icon-help:before, .no-fontface .icon-download:before, .no-fontface .icon-documentation:before, .no-fontface .icon-community:before, .no-fontface .icon-code:before, .no-fontface .icon-close:before, .no-fontface .icon-calendar:before, .no-fontface .icon-beginner:before, .no-fontface .icon-advanced:before, .no-fontface .icon-sitemap:before, .no-fontface .icon-search:before, .no-fontface .icon-search-alt:before, .no-fontface .icon-python:before, .no-fontface .icon-github:before, .no-fontface .icon-get-started:before, .no-fontface .icon-feed:before, .no-fontface .icon-facebook:before, .no-fontface .icon-email:before, .no-fontface .icon-arrow-up:before, .no-fontface .icon-arrow-right:before, .no-fontface .icon-arrow-left:before, .no-fontface .icon-arrow-down:before, .no-fontface .errorlist:before, .no-fontface .icon-freenode:before, .no-fontface .icon-alert:before, .no-fontface .icon-versions:before, .no-fontface .icon-twitter:before, .no-fontface .icon-thumbs-up:before, .no-fontface .icon-thumbs-down:before, .no-fontface .icon-text-resize:before, .no-fontface .icon-success-stories:before, .no-fontface .icon-statistics:before, .no-fontface .icon-stack-overflow:before, .no-svg .icon-megaphone:before, .no-svg .icon-python-alt:before, .no-svg .icon-pypi:before, .no-svg .icon-news:before, .no-svg .icon-moderate:before, .no-svg .icon-mercurial:before, .no-svg .icon-jobs:before, .no-svg .icon-help:before, .no-svg .icon-download:before, .no-svg .icon-documentation:before, .no-svg .icon-community:before, .no-svg .icon-code:before, .no-svg .icon-close:before, .no-svg .icon-calendar:before, .no-svg .icon-beginner:before, .no-svg .icon-advanced:before, .no-svg .icon-sitemap:before, .no-svg .icon-search:before, .no-svg .icon-search-alt:before, .no-svg .icon-python:before, .no-svg .icon-github:before, .no-svg .icon-get-started:before, .no-svg .icon-feed:before, .no-svg .icon-facebook:before, .no-svg .icon-email:before, .no-svg .icon-arrow-up:before, .no-svg .icon-arrow-right:before, .no-svg .icon-arrow-left:before, .no-svg .icon-arrow-down:before, .no-svg .errorlist:before, .no-svg .icon-freenode:before, .no-svg .icon-alert:before, .no-svg .icon-versions:before, .no-svg .icon-twitter:before, .no-svg .icon-thumbs-up:before, .no-svg .icon-thumbs-down:before, .no-svg .icon-text-resize:before, .no-svg .icon-success-stories:before, .no-svg .icon-statistics:before, .no-svg .icon-stack-overflow:before, .no-generatedcontent .icon-megaphone:before, .no-generatedcontent .icon-python-alt:before, .no-generatedcontent .icon-pypi:before, .no-generatedcontent .icon-news:before, .no-generatedcontent .icon-moderate:before, .no-generatedcontent .icon-mercurial:before, .no-generatedcontent .icon-jobs:before, .no-generatedcontent .icon-help:before, .no-generatedcontent .icon-download:before, .no-generatedcontent .icon-documentation:before, .no-generatedcontent .icon-community:before, .no-generatedcontent .icon-code:before, .no-generatedcontent .icon-close:before, .no-generatedcontent .icon-calendar:before, .no-generatedcontent .icon-beginner:before, .no-generatedcontent .icon-advanced:before, .no-generatedcontent .icon-sitemap:before, .no-generatedcontent .icon-search:before, .no-generatedcontent .icon-search-alt:before, .no-generatedcontent .icon-python:before, .no-generatedcontent .icon-github:before, .no-generatedcontent .icon-get-started:before, .no-generatedcontent .icon-feed:before, .no-generatedcontent .icon-facebook:before, .no-generatedcontent .icon-email:before, .no-generatedcontent .icon-arrow-up:before, .no-generatedcontent .icon-arrow-right:before, .no-generatedcontent .icon-arrow-left:before, .no-generatedcontent .icon-arrow-down:before, .no-generatedcontent .errorlist:before, .no-generatedcontent .icon-freenode:before, .no-generatedcontent .icon-alert:before, .no-generatedcontent .icon-versions:before, .no-generatedcontent .icon-twitter:before, .no-generatedcontent .icon-thumbs-up:before, .no-generatedcontent .icon-thumbs-down:before, .no-generatedcontent .icon-text-resize:before, .no-generatedcontent .icon-success-stories:before, .no-generatedcontent .icon-statistics:before, .no-generatedcontent .icon-stack-overflow:before {
     display: none;
     margin-right: 0; }
   .no-fontface .icon-megaphone span, .no-fontface .icon-python-alt span, .no-fontface .icon-pypi span, .no-fontface .icon-news span, .no-fontface .icon-moderate span, .no-fontface .icon-mercurial span, .no-fontface .icon-jobs span, .no-fontface .icon-help span, .no-fontface .icon-download span, .no-fontface .icon-documentation span, .no-fontface .icon-community span, .no-fontface .icon-code span, .no-fontface .icon-close span, .no-fontface .icon-calendar span, .no-fontface .icon-beginner span, .no-fontface .icon-advanced span, .no-fontface .icon-sitemap span, .no-fontface .icon-search span, .no-fontface .icon-search-alt span, .no-fontface .icon-python span, .no-fontface .icon-github span, .no-fontface .icon-get-started span, .no-fontface .icon-feed span, .no-fontface .icon-facebook span, .no-fontface .icon-email span, .no-fontface .icon-arrow-up span, .no-fontface .icon-arrow-right span, .no-fontface .icon-arrow-left span, .no-fontface .icon-arrow-down span, .no-fontface .errorlist:before span, .no-fontface .icon-freenode span, .no-fontface .icon-alert span, .no-fontface .icon-versions span, .no-fontface .icon-twitter span, .no-fontface .icon-thumbs-up span, .no-fontface .icon-thumbs-down span, .no-fontface .icon-text-resize span, .no-fontface .icon-success-stories span, .no-fontface .icon-statistics span, .no-fontface .icon-stack-overflow span, .no-svg .icon-megaphone span, .no-svg .icon-python-alt span, .no-svg .icon-pypi span, .no-svg .icon-news span, .no-svg .icon-moderate span, .no-svg .icon-mercurial span, .no-svg .icon-jobs span, .no-svg .icon-help span, .no-svg .icon-download span, .no-svg .icon-documentation span, .no-svg .icon-community span, .no-svg .icon-code span, .no-svg .icon-close span, .no-svg .icon-calendar span, .no-svg .icon-beginner span, .no-svg .icon-advanced span, .no-svg .icon-sitemap span, .no-svg .icon-search span, .no-svg .icon-search-alt span, .no-svg .icon-python span, .no-svg .icon-github span, .no-svg .icon-get-started span, .no-svg .icon-feed span, .no-svg .icon-facebook span, .no-svg .icon-email span, .no-svg .icon-arrow-up span, .no-svg .icon-arrow-right span, .no-svg .icon-arrow-left span, .no-svg .icon-arrow-down span, .no-svg .errorlist:before span, .no-svg .icon-freenode span, .no-svg .icon-alert span, .no-svg .icon-versions span, .no-svg .icon-twitter span, .no-svg .icon-thumbs-up span, .no-svg .icon-thumbs-down span, .no-svg .icon-text-resize span, .no-svg .icon-success-stories span, .no-svg .icon-statistics span, .no-svg .icon-stack-overflow span, .no-generatedcontent .icon-megaphone span, .no-generatedcontent .icon-python-alt span, .no-generatedcontent .icon-pypi span, .no-generatedcontent .icon-news span, .no-generatedcontent .icon-moderate span, .no-generatedcontent .icon-mercurial span, .no-generatedcontent .icon-jobs span, .no-generatedcontent .icon-help span, .no-generatedcontent .icon-download span, .no-generatedcontent .icon-documentation span, .no-generatedcontent .icon-community span, .no-generatedcontent .icon-code span, .no-generatedcontent .icon-close span, .no-generatedcontent .icon-calendar span, .no-generatedcontent .icon-beginner span, .no-generatedcontent .icon-advanced span, .no-generatedcontent .icon-sitemap span, .no-generatedcontent .icon-search span, .no-generatedcontent .icon-search-alt span, .no-generatedcontent .icon-python span, .no-generatedcontent .icon-github span, .no-generatedcontent .icon-get-started span, .no-generatedcontent .icon-feed span, .no-generatedcontent .icon-facebook span, .no-generatedcontent .icon-email span, .no-generatedcontent .icon-arrow-up span, .no-generatedcontent .icon-arrow-right span, .no-generatedcontent .icon-arrow-left span, .no-generatedcontent .icon-arrow-down span, .no-generatedcontent .errorlist:before span, .no-generatedcontent .icon-freenode span, .no-generatedcontent .icon-alert span, .no-generatedcontent .icon-versions span, .no-generatedcontent .icon-twitter span, .no-generatedcontent .icon-thumbs-up span, .no-generatedcontent .icon-thumbs-down span, .no-generatedcontent .icon-text-resize span, .no-generatedcontent .icon-success-stories span, .no-generatedcontent .icon-statistics span, .no-generatedcontent .icon-stack-overflow span {
     display: inline; }
 
 /* Show in IE8: supports FontFace (eot) but not SVG. */
-.ie8 .icon-megaphone:before, .ie8 .icon-python-alt:before, .ie8 .icon-pypi:before, .ie8 .icon-news:before, .ie8 .icon-moderate:before, .ie8 .icon-mercurial:before, .ie8 .icon-jobs:before, .ie8 .icon-help:before, .ie8 .icon-download:before, .ie8 .icon-documentation:before, .ie8 .icon-community:before, .ie8 .icon-code:before, .ie8 .icon-close:before, .ie8 .icon-calendar:before, .ie8 .icon-beginner:before, .ie8 .icon-advanced:before, .ie8 .icon-sitemap:before, .ie8 .icon-search:before, .ie8 .icon-search-alt:before, .ie8 .icon-python:before, .ie8 .icon-github:before, .ie8 .icon-get-started:before, .ie8 .icon-feed:before, .ie8 .icon-facebook:before, .ie8 .icon-email:before, .ie8 .icon-arrow-up:before, .ie8 .icon-arrow-right:before, .ie8 .icon-arrow-left:before, .ie8 .icon-arrow-down:before, .ie8 .errorlist:before:before, .ie8 .icon-freenode:before, .ie8 .icon-alert:before, .ie8 .icon-versions:before, .ie8 .icon-twitter:before, .ie8 .icon-thumbs-up:before, .ie8 .icon-thumbs-down:before, .ie8 .icon-text-resize:before, .ie8 .icon-success-stories:before, .ie8 .icon-statistics:before, .ie8 .icon-stack-overflow:before {
+.ie8 .icon-megaphone:before, .ie8 .icon-python-alt:before, .ie8 .icon-pypi:before, .ie8 .icon-news:before, .ie8 .icon-moderate:before, .ie8 .icon-mercurial:before, .ie8 .icon-jobs:before, .ie8 .icon-help:before, .ie8 .icon-download:before, .ie8 .icon-documentation:before, .ie8 .icon-community:before, .ie8 .icon-code:before, .ie8 .icon-close:before, .ie8 .icon-calendar:before, .ie8 .icon-beginner:before, .ie8 .icon-advanced:before, .ie8 .icon-sitemap:before, .ie8 .icon-search:before, .ie8 .icon-search-alt:before, .ie8 .icon-python:before, .ie8 .icon-github:before, .ie8 .icon-get-started:before, .ie8 .icon-feed:before, .ie8 .icon-facebook:before, .ie8 .icon-email:before, .ie8 .icon-arrow-up:before, .ie8 .icon-arrow-right:before, .ie8 .icon-arrow-left:before, .ie8 .icon-arrow-down:before, .ie8 .errorlist:before, .ie8 .icon-freenode:before, .ie8 .icon-alert:before, .ie8 .icon-versions:before, .ie8 .icon-twitter:before, .ie8 .icon-thumbs-up:before, .ie8 .icon-thumbs-down:before, .ie8 .icon-text-resize:before, .ie8 .icon-success-stories:before, .ie8 .icon-statistics:before, .ie8 .icon-stack-overflow:before {
   display: inline; }
 .ie8 .icon-megaphone span, .ie8 .icon-python-alt span, .ie8 .icon-pypi span, .ie8 .icon-news span, .ie8 .icon-moderate span, .ie8 .icon-mercurial span, .ie8 .icon-jobs span, .ie8 .icon-help span, .ie8 .icon-download span, .ie8 .icon-documentation span, .ie8 .icon-community span, .ie8 .icon-code span, .ie8 .icon-close span, .ie8 .icon-calendar span, .ie8 .icon-beginner span, .ie8 .icon-advanced span, .ie8 .icon-sitemap span, .ie8 .icon-search span, .ie8 .icon-search-alt span, .ie8 .icon-python span, .ie8 .icon-github span, .ie8 .icon-get-started span, .ie8 .icon-feed span, .ie8 .icon-facebook span, .ie8 .icon-email span, .ie8 .icon-arrow-up span, .ie8 .icon-arrow-right span, .ie8 .icon-arrow-left span, .ie8 .icon-arrow-down span, .ie8 .errorlist:before span, .ie8 .icon-freenode span, .ie8 .icon-alert span, .ie8 .icon-versions span, .ie8 .icon-twitter span, .ie8 .icon-thumbs-up span, .ie8 .icon-thumbs-down span, .ie8 .icon-text-resize span, .ie8 .icon-success-stories span, .ie8 .icon-statistics span, .ie8 .icon-stack-overflow span {
   display: none; }
@@ -3559,7 +3573,6 @@ span.highlighted {
   src: url("../fonts/FluxRegular.eot?#iefix") format("embedded-opentype"), url("../fonts/FluxRegular.woff") format("woff"), url('data:font/truetype;base64,AAEAAAAQAQAABAAAR1BPUwXqBEYAAO3gAAALEkxUU0jo62e1AADs5AAAAPtPUy8yb5Vf2wAAAWQAAABgVkRNWGnecWUAAOUAAAAF4GNtYXB1vQdaAAABxAAABbJjdnQgANMGSAAA6uAAAAAaZnBnbQZZnDcAAOr8AAABc2dseWZ+h6fOAAASlAAA0mxoZWFk8yrzrwAAASwAAAA2aGhlYQbbA9UAAAd4AAAAJGhtdHi7UCDiAAAHnAAAA9xsb2Nh3rMTJAAAEKQAAAHwbWF4cAMJAl8AAAEMAAAAIG5hbWUajMb6AAALeAAAAuxwb3N0LXuX3gAADmQAAAI/cHJlcKKsnm0AAOxwAAAAcgABAAAA9wB+AAcAAAAAAAEAAAAAAAoAAAIAAeAAAAAAAAEAAAABGZn2RTxIXw889QAbA+gAAAAAxA+R9AAAAADMZwTc/4j/AgP9A14AAAAJAAIAAAAAAAAAAwF8AZAABQAEArwCigAAAIwCvAKKAAAB3QAyAPoAAAIABQYFAAACAASAAACvQAAgSgAAAAAAAAAAdDI2IABAACD7AgLf/vcAdANHARUgAAADAAAAAAH0ArwAAAAgAAIAAAADAAAAAwAAABwAAQAAAAACZAADAAEAAANqAAQCSAAAAFQAQAAFABQAIAB+AKMArAD/ATEBQgFTAWEBeAF+AZICxwLdA5QDqQO8A8AgFCAaIB4gIiAmIDAgOiBEIKwhIiEmIgIiBiIPIhIiGiIeIisiSCJgImUlyvsC//8AAAAgACEAoAClAK4BMQFBAVIBYAF4AX0BkgLGAtgDlAOpA7wDwCATIBggHCAgICYgMCA5IEQgrCEiISYiAiIGIg8iESIaIh4iKyJIImAiZCXK+wH//wAA/+kAAAAAAAD/nf+c/1b/lP87/of/DgAAAAD9U/1B/N39LOCXAAAAAAAA4H7gjeB84HDgLd9w38Te7d7h3t4AAN7O3tXewN5Z3jUAANrnBbYAAQBUAAAAUgBYAGYAAAAAAAAAAAAAAAAAAAD6APwAAAAAAAAAAAAAAPwBAAEEAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAAAAAAAAAAAA7AAAAAAAAAADANoAnwCKAIsAmAAGAIwAlACRAJoAogDpAJAA0QCJAPIA5gDlAJMAmQCOALoA1QDjAJsAowDiAOEA5ACeAKUAwAC+AKYAaABpAJYAagDCAGsAvwDBAMYAwwDEAMUA2wBsAMoAxwDIAKcAbQAIAJcAzQDLAMwAbgD2AN8AjwBwAG8AcQBzAHIAdACcAHUAdwB2AHgAeQB7AHoAfAB9ANwAfgCAAH8AgQCDAIIAsACdAIUAhACGAIcACQDgALIAzwDYANIA0wDUANcA0ADWAK4ArwC7AKwArQC8AIgAuQCNAO4ABwDxAPAAAAEGAAABAAAAAAAAAAECAAAAAgAAAAAAAAAAAAAAAAAAAAEAAAMKCwwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnAGhpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYaHiImKi4yNjo+QkZKTlJWWl/Py8fCYme/u7ezrmpvqnJ2en+nooKHnoqOkA6Wmp6ipqqusra6vsLGys7TZtba3uLm6u7y9vr/AwcLDxMXGx8gAysvMzc7P0NHS09TV1tfYAAQCSAAAAFQAQAAFABQAIAB+AKMArAD/ATEBQgFTAWEBeAF+AZICxwLdA5QDqQO8A8AgFCAaIB4gIiAmIDAgOiBEIKwhIiEmIgIiBiIPIhIiGiIeIisiSCJgImUlyvsC//8AAAAgACEAoAClAK4BMQFBAVIBYAF4AX0BkgLGAtgDlAOpA7wDwCATIBggHCAgICYgMCA5IEQgrCEiISYiAiIGIg8iESIaIh4iKyJIImAiZCXK+wH//wAA/+kAAAAAAAD/nf+c/1b/lP87/of/DgAAAAD9U/1B/N39LOCXAAAAAAAA4H7gjeB84HDgLd9w38Te7d7h3t4AAN7O3tXewN5Z3jUAANrnBbYAAQBUAAAAUgBYAGYAAAAAAAAAAAAAAAAAAAD6APwAAAAAAAAAAAAAAPwBAAEEAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAAAAAAAAAAAA7AAAAAAAAAADANoAnwCKAIsAmAAGAIwAlACRAJoAogDpAJAA0QCJAPIA5gDlAJMAmQCOALoA1QDjAJsAowDiAOEA5ACeAKUAwAC+AKYAaABpAJYAagDCAGsAvwDBAMYAwwDEAMUA2wBsAMoAxwDIAKcAbQAIAJcAzQDLAMwAbgD2AN8AjwBwAG8AcQBzAHIAdACcAHUAdwB2AHgAeQB7AHoAfAB9ANwAfgCAAH8AgQCDAIIAsACdAIUAhACGAIcACQDgALIAzwDYANIA0wDUANcA0ADWAK4ArwC7AKwArQC8AIgAuQCNAO4ABwDxAPAAAAABAAAC3/73AHQEJf+I/8ED/QABAAAAAAAAAAAAAAAAAAAA9wEoAAAAAAAAASgAAAEoAAACIQAjAbQAHwEFAGQCDgApAf4AWwHlAD8A8gBGAWUARgJSADEBzgASAsYAFwJDADEA5wBQATQAPAE0AAYBZQAZAccALwDeADwBNwA8AN4AOwFPAAABzQAoAQoAHgG0ACgBpgAoAckAFAGvADIB4QAmAY8ADwHCAB4B1wAcAPYASQD8AEwBVAAsApkAMQFUACwBygAoAwQAMgIXAAoB/wA8AhgAHAIcADwBwwA8AaQAPAIhAB0CNwA8ANYARgFWAAoB9gA8AYIAPALHADwCVAA8AlsAHgHUADwCWwAeAdcAPAHiAB4B0wAKAjUANwIAAAoC/QAKAkYAKAHQAAoCQAAoAQsAPAFQAAABCwAfAowAUgH0AAQBUgBCAaMAHgHVADwBjwAeAdkAHgGjAB4BGwAeAdsAKAHSADwA1wA8AN7/iAGnADwA3wA8Ap4AMgHFADIBzQAeAdYAPAHgACMBSwA8AYoAKAETAB4BzAAyAbIADwJrAA8BswAeAdMAMgGqAB4BUQAeAOkAUAFQAAwBmQAwAhcACgIXAAoCLAAmAcMAPAJUADwCWwAeAj8APAGtACgBrQAoAbYAKAGtACgBrQAoAa0AKAGPAB4BowAeAaMAHgGkAB4BowAeANsAEgDf//QA3//LAN//2QHFADIBzQAeAc0AHgHNAB4BzQAeAc0AHgHMADIBzAAyAcwAMgHMADICFgAtASEAMgGZAB4CMwAoAc0AMgGfADwB7gAeAiwAFAM4ADIDNwAyAjUAHgFbADwBpAA7ApoAPAMbAAoCWgAeAlcAHgHMADIBnwAoAZ8AKAK+ACgBzQAeAcsAJwDyAEYBrAAKAhwAFAHxADIB8QAyAp4AOwIXAAoCFwAKAlsAHgMUABwC9QAoAoMAPAM3ADwBdQA7AXQAOwDeADsA3gA7AuMAFAMYABQB5wA8AeQAFAHO/+wBQwAyAUMAMgHiABQCFgAUAgwAKADeADsA3gA7AaAAOwQlACgCFwAKAcMAPAIXAAoBwwA8AcMAPADhACUA4f/LAOH/5ADh//ECWwAeAlsAHgNxACgCWwAeAj8APAI/ADwCPwA8AN8AUAGeACUBsQA+AagAOAGeACUBAQBLAT8AQQFfAFcBeAAZAV8AVwMKAAACZgAoASgAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAABzgASAXgAEAGo//kAAAAPALoAAQABAAAAAQAAAAAAAQABAAAABAAMAiYAAwABBAkAAAByAKAAAwABBAkAAQAAAAAAAwABBAkAAgACAfQAAwABBAkAAwBQAS4AAwABBAkABAAaAfQAAwABBAkABQBsARIAAwABBAkABgAYAg4AAwABBAkABwBaAX4AAwABBAkACAAaAIYAAwABBAkACQAaAIYAAwABBAkACgCgAAAAAwABBAkACwAcAdgAAwABBAkADgAAAAAAWwBUAC0AMgA2AF0AIABDAGgAaQBjAGEAZwBvACAAdwB3AHcALgB0ADIANgAuAGMAbwBtACAANwA3ADMALgA4ADYAMgAuADEAMgAwADEAIABUADAAMgAxADYAIABJAEQAIwA1ADAAOAA3ADMAMQAwACAAZABlAHMAaQBnAG4AZQByADoAIABNAG8AbgBpAGIAIABNAGEAaABkAGEAdgBpAEMAbwBwAHkAcgBpAGcAaAB0ACAAKABjACkAIAAxADkAOQA2ACAAYgB5ACAATQBvAG4AaQBiACAATQBhAGgAZABhAHYAaQAuACAAQQBsAGwAIAByAGkAZwBoAHQAcwAgAHIAZQBzAGUAcgB2AGUAZAAuAFYAZQByAHMAaQBvAG4AIAAxAC4AMQAwADAAOwBjAG8AbQAuAG0AeQBmAG8AbgB0AHMALgB0ADIANgAuAGYAbAB1AHgALgByAGUAZwB1AGwAYQByAC4AdwBmAGsAaQB0ADIALgBkAHAAUwBwAEYAbAB1AHgAIABSAGUAZwB1AGwAYQByACAAaQBzACAAYQAgAHQAcgBhAGQAZQBtAGEAcgBrACAAbwBmACAATQBvAG4AaQBiACAATQBhAGgAZABhAHYAaQAuAGgAdAB0AHAAOgAvAC8AdAAyADYALgBjAG8AbSYeAEYAbAB1AHgAIABSAGUAZwB1AGwAYQByAEYAbAB1AHgALQBSAGUAZwB1AGwAYQByRmx1eCBSZWd1bGFyAAIAAAAAAAD/bgAYAAAAAAAAAAAAAAAAAAAAAAAAAAAA9wAAAQIAAgADAOYA5wDoAO8A8ADsAAQABQAGAAcACAAJAAoACwAMAA0ADgAPABAAEQASABMAFAAVABYAFwAYABkAGgAbABwAHQAeAB8AIAAhACIAIwAkACUAJgAnACgAKQAqACsALAAtAC4ALwAwADEAMgAzADQANQA2ADcAOAA5ADoAOwA8AD0APgA/AEAAQQBCAEMARABFAEYARwBIAEkASgBLAEwATQBOAE8AUABRAFIAUwBUAFUAVgBXAFgAWQBaAFsAXABdAF4AXwBgAGEAYgBjAGQAZQBmAGcAaABpAGoAawBsAG0AbgBvAHAAcQByAHMAdAB1AHYAdwB4AHkAegB7AHwAfQB+AH8AgACBAIIAgwCEAIUAhgCHAIgAiQCKAIsAjACNAI4AjwCQAJEAlgCXAJ0AngCgAKEAogCjAKYApwCpAKoAqwCtAK4ArwCwALEAsgCzALQAtQC2ALcAuAC5ALoAuwC8AL4AvwDAAMEAwgEDAMQAxQDGAMcAyADJAMoAywDMAM0AzgDPANAA0QDSANMA1ADVANYA1wDYANkBBADbANwA3QDeAN8A4ADhAQUBBgDpAOoA4gDjAO0A7gD0APUA8QD2APMA8gEHAKUApACfAJwAmwCaAJkAmACVAJQAkwCSAOQA5QDrBS5udWxsDnBlcmlvZGNlbnRlcmVkBm1hY3JvbgRFdXJvB3VuaTAwQTAFRGVsdGEAAAAAAAAAAAAAAACwAOYBEgEsAVACDgKeAroDIAP0BRYF2AXqBkgGqgcKB0AHeAeQCAoIHgjoCQoJYAnYCiwKqguYC7IM5g2eDkIOtg7MDuwPAg+8EOgRHBHWEnQTHhNaE44URBSQFK4U5hUmFUoVrBX6FsIXQBgoGKwZmhnGGkIaahqyGu4bKBtSG3YbjBu0G9Yb6hv+HMwdjB4eHtYfTh+cIHQg1CEMIU4hiiGoIiIibiM2I/okuCToJcomEiaMJrQm/CdGJ/AoFihwKIgo4ikWKdQqiit4K7wsLC1YLkIvHC/4MNIx0jLGM/w08DVyNfQ2gDdIN3Q3oDfOOEY4yDmeOnQ7RjxqPWI97j56PwY/3EAWQJpBFkGAQp5CxEMGQ7ZEmkVuRdBF5EZoRrBHCkgISIhJDEnYSrJLzkzQTUhNrk3qTnpOrE7eT8BQAlBiUVhR8lMkUzhTTFP+VH5UwFUEVb5WaFdyWBhYLlhKWGZY6FleWbxZ/Fo8WuxcilzQXRhdVF3wXjZeYl6QXyhfVGAmYPxhsmKEYwxjmmQiZEBkWGSMZKBkuGTwZXRltGXSZghmCGbAZsBmwGbAZsBmwGbAZsBmwGbAZsBmwGbAZsBmwGbAZsBmwGbAZsBmwGbAZsBmwGbAZsBmwGgAaPZpNgADACMAAAITAxUADAAZACIA7rgAIy+4AAMvQQUAegADAIoAAwACXUEPAAkAAwAZAAMAKQADADkAAwBJAAMAWQADAGkAAwAHXbkACQAE9LoAAAADAAkREjm4ACMQuAAQ0LgAEC+5ABYABPRBDwAGABYAFgAWACYAFgA2ABYARgAWAFYAFgBmABYAB11BBQB1ABYAhQAWAAJdugANABAAFhESOboAGwADAAkREjm6AB8AEAAWERI5uAAJELgAJNwAuAAARVi4ABovG7kAGgAFPlm7AAYAAQAMAAQruwAeAAEAGwAEK7gADBC4AA3QuAAGELgAE9C4ABoQuQAfAAH0MDEBIiY1JjYzMhYVFAYjIyImNTQ2MzIWFxQGIwMBITchASEjFwF9Fh8BHhUWHh4UxRUfHRQWHwEeFpMBXf63GQGk/qQBewEBAq0eFRYfHxYVHh4VFh8fFhUe/VMCRDL9vTMAAgAfAAABgwKhAAUADQAwALgAAi+4AAQvuAAARVi4AAYvG7kABgAFPlm7AAoAAQAHAAQruAAGELkACwAB9DAxEyc3FzcXARMjNyEDMxXUpR2IjSH+neTcGQEx5PYCAXcpTk4p/YgBhDL+fDIAAgBk/90AoQL0AAMABwAtuwAHAAMABAAEK7gABBC4AADQuAAAL7gABxC4AALQuAACLwC4AAIvuAAHLzAxExE3EQMRNxFmOz07AaMBNxr+r/5UATkB/qwAAAEAKQFNAdgBgQADABoAuAAARVi4AAEvG7kAAQAHPlm5AAAAAfQwMRM1IRcpAZQbAU00NAABAFsASwGlAakACwATALgAAC+4AAIvuAAGL7gACC8wMSUnByc3JzcXNxcHFwFzdHQwd3cwdHQyeXhLfn4tgoEufn4tgoEAAAACAD//HQGuApYAAwAwAOW4ADEvuAAjL7gAA9C4AAMvuAAjELgADtC4AA4vuAAjELgAEdC4ABEvuAAxELgAGdC4ABkvuQAcAAP0uAAjELkAJgAD9LgAMtwAuAACL7gAMC+4AABFWLgAFC8buQAUAAU+WbkAIAAB9EEhAAcAIAAXACAAJwAgADcAIABHACAAVwAgAGcAIAB3ACAAhwAgAJcAIACnACAAtwAgAMcAIADXACAA5wAgAPcAIAAQXUEJAAcAIAAXACAAJwAgADcAIAAEcUEFAEYAIABWACAAAnG6ABEAFAAgERI5ugAbADAAAhESOTAxEyc3FwM+Azc+AzU0NicGBiMiLgI1ETcRNRQWNzY2NxEzERQOAgcOAwekI8YdsRUxLicLBgYDAQEBEUxAGTIpGUpAMR08EkkCBQkIDjI8PxwB/CR2O/zwAwgPGhUKHiAfDAgDCAgaESEwHgEwGf7NATMzAQEaDAFl/nMTLi4qDxomGAsBAAAAAAIARv/3AKwCywADABAA5bsADQAEAAcABCtBDwAGAA0AFgANACYADQA2AA0ARgANAFYADQBmAA0AB11BBQB1AA0AhQANAAJdugAAAAcADRESObgAAC+5AAMAA/S6AAQABwANERI5ALgAAS+4AABFWLgABC8buQAEAAU+WboAAwAEAAEREjm5AAoAAfRBIQAHAAoAFwAKACcACgA3AAoARwAKAFcACgBnAAoAdwAKAIcACgCXAAoApwAKALcACgDHAAoA1wAKAOcACgD3AAoAEF1BCQAHAAoAFwAKACcACgA3AAoABHFBBQBGAAoAVgAKAAJxMDE3ETMRByImNTQ2MzIWFxQGI1RKJBYeHRQWHgEeFb4CDf3arh4VFh8fFhUeAAIARgHdAR8CxAADAAcAEwC4AAEvuAAFL7gAAC+4AAQvMDETJzMVByczFfIfTLofTQHd59US59UAAgAx/+wCIQJ8ABsAHwBnALgAAC+4AAQvuAAOL7gAEi+7AB8AAQABAAQruwAMAAEACQAEK7gAARC4AAXQuAAfELgAB9C4AAwQuAAP0LgADBC4ABPQuAAJELgAFdC4AB8QuAAX0LgAARC4ABnQuAAJELgAHNAwMQU3IwcHNyM1MzcjNTM3NwczNzcHMxUjBzMVIwcDIwczATQddx5HHWFsEmBrG0oeeBZOHGBqFGBrGw53E3YUw6MfwkKIQ6UbwJ4hv0OIQqoBdIgAAAAAAwAS/5ABuALkAC0ANAA9AOW7ADEAAwARAAQruwAtAAMAAAAEK7sAJgADADoABCu4AAAQuAAK0LgAABC4ABTQuAAtELgAFtC4AC0QuAAe0LgAABC4AC7QQQ8ABgAxABYAMQAmADEANgAxAEYAMQBWADEAZgAxAAddQQUAdQAxAIUAMQACXboANAARACYREjm4AC0QuAA10EEFAHoAOgCKADoAAl1BDwAJADoAGQA6ACkAOgA5ADoASQA6AFkAOgBpADoAB126AD0AEQAmERI5uAAmELgAP9wAuAAAL7gAFi+6ADQAAAAWERI5ugA9AAAAFhESOTAxFzcmJic3HgMXNScmJyYmNTQ2NzU3BxYWFwcmJicVFxYWFxYWFRQGBwYGBxUDBgYHBhYXEzY2NzY1NCYnyAE2Yx4hCyEoKxYSUx4UEVtNPwEoPx0hFDAeHSk1ExMQLCoULRo/KSsBASktPwwUCy8rL3BqAy0dNQoWEw0C7gYcIBUzHklgCUwWYQUfFTIPGAXTCg4gFhc4HS1PHA4QBFcCnAg0JyApEP65AwoIJDMmMBIAAAUAF//zAqkCrwAUABgALABAAFQBUbsARgADAB4ABCu7ACgAAwBQAAQruwAyAAMABQAEK7sADwADADwABCtBBQB6AAUAigAFAAJdQQ8ACQAFABkABQApAAUAOQAFAEkABQBZAAUAaQAFAAddugAVAB4ADxESOboAFwAeAA8REjlBDwAGACgAFgAoACYAKAA2ACgARgAoAFYAKABmACgAB11BBQB1ACgAhQAoAAJdQQUAegA8AIoAPAACXUEPAAkAPAAZADwAKQA8ADkAPABJADwAWQA8AGkAPAAHXUEPAAYARgAWAEYAJgBGADYARgBGAEYAVgBGAGYARgAHXUEFAHUARgCFAEYAAl24AA8QuABW3AC4ABYvuAAjL7gAAEVYuAAULxu5ABQABT5ZuAAARVi4ABUvG7kAFQAFPlm7ADcAAgAAAAQruwAKAAEALQAEK7sASwACABkABCu6ABcAFAAjERI5MDEFIi4CNTQ+AjMyHgIVFA4CIyUBMwEDIi4CNTQ+AjMyHgIVFA4CBQ4DFRQeAjMyPgI1NC4CAQ4DFRQeAjM+AzU0LgICHCQ0IhETJDUhITQjExEjNCT+dgFOSP6yOSQ0IhETJDQhITQjExEjNAFWFxwRBgcSHBUXHREFBxIc/nEXHBEGBxIcFRcdEQYHEh0NHjA+ISA7LRsbLTwgID4wHQwCqf1XAWAeMD4gIDstGxwtOyAgPjAdTwIUICgVFywkFhcjLRcVKB8VAW8CFCApFRcsJBUBFiMsFxUoIBQAAAACADH//wJCAnUALwA+AM+7ADYAAwALAAQruwAtAAMAKgAEK7gALRC4AADQQQ8ABgA2ABYANgAmADYANgA2AEYANgBWADYAZgA2AAddQQUAdQA2AIUANgACXboAEwALADYREjm4ABMvuQAkAAP0ugAQABMAJBESObgAKhC4ADDQuAAtELgAQNwAuAAARVi4AAEvG7kAAQAFPlm4AABFWLgABi8buQAGAAU+WbsAGAABAB8ABCu7ACkAAQAxAAQruAAxELgAANC4AAAvugAQADEAKRESObgAKRC4AC3QMDEBESIGIiInLgM1PgM3JiYnJj4CMzIWFwcmJgciDgIVFB4CMzM1NxUzFSMnIg4CFxQeAhcWNjMB1w8zP0UfKEY1HgEVJDEbIB4BARorNx0hQx0VFzkaEx4VCgsWIRdzSWu0dSg5IxABEB4tHSpQFgFX/qkBAQEfNEUoKD4uHwoUMyQjNSMREBMnCw4BEBgfEBAiHRJRGWo0ARssOBwbMCUZAwUFAAAAAQBQAd0AlwLEAAMACwC4AAEvuAAALzAxEyczFWMTRwHd59UAAQA8/1sBLgLyACQAQ7sAHAADAAoABCtBDwAGABwAFgAcACYAHAA2ABwARgAcAFYAHABmABwAB11BBQB1ABwAhQAcAAJdALgAEy+4AAAvMDEFJiYnJiYnFSYmNTY2NzY2NzY2NxcGBgcOAxUUHgIXFhYXAQoXORojLgoFBAEDBQouIxo5FyQoPhAPFAoEBAsTDxA9KKUTMyAqa0gBH0QmJ0QfSGorIDITISVGJSNAQ0ksLElDQCMlRiUAAAABAAb/WwD4AvIAJABLuwAaAAMACAAEK0EFAHoACACKAAgAAl1BDwAJAAgAGQAIACkACAA5AAgASQAIAFkACABpAAgAB124ABoQuAAm3AC4ABEvuAAkLzAxFzY2Nz4DNTQuAicmJic3FhYXFhYXFhYXFAYHNQYGBwYGBwcoPRAPEwsEAwsUDxA+KCQXORojLgoFAwEEBQouIxo5F4UlRiUjQENJLCxJQ0AjJUYlIRMyICtqSB9EJyZEHwFIayogMxMAAAAAAQAZAYIBTALCABEAfLsAAQADAAIABCu4AAIQuAAJ0LgACS+4AAEQuAAL0LoADAACAAEREjkAuAAKL7gAAEVYuAABLxu5AAEABz5ZugAAAAEAChESOboAAwABAAoREjm6AAYAAQAKERI5ugAJAAEAChESOboADAABAAoREjm6AA8AAQAKERI5MDETFyM3Byc3JzcXJzMHNxcHFwfMAjsDXx5jYxxhAzsCYR9lYx0B9HJyOzM3MTY3b286Mjg2NAAAAQAvACkBlwHKAAsAP7sAAQADAAIABCu4AAIQuAAG0LgAARC4AAjQALgACC+4AAIvuwAJAAEAAAAEK7gAABC4AAPQuAAJELgABdAwMSUVBzUjJzM1NxUzFQEERY8BkEWT2JMcr0STG65EAAAAAQA8/58ApABkABUAJgC4AA8vuAADL7gAAEVYuAAJLxu5AAkABT5ZugAAAAMADxESOTAxFwYGByc+AzEiJjU0NjMyFhcWBgdzCA8MEA4TCwQWHh0VFB0CAxgZRQkLCBYJGRYQHhQWHxoUJjwaAAAAAAEAPADlAPsBMQAEABUAuwABAAEAAAAEK7gAARC4AAPQMDE3NTMzFTweoeVMTAAAAAEAO//3AKIAXwAMAMO7AAkABAADAAQrQQUAegADAIoAAwACXUEPAAkAAwAZAAMAKQADADkAAwBJAAMAWQADAGkAAwAHXboAAAADAAkREjkAuAAARVi4AAAvG7kAAAAFPlm5AAYAAfRBIQAHAAYAFwAGACcABgA3AAYARwAGAFcABgBnAAYAdwAGAIcABgCXAAYApwAGALcABgDHAAYA1wAGAOcABgD3AAYAEF1BCQAHAAYAFwAGACcABgA3AAYABHFBBQBGAAYAVgAGAAJxMDEXIiY1JjYzMhYVFAYjcRYfAR4VFh4eFAkeFRYfHxYVHgAAAAABAAD/ZgFPAwAAAwALALgAAS+4AAMvMDEVARcBAQ9A/vCEA4QW/HwAAgAo//cBpQHBABQAKQEbuAAqL7gAHy+4ACoQuAAA0LgAAC9BBQB6AB8AigAfAAJdQQ8ACQAfABkAHwApAB8AOQAfAEkAHwBZAB8AaQAfAAdduAAfELkACgAD9LgAABC5ABUAA/RBDwAGABUAFgAVACYAFQA2ABUARgAVAFYAFQBmABUAB11BBQB1ABUAhQAVAAJduAAKELgAK9wAuAAARVi4AA8vG7kADwAFPlm7AAUAAQAkAAQruAAPELkAGgAC9EEhAAcAGgAXABoAJwAaADcAGgBHABoAVwAaAGcAGgB3ABoAhwAaAJcAGgCnABoAtwAaAMcAGgDXABoA5wAaAPcAGgAQXUEJAAcAGgAXABoAJwAaADcAGgAEcUEFAEYAGgBWABoAAnEwMTc0PgIzMh4CFRQOAiMiLgI1MxQeAjM+AzU0LgInDgMVKBoyRy0tRjAaFzBHMDBILxdLCxosISQtGQkLGy0hJCwZCeMsUT0kJD1RLC1VQigoQlUtIEI3IgEjNkEgHjsxIAICIDE7HgAAAAABAB4AAAC/AcIABQAiuwAFAAMAAAAEKwC4AAQvuAAARVi4AAAvG7kAAAAFPlkwMTMRByc3EXZHEaEBbw8sNv4+AAAAAAEAKAAAAYwBwwArACgAuAAARVi4AAAvG7kAAAAFPlm7ABwAAgATAAQruAAAELkAKQAB9DAxMyYmJz4DNz4DJzUuAyMiDgIHJzY2FzIeAhcWDgIHBgYHIRVIBRMIHSkjJBkaKBoJBQUXHR8MCxscGwkWGkwgHDgvIAUDAxMnHyVYHQEDDSMSExsYGRMTIiIlGAEXHRAFBgkLBCcRFwEMGisfFigoKhgdNRREAAABACj/HgGJAcIAMwBTuwAuAAMABQAEK0EFAHoABQCKAAUAAl1BDwAJAAUAGQAFACkABQA5AAUASQAFAFkABQBpAAUAB124AAUQuAAl0LgAJS+4AC4QuAA13AC4ADMvMDEXPgM1NC4CJyYmIiIjNzY2NzY2JyYmJyYGByc+AhYXFhYHNwYGBx4DBw4DB1gwUz0jEiIwHQsWHSYaARYxDTc3BQU2Hxo1FxIaPT46FyAVAQECLx0jNyYUAQI+WGIltw0fLkEvGzEmGAMBAS8BAwQPNiomIQICEQskEBMEDRAXOhQBLjQPCSQyOyBFWTcbCAACABT/HQG1AcEACQAMAG+7AAkAAwAAAAQruAAJELgABNC4AAAQuAAK0LgACRC4AA7cALgABC+4AAAvuAAARVi4AAEvG7kAAQAFPlm4AABFWLgABy8buQAHAAU+WbgAARC5AAUAAfS4AAbQugAKAAAABBESObgAC9C4AAzQMDEFNSEBNxEzFSMVAwMzARz++AEGS1BQSa2t4+MBqRj+cjPLAhb+6AAAAAABADL/HgGRAbkAIgCXuAAjL7gACy9BBQB6AAsAigALAAJdQQ8ACQALABkACwApAAsAOQALAEkACwBZAAsAaQALAAdduQAAAAP0uAAjELgAE9C4ABMvuQAYAAP0uAAF0LgABS+6ABUACwAAERI5uAAAELgAJNwAuAAFL7sAFQABABYABCu7ABgAAQATAAQruAATELgAENC4ABAvuAAYELgAHdAwMSUOAwcnPgM1NC4CJyYGIxEhByMVOgMzMh4CBwGRAjxWYSYSMFI8IhEgLx0VTDQBIhrBDhQSEgwwSzIZARRFWDUbCSsNHy5CLxs0KRoDAgEBDzOkJDtJJgACACb/9gHFAp0AIwA3ASm4ADgvuAAuL7gAOBC4ABrQuAAaL7kAJAAD9EEPAAYAJAAWACQAJgAkADYAJABGACQAVgAkAGYAJAAHXUEFAHUAJACFACQAAl24AAfQuAAHL0EFAHoALgCKAC4AAl1BDwAJAC4AGQAuACkALgA5AC4ASQAuAFkALgBpAC4AB124AC4QuQAPAAP0uAA53AC4ACMvuAAARVi4ABQvG7kAFAAFPlm7AAoAAQAzAAQrugAHADMAChESObgAFBC5ACkAAvRBIQAHACkAFwApACcAKQA3ACkARwApAFcAKQBnACkAdwApAIcAKQCXACkApwApALcAKQDHACkA1wApAOcAKQD3ACkAEF1BCQAHACkAFwApACcAKQA3ACkABHFBBQBGACkAVgApAAJxMDEBBgcGBgcGBzY2Fx4DBw4DBwYmJyYmNzY2NzY2NzY2NwMGHgIXFj4CNTQuAicmBgcGAWFLLCo0CgkCG1EqMEctFAICGDNPOkBcFQoMAwIMCxVQLRw9ItoFDiEyHiI0IxILGy8kGjIUGAJyDRgXQTQuJxQeAgIkPE0pKko4IAEBQz8daT8pTSNDUBUNDgT+kkFjQyMBARwuORwZNzAhAgIRCwwAAAEAD/8dAYABuQAFABEAuAAFL7sABAABAAEABCswMRcTITchAT3s/uYkAU3+7dECP0v9ZAADAB7/9wGkAoMAIwA3AEwBlLsAQgADAA0ABCu7AB8AAwApAAQrQQUAegApAIoAKQACXUEPAAkAKQAZACkAKQApADkAKQBJACkAWQApAGkAKQAHXboAOAApAB8REjm4ADgvQQUAegA4AIoAOAACXUEPAAkAOAAZADgAKQA4ADkAOABJADgAWQA4AGkAOAAHXbkAAwAD9LoAAAANAAMREjm6ABAADQADERI5QQUAVgBCAGYAQgACXUELAAYAQgAWAEIAJgBCADYAQgBGAEIABV1BBQB1AEIAhQBCAAJdugAVAA0AQhESObgAFS+5ADMAA/S4AAMQuABO3AC4AABFWLgACC8buQAIAAU+WbsAGgACAC4ABCu7ACQAAQA9AAQrugAAAD0AJBESOboAEAA9ACQREjm4AAgQuQBHAAL0QSEABwBHABcARwAnAEcANwBHAEcARwBXAEcAZwBHAHcARwCHAEcAlwBHAKcARwC3AEcAxwBHANcARwDnAEcA9wBHABBdQQkABwBHABcARwAnAEcANwBHAARxQQUARgBHAFYARwACcTAxARYWFRQOAiMiLgI1NDY3LgM1ND4CMzIeAhUUDgInMj4CNTQuAiMiDgIVFB4CFzQuAiMiDgIVFB4CMzI+AjUBJEQ8FS9LNTVKLhU+RBgiFgsZKjkgITkrGQsWIloWIxgNDhgjFRUjGA4NGCOLDRwtHx8tHg0LGi0jIy4bCwFvF2Q6I0Y4IiI4RiM6ZBcIHiQnESA2JxUVJzUgEickHg4VIScTEiUeFBIeJhITKCEVyhc2LR4eLTYXGjYsHR0tNhoAAAAAAgAc/xkBuwG/ACQAOQC5uAA6L7gAJS9BBQB6ACUAigAlAAJdQQ8ACQAlABkAJQApACUAOQAlAEkAJQBZACUAaQAlAAdduAAI0LgACC+4ADoQuAAQ0LgAEC+4ACUQuQAbAAP0uAAQELkALwAD9EEPAAYALwAWAC8AJgAvADYALwBGAC8AVgAvAGYALwAHXUEFAHUALwCFAC8AAl24ABsQuAA73AC4ACQvuwAVAAIAKgAEK7sANAABAAsABCu6AAgACwA0ERI5MDEXNjY3NjY3NjcGBicuAzc+AzM2FhcWFgcGBgcGBgcGBgcTNi4CJyYOAhUUHgIXFjY3Njd/JjsXKjQJCgEbUSorRS8YAgMYMk85QFwVCg0DAgwLFFEtHD0j2wUOITIfIzMjEQobLyQaMRQXFrwHEQwWQjQuKBQdAQElPE0pKko3IQFDPx1oPylNI0NQFQ0OBAFuQWNDIgEBHC05HBk4MCECAhALDBEAAAACAEn//wCxAZcADAAZAPO7ABYABAAQAAQrQQUAegAQAIoAEAACXUEPAAkAEAAZABAAKQAQADkAEABJABAAWQAQAGkAEAAHXboAAAAQABYREjm4ABAQuAAD0LgAAy+4ABYQuAAJ0LgACS+6AA0AEAAWERI5ALgAAEVYuAANLxu5AA0ABT5ZuwAGAAEADAAEK7gADRC5ABMAAfRBIQAHABMAFwATACcAEwA3ABMARwATAFcAEwBnABMAdwATAIcAEwCXABMApwATALcAEwDHABMA1wATAOcAEwD3ABMAEF1BCQAHABMAFwATACcAEwA3ABMABHFBBQBGABMAVgATAAJxMDETIiY1JjYzMhYVFAYjEyImNSY2MzIWFRQGI38WHwEeFRYeHhQCFh8BHhUWHh4UAS8eFRYfHxYVHv7QHhUWHx8WFR4AAAAAAgBM/58AuAGOAAsAIQB8uwAeAAQAGAAEK0EPAAYAHgAWAB4AJgAeADYAHgBGAB4AVgAeAGYAHgAHXUEFAHUAHgCFAB4AAl24AB4QuAAA0LgAAC+4ABgQuAAG0LgABi+6ABUAGAAeERI5ALgADy+4AABFWLgAFS8buQAVAAU+WbsACQABAAMABCswMRMUBiMiJicmNjMyFgMGBgcnPgMxIiY1JjYzMhYXFgYHuB8WFh8BASAWFh8yCA8LEQ4TCwUWHwEeFhQdAgMYGQFZFh8fFhYfH/5MCQsIFgkZFhAeFBYfGhQmPBoAAAEALAAuASgCKgAFAAsAuAAAL7gAAi8wMTcnNxcHF/DExDioqC7+/iTa2gAAAgAxALoCUwGdAAMABwAXALsABQABAAQABCu7AAEAAQAAAAQrMDETJyEVBTUhF0saAgv+DAHxGgFoNTWuNTUAAAEALAAuASgCKgAFAAsAuAADL7gABS8wMTc3JzcXByyoqDnDw1La2iT+/gAAAgAo//gBrQLRACEALQDouwArAAQAJQAEK0EPAAYAKwAWACsAJgArADYAKwBGACsAVgArAGYAKwAHXUEFAHUAKwCFACsAAl26AAAAJQArERI5uAAAL7kAIQAD9AC4AABFWLgAAS8buQABAAc+WbgAAEVYuAAiLxu5ACIABT5ZugAAACIAARESObkAKAAB9EEhAAcAKAAXACgAJwAoADcAKABHACgAVwAoAGcAKAB3ACgAhwAoAJcAKACnACgAtwAoAMcAKADXACgA5wAoAPcAKAAQXUEJAAcAKAAXACgAJwAoADcAKAAEcUEFAEYAKABWACgAAnEwMTc1MzI+AiYmJyYGByc2NhceAxcWDgIHNQYHBgYjFQciJjU0NjMyFhUUBpIwKz4jBhc4LCpOGh8mYjonRTUgAQEVJTIbDAwLGgskFh4dFRYeHqTQKDxIQDAGBhwUJhskBgQdMUUtKT4tIAsBBAMCBX3GHhUWHx8WFR4AAAAAAgAy//oC1AK1AFYAYwE9uwATAAMAJgAEK7sAWwADAEIABCu7AAAAAwBjAAQruAAAELkABgAE9EEPAAYAEwAWABMAJgATADYAEwBGABMAVgATAGYAEwAHXUEFAHUAEwCFABMAAl24AGMQuABG0LgARi9BDwAGAFsAFgBbACYAWwA2AFsARgBbAFYAWwBmAFsAB11BBQB1AFsAhQBbAAJdALgAAEVYuAAhLxu5ACEABT5ZuwArAAEADgAEK7sAYAACAD0ABCu7AFEAAgBKAAQruwBGAAIAVwAEK7gAIRC5ABgAAfRBIQAHABgAFwAYACcAGAA3ABgARwAYAFcAGABnABgAdwAYAIcAGACXABgApwAYALcAGADHABgA1wAYAOcAGAD3ABgAEF1BCQAHABgAFwAYACcAGAA3ABgABHFBBQBGABgAVgAYAAJxMDEBFhY3NjY3Ni4CJyYmIyIOAhUUHgIzMjY3FhYXBgYjIi4CNTQ+AjMyFhceAgYHBgYHBicmJwYGJyIuAjU2NjMzNTQmIyIGByc2NjMyHgIVByMiBhcUHgIzMjY3AgQHIxEqKgMBEBwlEyNTLjxrTy0uUGs9RXsqChQJMY5VSIBeNzdegEg5ZSsoORsGFhMwJCYhCAMaTjMYLCASAUgzXi0cGisaECE4IxYsIRU+SyErAQsVHBEYKQgBHwkRAgU6Px87NSoNFxsuT2s9PGtQLj4zCA8IP0w3X4BISIBfNiEdHVJdXigiIwcGEAQCGCQBEyArGDQ9Hx0lDQwlEg4OGygZTiQgDxsVDRQIAAAAAgAKAAACDQKDAAcACgAzALgABi+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAADLxu5AAMABT5ZuwAKAAIAAQAEKzAxIScjByMTNxMBAzMBv0PzSDfkR9j+/G7SxMQCbBf9fQIe/tUAAAADADz/9gHhAnYAGAAlADcAzbsAJQADAAAABCu7AAYAAwAeAAQrQQUAegAeAIoAHgACXUEPAAkAHgAZAB4AKQAeADkAHgBJAB4AWQAeAGkAHgAHXboACQAeAAYREjm6ADcAHgAGERI5uAA3L0EFAHoANwCKADcAAl1BDwAJADcAGQA3ACkANwA5ADcASQA3AFkANwBpADcAB125AA4AA/S6ACYAHgAGERI5uAAlELgALNC4ACwvuAAOELgAOdwAuwABAAEAIwAEK7sAJQACACwABCu6AAkALAAlERI5MDETMzIeAgcGBgceAxcUDgIHBiYnJicTMj4CNTQuAiMjBwU0LgIjIwceAzc+AzU8xR04LBoBAR4gGzAkFQEfNEYnM1IfJB3JFB0SCQ4YIRJzAQEJECM3KHYBCB4mLBUdLiERAnYSIzUkJDMUCx8tPSgoRTUgBAUXERMbATsTHiMQESAZD77JGDctHvsIEw8JAwQbJzEbAAABABz/+gH6AoQAJgDHuwAaAAQACQAEK0EPAAYAGgAWABoAJgAaADYAGgBGABoAVgAaAGYAGgAHXUEFAHUAGgCFABoAAl0AuAAARVi4AAMvG7kAAwAFPlm7AA4AAQAVAAQruAADELkAIQAB9EEhAAcAIQAXACEAJwAhADcAIQBHACEAVwAhAGcAIQB3ACEAhwAhAJcAIQCnACEAtwAhAMcAIQDXACEA5wAhAPcAIQAQXUEJAAcAIQAXACEAJwAhADcAIQAEcUEFAEYAIQBWACEAAnEwMSUGBiMjIi4CNz4DFxYWFwcmJiMiDgIHFB4EMzI+AjcB+jdtPgE9XkAgAgEhQGBANlwlGiNIJzJDKREBBxEcJjIgGysoLB1KKyU/YnQ2OHJcOQEBGRssFxI0TlwpGT08OCsaCBEYEAAAAgA8//kB/gJ3ABAAHwDxuAAgL7gAGi+4ACAQuAAA0LgAAC9BBQB6ABoAigAaAAJdQQ8ACQAaABkAGgApABoAOQAaAEkAGgBZABoAaQAaAAdduAAaELkABgAD9LgAABC5ABEAA/S4AAYQuAAh3AC4AAAvuAAARVi4AAsvG7kACwAFPlm7AAEAAQAfAAQruAALELkAFQAB9EEhAAcAFQAXABUAJwAVADcAFQBHABUAVwAVAGcAFQB3ABUAhwAVAJcAFQCnABUAtwAVAMcAFQDXABUA5wAVAPcAFQAQXUEJAAcAFQAXABUAJwAVADcAFQAEcUEFAEYAFQBWABUAAnEwMRMXMh4CFRQOAiMiLgInExEWFjMyPgI1NC4CIzzKQV48HSNCXTkeOjMsEEoSPCAuRS4WETBTQgJ3ATpddDo6cFg2DxYcDQH9/hQRGy9JWiszZlAyAAEAPAAAAZsCdwALAEi7AAQAAwABAAQruAAEELgACNAAuAACL7gAAEVYuAAALxu5AAAABT5ZuwABAAEABAAEK7sABgABAAcABCu4AAAQuQAJAAH0MDEzAyUHIxUzByMRIRU9AQFfGf3SGrgBEAJ2ATPYMv74MgAAAAEAPAAAAZoCdgAJAD67AAkAAwAAAAQruAAJELgABNC4AAQvALgAAEVYuAAALxu5AAAABT5ZuwACAAEAAwAEK7sABgABAAcABCswMTMRIQcjFTMHIxE8AV4a/NMbtwJ2M9cy/sYAAAAAAQAd//oB7wKDACcA77gAKC+4AAAvuQADAAP0uAAoELgADNC4AAwvuQAfAAT0QQ8ABgAfABYAHwAmAB8ANgAfAEYAHwBWAB8AZgAfAAddQQUAdQAfAIUAHwACXbgAAxC4ACncALgAAEVYuAAHLxu5AAcABT5ZuwARAAEAGgAEK7sAAwACAAAABCu4AAcQuQAkAAH0QSEABwAkABcAJAAnACQANwAkAEcAJABXACQAZwAkAHcAJACHACQAlwAkAKcAJAC3ACQAxwAkANcAJADnACQA9wAkABBdQQkABwAkABcAJAAnACQANwAkAARxQQUARgAkAFYAJAACcTAxASM3FxEGBiMiLgI3PgMXHgMXByYmIyIOAgcGHgIzMjY3AaZ9GK43Yz49Xj8gAQEhP19AGy8sKxcaI0gnMkMpEQEBEylDLyc7HQEkMQH++CwmP2F0NjhzXDgBAQUMFA8sFxMzTl0pJl9TOBYRAAAAAAEAPAAAAfsCggALAGe4AAwvuAAAL7gADBC4AATQuAAEL7kAAwAD9LgABtC4AAAQuAAI0LgAABC5AAsAA/S4AA3cALgABi+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAADLxu5AAMABT5ZuwAIAAEAAQAEKzAxIREhESMRNxEhETMRAbH+1UpKAStKASv+1QJpGf7dARf9igAAAQBGAAAAkAKCAAMAIrsAAwADAAAABCsAuAACL7gAAEVYuAAALxu5AAAABT5ZMDEzETcRRkoCaRn9fgAAAQAK//gBGgKDABMAKrsAAQADAAAABCu4AAEQuAAV3AC4AAEvuAAARVi4AAcvG7kABwAFPlkwMRM3ERQOAiMiJic3FhYXFj4CNdBKGzNHLBgiFRAIFAgxOh4JAmoZ/kw4UjQZCQouAggBCBsyPx0AAAEAPAAAAeICgwALAEm7AAMAAwAEAAQruAADELgABtAAuAAGL7gACC+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAADLxu5AAMABT5ZugAHAAAABhESOTAxIQMHESMRNxEBFwcTAYrXLklJAQsp0vsBQTL+8QJqGf7ZASci5/6GAAAAAQA8AAABbgKCAAUAKLsAAwADAAAABCsAuAACL7gAAEVYuAAALxu5AAAABT5ZuQADAAH0MDEzETcRMxc8Sc4bAmoY/bI0AAAAAQA8//cCiwKCAAwAirgADS+4AAAvuAANELgABtC4AAYvuQAFAAP0uAAAELkADAAD9LoACQAGAAwREjm4AA7cALgACC+4AABFWLgAAy8buQADAAU+WbgAAEVYuAAALxu5AAAABT5ZuAAARVi4AAUvG7kABQAFPlm6AAEAAwAIERI5ugAEAAMACBESOboACQADAAgREjkwMSERAwcDESMRNxMTMxECQsc+zjNJ4s9VAgj+BRYB//4KAmoY/eYCDv2KAAAAAAEAPAAAAhgCgwAJAG24AAovuAAGL7gAChC4AAPQuAADL7kAAgAD9LgABdC4AAUvuAAGELkACQAD9LgAC9wAuAAFL7gAAEVYuAAALxu5AAAABT5ZuAAARVi4AAIvG7kAAgAFPlm6AAEAAAAFERI5ugAGAAAABRESOTAxIQERIxE3AREzEQHQ/p8zOgFwMgIE/fwCbxT95gIN/YoAAAIAHv/3Aj0ChAAUACgBGLgAKS+4ABovQQUAegAaAIoAGgACXUEPAAkAGgAZABoAKQAaADkAGgBJABoAWQAaAGkAGgAHXbkAAAAD9LgAKRC4AArQuAAKL7kAJAAD9EEJADYAJABGACQAVgAkAGYAJAAEXUEHAAYAJAAWACQAJgAkAANdQQUAdQAkAIUAJAACXbgAABC4ACrcALgAAEVYuAAFLxu5AAUABT5ZuwAPAAEAHwAEK7gABRC5ABUAAfRBIQAHABUAFwAVACcAFQA3ABUARwAVAFcAFQBnABUAdwAVAIcAFQCXABUApwAVALcAFQDHABUA1wAVAOcAFQD3ABUAEF1BCQAHABUAFwAVACcAFQA3ABUABHFBBQBGABUAVgAVAAJxMDEBFA4CIyIuAjU0PgIzMh4CFQEyPgI1NC4CIyIOAhUUHgICPCNEZkJCZkQjJEZkQUFlRiT+7y5GMBgXL0YvMEcvFxgwRgFFOndgPT1gdzo8clo3N1pyPP7rMU9jMi5dTDAwTF0uMmNPMQACADwAAAG2AngAEQAcAKa4AB0vuAAVL7gAHRC4AADQuAAAL7kAEQAD9LgAAtC4AAIvQQUAegAVAIoAFQACXUEPAAkAFQAZABUAKQAVADkAFQBJABUAWQAVAGkAFQAHXbgAFRC5AAoAA/S4ABEQuAAb0LgAChC4AB7cALgAAS+4AAUvuAAARVi4AAAvG7kAAAAFPlm7ABIAAQAPAAQruAAFELgAAtC4AAIvuAAFELkAGgAB9DAxMxEzMjYzMh4CFRQOAiMjERMyNjU0LgIjIxU8RR5GHiZBMBwZLT4kiXM0QBIfKRh1AncBGi4+JCQ9LRn+2QFZQjUWKiAT6gACAB7/cwI9AoQAHwAzAT64ADQvuAAlL7gANBC4AArQuAAKL0EFAHoAJQCKACUAAl1BDwAJACUAGQAlACkAJQA5ACUASQAlAFkAJQBpACUAB124ACUQuQAUAAP0uAAlELgAH9C4AAoQuQAvAAP0QQ8ABgAvABYALwAmAC8ANgAvAEYALwBWAC8AZgAvAAddQQUAdQAvAIUALwACXbgAFBC4ADXcALgAAEVYuAAFLxu5AAUABT5ZuAAARVi4ABkvG7kAGQAFPlm7AA8AAQAqAAQruwAeAAEAAAAEK7gABRC5ACAAAfRBIQAHACAAFwAgACcAIAA3ACAARwAgAFcAIABnACAAdwAgAIcAIACXACAApwAgALcAIADHACAA1wAgAOcAIAD3ACAAEF1BCQAHACAAFwAgACcAIAA3ACAABHFBBQBGACAAVgAgAAJxMDEFBi4CJy4DNTQ+AjMyHgIVFA4CBx4DMzMnMj4CNTQuAiMiDgIVFB4CAcohPTAhBT1cPyAkRmRBQWVGJB48WDkEFyAnFSC8LkYwGBcvRi8wRy8XGDBGiwIRIzMeBUBecjg8clo3N1pyPDZvXUEIExsRCH0xT2MyLl1MMDBMXS4yY08xAAIAPAAAAbkCdwARABwAq7gAHS+4ABUvuAAdELgABNC4AAQvuQADAAP0QQUAegAVAIoAFQACXUEPAAkAFQAZABUAKQAVADkAFQBJABUAWQAVAGkAFQAHXbgAFRC5AAsAA/S4ABHQuAARL7gAAxC4ABvQuAALELgAHtwAuAAARVi4AAAvG7kAAAAFPlm4AABFWLgAAy8buQADAAU+WbsABgABABoABCu7ABIAAQAQAAQruAAQELgAAdAwMSEDIxEjETMyHgIVFA4CIxMDNjY1NC4CIyMVAWGnNUnHJUIwHBktPiSrwDQ/Eh8pGHUBJ/7ZAncaLj4kJD0sGf7ZAVoBQzEWKiAU6gAAAAEAHv/5AcQChAA4ATC4ADkvuAATL0EFAHoAEwCKABMAAl1BDwAJABMAGQATACkAEwA5ABMASQATAFkAEwBpABMAB124AADQuAAAL7gAORC4ABzQuAAcL7gAExC4ACXQuAAlL7gAHBC5ACsAA/RBBwAGACsAFgArACYAKwADXUEJADYAKwBGACsAVgArAGYAKwAEXUEFAHUAKwCFACsAAl24ABMQuQA1AAP0uAA63AC4AABFWLgAAy8buQADAAU+WbsAIQABACgABCu4AAMQuQAOAAH0QSEABwAOABcADgAnAA4ANwAOAEcADgBXAA4AZwAOAHcADgCHAA4AlwAOAKcADgC3AA4AxwAOANcADgDnAA4A9wAOABBdQQkABwAOABcADgAnAA4ANwAOAARxQQUARgAOAFYADgACcTAxJQYGIyIuAic3HgMzMjY3NjU0JicnJicmJjU0PgIzMhYXByYmIyYGBwYWFxcWFhcWFhUUBgcBbR9CKxw4MywQHw0lLC8YIycULzU5P1MeFBEdNUstM0shHxk7KDtBAQE1OEcqNBMTEC0qHxQSDRUcDzMLFxMMCw8iNyoyExUcIBQzHihCMBohGDASGwE5MCQtEhcOIBYXOB0sThwAAAAAAQAKAAAByQJ3AAcANLsABwADAAAABCsAuAAEL7gAAEVYuAAALxu5AAAABT5ZuwADAAIAAgAEK7gAAhC4AAXQMDEzESM3JRUjEca8FwGouQJFMQEy/bsAAAEAN//3Af4CgwAVAK24ABYvuAAAL7kAAQAD9LgAFhC4AA3QuAANL7kADgAD9LgAARC4ABfcALgADi+4AABFWLgABy8buQAHAAU+WbkAEgAB9EEhAAcAEgAXABIAJwASADcAEgBHABIAVwASAGcAEgB3ABIAhwASAJcAEgCnABIAtwASAMcAEgDXABIA5wASAPcAEgAQXUEJAAcAEgAXABIAJwASADcAEgAEcUEFAEYAEgBWABIAAnEwMQEzERQOAiMiLgI1ETcTFBY3MjY1AcU5Iz5UMTBSPCNKAUxQT1gCdv5gMlI7ICA7UTIBlRn+XlFeAWFPAAAAAQAK//cB9gKDAAYAJgC4AAIvuAAEL7gAAEVYuAAALxu5AAAABT5ZugADAAAAAhESOTAxFwM3ExMXA+nfSLu6L9YJAnEb/fcCCBH9mgAAAAABAAr/9wLzAoMADABPALgABS+4AAgvuAAKL7gAAEVYuAAALxu5AAAABT5ZuAAARVi4AAMvG7kAAwAFPlm6AAEAAAAKERI5ugAGAAAAChESOboACQAAAAoREjkwMQUDAwcDNxMTNxMTFwMCFpqJObBHjYZIjY8rpQkCH/31FAJyGf4DAeQZ/gMB/gn9kQAAAAABACgAAAIeAoMACwBBALgABi+4AAgvuAAARVi4AAAvG7kAAAAFPlm4AABFWLgAAi8buQACAAU+WboAAQAAAAYREjm6AAcAAAAGERI5MDEhAwMjEwM3FzcXAxMBx621PdS+SqCnMrvYARL+7gFAASsY//4T/ub+qwABAAoAAAHGAoMADAA6uwAMAAMAAAAEK7oABAAAAAwREjkAuAADL7gACS+4AABFWLgAAC8buQAAAAU+WboABAAAAAMREjkwMTMRAzcTNjY3NjcXAxHCuEalEzcaHiAvuwElAUQa/twjZC42ORP+rP7kAAAAAAEAKAAAAhgCdgAIACgAuAAARVi4AAAvG7kAAAAFPlm7AAQAAQABAAQruAAAELkABQAB9DAxMwEhNyEBISMXKAFd/rcZAaT+pAF7AQECRDL9vTMAAAEAPP90AOsC7AAHACW7AAUAAwAAAAQrALgAAC+7AAYAAQAHAAQruwACAAEAAwAEKzAxFxEzByMRMxU8rxdQXYwDeDP87zMAAAEAAP9mAVADAAADAAsAuAAAL7gAAi8wMQUBNwEBEP7wQAEQmgOEFvx8AAAAAQAf/3QAzwLsAAcALbsABwADAAIABCu4AAcQuAAJ3AC4AAcvuwABAAEAAAAEK7sABgABAAMABCswMRc1MxEjJzMRKl1QGLCLMwMRM/yIAAABAFIBWQI6AskABgAZALgAAC+4AAIvuAAEL7oAAQAAAAQREjkwMQEDAycTMxMB/be3PdY81gFZARz+5BcBWf6mAAAAAAEABP+DAfT/tQADAA0AuwABAAEAAAAEKzAxFychFRYSAfB9MjIAAAABAEIB+wElApUAAwALALgAAS+4AAMvMDETNxcHQh3GIwJaO3YkAAAAAgAe//cBcQHBACIALwEPuAAwL7gAIy+4ADAQuAAK0LgACi+4ACMQuAAQ0LgAEC+4ACMQuQAiAAP0uAAKELkAKQAD9EEPAAYAKQAWACkAJgApADYAKQBGACkAVgApAGYAKQAHXUEFAHUAKQCFACkAAl24ACIQuAAx3AC4AABFWLgABS8buQAFAAU+WbsAHQACABYABCu7AA8AAgAmAAQruAAmELgAI9C4ACMvuAAFELkALAAC9EEhAAcALAAXACwAJwAsADcALABHACwAVwAsAGcALAB3ACwAhwAsAJcALACnACwAtwAsAMcALADXACwA5wAsAPcALAAQXUEJAAcALAAXACwAJwAsADcALAAEcUEFAEYALABWACwAAnEwMSUOAyciLgI1PgMzMzU0LgIjIgYHJzY2MzIeAhUHIgYjBgYVFBYXMjY3AXEQKTE6IR40JhYBFyk2IHcQGiMSITUdEidELRs1KBlHETQbKjg4LCA0CkMQHBQMARcnNR4gMyMSKxMfFgwQDyoVERIhMB5dAQEsKiY7ARkLAAAAAAIAPP/2AbcCuQAVACgBAbgAKS+4ACAvuAApELgABdC4AAUvuQAoAAP0uAAH0EEFAHoAIACKACAAAl1BDwAJACAAGQAgACkAIAA5ACAASQAgAFkAIABpACAAB124ACAQuQAQAAP0ugAIAAUAEBESObgAKtwAuAAHL7gAAEVYuAAALxu5AAAABT5ZuwALAAEAJQAEK7oACAAlAAsREjm4AAAQuQAbAAL0QSEABwAbABcAGwAnABsANwAbAEcAGwBXABsAZwAbAHcAGwCHABsAlwAbAKcAGwC3ABsAxwAbANcAGwDnABsA9wAbABBdQQkABwAbABcAGwAnABsANwAbAARxQQUARgAbAFYAGwACcTAxBS4DMRE3ETY2Fx4DFRQOAicnHgM3PgM1NC4CJyYGBwEHN00xFkcfQCUtQiwVGCxCKoMDFh8pFyApGAkHGCskIkESCAIYHBYCXRj+4RMVAQIlPU4qMFdCJgFWBA0MCAEBJjg/Gxw7MiICAhgLAAAAAAEAHv/3AXEBwgAhALm7ABkAAwAIAAQrQQ8ABgAZABYAGQAmABkANgAZAEYAGQBWABkAZgAZAAddQQUAdQAZAIUAGQACXQC4AABFWLgAAy8buQADAAU+WbkAHgAC9EEhAAcAHgAXAB4AJwAeADcAHgBHAB4AVwAeAGcAHgB3AB4AhwAeAJcAHgCnAB4AtwAeAMcAHgDXAB4A5wAeAPcAHgAQXUEJAAcAHgAXAB4AJwAeADcAHgAEcUEFAEYAHgBWAB4AAnEwMSUGBiMiLgI1NDY3NjYWFhcHJiYHDgMVFB4CMxY2NwFxIFEwKkIuGDEuFzg7OxoVFzgaHiwdDxAfLx8jOB4lFRknP1ApPm8gEA8CERAnCw8CAiM1QR8ePTIhARYOAAACAB7/+AGdAroAEgAjAP+4ACQvuAAAL7kAAQAD9LgAJBC4AArQuAAKL7gAABC4ABPQuAAKELkAGwAD9EEPAAYAGwAWABsAJgAbADYAGwBGABsAVgAbAGYAGwAHXUEFAHUAGwCFABsAAl24AAEQuAAl3AC4AAEvuAAARVi4AAUvG7kABQAFPlm7AA8AAgAWAAQrugASABYADxESObgABRC5ACAAAvRBIQAHACAAFwAgACcAIAA3ACAARwAgAFcAIABnACAAdwAgAIcAIACXACAApwAgALcAIADHACAA1wAgAOcAIAD3ACAAEF1BCQAHACAAFwAgACcAIAA3ACAABHFBBQBGACAAVgAgAAJxMDEBNxMGBiMiLgI1ND4CMzIWFxUmJiMiDgIVFB4CMzI2NwFWRgEtaD0tQSsUFy1ELSNAIBw0ISMuGwwLGy0hIj8UAqIY/YsjKipCUScoUkIpEQ84ERclOEIbGj42JRsOAAAAAAIAHv/2AXsBvgAeACoAabgAKy+4AB8vuQAVAAP0uAAA0LgAAC+4AB8QuAAD0LgAAy+4ACsQuAAL0LgACy+5ABYAA/S4AAjQuAAWELgAKdC4ACkvuAAVELgALNwAuwAQAAIAJAAEK7oAFgAbAAMruAAkELgAKtwwMSUGBgcGBiYmJyYmNTQ+AjMyHgIXIQYeAjc2NjcnNC4CIyIOAgczAXsRJBYYNDUxEyQpEypDMC4/KRIB/vQDESQzHyY5HDwLFiQYGiUXDALAKAsTBwcGBBERH2E4K1RCKR45UTMrRjEbAQIUDsIYLyYXFyYuGAAAAAEAHgAAAUMCvwAYAFC7ABgAAwAAAAQruAAAELgABNC4ABgQuAAT0LgAEy8AuAAIL7gAAEVYuAAALxu5AAAABT5ZuwAEAAEAAQAEK7gABBC4ABTQuAABELgAFtAwMTMRIzUzNTQ2MzMyFhcHJyYOAhUHMxUjEU0vL2hYARAYDRAJMzoeCAFlZQGCMzJxZwUFLAMJGzJAHDcz/n4AAAIAKP8dAakBwAAmADcBD7gAOC+4ADcvuAAK0LgACi+4ADcQuAAN0LgADS+4ADgQuAAV0LgAFS+4ADcQuQAeAAP0uAAVELkALwAD9EEPAAYALwAWAC8AJgAvADYALwBGAC8AVgAvAGYALwAHXUEFAHUALwCFAC8AAl24AB4QuAA53AC4ACYvuAAARVi4ABAvG7kAEAAFPlm7ABoAAQAqAAQruAAQELkANAAC9EEhAAcANAAXADQAJwA0ADcANABHADQAVwA0AGcANAB3ADQAhwA0AJcANACnADQAtwA0AMcANADXADQA5wA0APcANAAQXUEJAAcANAAXADQAJwA0ADcANAAEcUEFAEYANABWADQAAnG6AA0AEAA0ERI5MDEXPgM3PgM1NDYnBgYjIi4CNTQ+AjMyFhcDFAYHDgMHEyYmIyIOAhUUHgIzMjY3rRUxLicLBgYDAQEBIkIqLUErFBUrQCwzcjABCRAOMjw/HKgcNCEjLRwLCxsrISI3HbUDCA8aFQoeIB8MCA8IFxcpQVAoJVFELCYq/rAoWR4aJhgLAQJKERYkN0AbGj40IxwRAAEAPAAAAaACuQAXAHO4ABgvuAAAL7gAGBC4AAvQuAALL7kACgAD9LgADdC4AAAQuQAXAAP0ugAOAAsAFxESObgAGdwAuAANL7gAAEVYuAAALxu5AAAABT5ZuAAARVi4AAovG7kACgAFPlm7ABEAAQAGAAQrugAOAAAADRESOTAxIRE0LgIjIgYHESMRNxE2NjMyHgIVEQFWChQgFiM+HElJIUstHTAiEwEaEycfFCEU/q4Cohf+zRgbFSUyHP7PAAIAPAAAAJsCfgAMABAAMrsADwADAAwABCu4AA8QuQANAAP0ALgAAEVYuAANLxu5AA0ABT5ZuwADAAEACQAEKzAxEzQ2MzIWFRQGIyImNRMRNxE8HBQUGxwUFBsMSAJPFBscFBQbGxT9sgGpGP4/AAAC/4j/AgCiAn4ADAAgABu7AA8AAwAgAAQrALgAFC+7AAMAAQAJAAQrMDETNDYzMhYVFAYjIiY1FzcRFA4CIyImJzcWFhcWPgI1QxwUFBscFBQbC0kbMkcsGCIVEAcVCDE6HggCTxQbHBQUGxsUphr+GDhSNRkJCTADBwIHGzA+HQAAAAABADwAAAGdArkACwBFuwADAAMABAAEK7gAAxC4AAbQALgABi+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAADLxu5AAMABT5ZugAHAAAABhESOTAxIScHFSMRNxE3FwcTAUeZKUlJzSSRuOslxgKgGf5QuiKD/uIAAAABADz/8gDVArkACQARuwAGAAMAAwAEKwC4AAUvMDEXBiY1ETcRFBYX1UlQRywmBwc8OQI7F/2wLBwCAAABADIAAAJsAcEAJwB6uwAUAAMAFQAEK7sACwADAAwABCu7ACYAAwABAAQruAAmELgAKdwAuAAARVi4AAAvG7kAAAAFPlm4AABFWLgACy8buQALAAU+WbgAAEVYuAAULxu5ABQABT5ZuwAbAAEAEAAEK7gAEBC4AATQuAAEL7gAGxC4ACHQMDEhAzQmBwYGBxYWFREjETQmBwYGBxEjET4DMzIWFzY2MzIeAhURAiMBMjcUKQ0CAkkyORQoCEkYKSowHx44FCFCLBkwJhgBKjM1AgEVCgcSCP6xASozNQMCFQn+kQF4EhsSChYVFBcQHy0b/rYAAQAyAAABkwHFABQATbgAFS+4AAAvuAAVELgACdC4AAkvuQAIAAP0uAAAELkAFAAD9LgAFtwAuAAARVi4AAAvG7kAAAAFPlm4AABFWLgACC8buQAIAAU+WTAxIRE0JgcGBgcRIxE2Njc2NhcWFhURAUo8MB01EUkcNSMbRycoPAEqMzUBARUM/pEBeBQfCQgJCQk3Lf6xAAACAB7/9wGvAcEAEwAoARu4ACkvuAAeL7gAKRC4AAXQuAAFL0EFAHoAHgCKAB4AAl1BDwAJAB4AGQAeACkAHgA5AB4ASQAeAFkAHgBpAB4AB124AB4QuQAPAAP0uAAFELkAFAAD9EEPAAYAFAAWABQAJgAUADYAFABGABQAVgAUAGYAFAAHXUEFAHUAFACFABQAAl24AA8QuAAq3AC4AABFWLgAAC8buQAAAAU+WbsACgABACMABCu4AAAQuQAZAAL0QSEABwAZABcAGQAnABkANwAZAEcAGQBXABkAZwAZAHcAGQCHABkAlwAZAKcAGQC3ABkAxwAZANcAGQDnABkA9wAZABBdQQkABwAZABcAGQAnABkANwAZAARxQQUARgAZAFYAGQACcTAxFyIuAjU0PgIzMh4CFRQOAicUHgIzMj4CNTQuAicOAxXlM0oyGBs0Si8vSzQbGDNMqgscLyMmLxoJDBwvIyYuGwkJKEJVLSxRPSQkPVEsLVVCKOwgQzgkJTdDIB47MSACAiAxOx4AAgA8/xsBuAHBABUAKgEDuAArL7gAIC+4ACsQuAAA0LgAAC9BBQB6ACAAigAgAAJdQQ8ACQAgABkAIAApACAAOQAgAEkAIABZACAAaQAgAAdduAAgELkADAAD9LgAABC5ABYAA/S4ABTQuAAUL7gADBC4ACzcALgAFS+4AABFWLgAES8buQARAAU+WbsABwACACUABCu4ABEQuQAbAAH0QSEABwAbABcAGwAnABsANwAbAEcAGwBXABsAZwAbAHcAGwCHABsAlwAbAKcAGwC3ABsAxwAbANcAGwDnABsA9wAbABBdQQkABwAbABcAGwAnABsANwAbAARxQQUARgAbAFYAGwACcboAFAARABsREjkwMRcTMD4CNxc2HgIVFA4CBwYmJxEDHgM3PgM1NC4CJyYOAgc8ARYxTTgBLUErFRUsQi0lQB8BCRofIhEkKxYHBxUpIhcpIRUEywI/Fx0YAQEBJkJWMCpPPSYBARYT/v0BNQYODAcBAiIzOxwbPzYmAgEIDAwEAAACACP/GwGkAcAAFwAoAQO4ACkvuAAAL7gAKRC4AAzQuAAML7gAABC5ABcAA/S4AAAQuAAY0LgADBC5ACAAA/RBDwAGACAAFgAgACYAIAA2ACAARgAgAFYAIABmACAAB11BBQB1ACAAhQAgAAJduAAXELgAKtwAuAAAL7gAAEVYuAAGLxu5AAYABT5ZuwARAAIAGwAEK7gABhC5ACUAAvRBIQAHACUAFwAlACcAJQA3ACUARwAlAFcAJQBnACUAdwAlAIcAJQCXACUApwAlALcAJQDHACUA1wAlAOcAJQD3ACUAEF1BCQAHACUAFwAlACcAJQA3ACUABHFBBQBGACUAVgAlAAJxugABAAYAJRESOTAxBREOAyM1Ii4CNTQ+AjMyHgIXEQMmJiMiDgIVFB4CMzI2NwFbER4gJBgtQSsUFy1FLxo3NjASSRg4ISMsGwoKGishIjYd5QELCxEMBwEpQVAnKlJCKQsVHhP9yAIyERckN0EbGj42JB0SAAEAPAAAATcBxwARAB67ABEAAwAAAAQrALgAAEVYuAAALxu5AAAABT5ZMDEzETY3NjYXBgYHJiYjIyIGBxE8Kj4hRC4HEAYLFggBJDMUAWwvFQwLCA4fDgIEFxH+ngAAAAEAKP/0AWIBxAA6ARi4ADsvuAAIL0EFAHoACACKAAgAAl1BDwAJAAgAGQAIACkACAA5AAgASQAIAFkACABpAAgAB124ADsQuAAW0LgAFi+5ACYAA/RBCQA2ACYARgAmAFYAJgBmACYABF1BBwAGACYAFgAmACYAJgADXUEFAHUAJgCFACYAAl24AAgQuQAyAAP0uAA83AC4AABFWLgANy8buQA3AAU+WbsAGwABACEABCu4ADcQuQADAAH0QSEABwADABcAAwAnAAMANwADAEcAAwBXAAMAZwADAHcAAwCHAAMAlwADAKcAAwC3AAMAxwADANcAAwDnAAMA9wADABBdQQkABwADABcAAwAnAAMANwADAARxQQUARgADAFYAAwACcTAxNxYWMzI+Aic0LgInJiYnJiYnJiY1ND4CMzIWFwcmIyIOAhUUFhcWFhcWFhcWFhUUDgIjIiYnQhc9HRIlHhMBDhUaDAoUCxQpERIYGis3HSI/HhsyLhAfGhAVEREqFRQpERIYHzI+HyZJHU8RFggTHRUQFg8LBQQHBAcSDQ4mHx8xIREUESsdCBEaEhMWCAgRCAgRDg4pHiM0IhEbFgAAAQAe//MA6wJKABEAVrsADgADAAMABCu4AAMQuAAH0LgADhC4AAnQuAADELkAEQAE9LgAC9AAuAAARVi4AAkvG7kACQALPlm7AAcAAgAEAAQruAAHELgACtC4AAQQuAAM0DAxFwYmNREjNTM1NxUzFSMRFBYX60lSMjJJUlIsJgYHPDkBHy96GpQv/uMsHAIAAQAy//gBmgHBABMArbgAFC+4AAAvuQABAAP0uAAUELgACtC4AAovuQANAAP0uAABELgAFdwAuAAML7gAAEVYuAAFLxu5AAUABT5ZuQAQAAL0QSEABwAQABcAEAAnABAANwAQAEcAEABXABAAZwAQAHcAEACHABAAlwAQAKcAEAC3ABAAxwAQANcAEADnABAA9wAQABBdQQkABwAQABcAEAAnABAANwAQAARxQQUARgAQAFYAEAACcTAxATMRBgYjIi4CNRE3ERQWNzY2NwFRSS5rQRkyKRpLQTAdNBIBuf6HIScPHy8hATIZ/s4zNgEBFgwAAAEAD//1AaMByQAGACYAuAACL7gABC+4AABFWLgAAC8buQAAAAU+WboAAwAAAAIREjkwMRcDNxMTFwPEtUOZiy2eCwG4HP6QAWoW/l0AAAAAAQAP//gCXAHBAAwATwC4AAUvuAAIL7gACi+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAADLxu5AAMABT5ZugABAAAABRESOboABgAAAAUREjm6AAkAAAAFERI5MDEFAwMHAzcTEzcTExcDAalzXjyNQ3BZQ3FgLXcIAV3+uBUBsRj+qwE9GP6rAVUQ/lwAAAAAAQAeAAABlQG5AAsAXwC4AAYvuAAIL7gAAEVYuAAALxu5AAAABT5ZuAAARVi4AAIvG7kAAgAFPlm6AAEAAAAGERI5ugADAAAABhESOboABQAAAAYREjm6AAcAAAAGERI5ugAJAAAABhESOTAxIScHJzcnNxc3FwcXAT5vcUCRi0ZvbzaFnKWlAdTNF6ekEsHjAAAAAAEAMv8dAaEBwQAsAM+4AC0vuAAfL7gACtC4AAovuAAfELgADdC4AA0vuAAtELgAFdC4ABUvuQAYAAP0uAAfELkAIgAD9LgALtwAuAAsL7gAFy+4AABFWLgAEC8buQAQAAU+WbkAHAAB9EEhAAcAHAAXABwAJwAcADcAHABHABwAVwAcAGcAHAB3ABwAhwAcAJcAHACnABwAtwAcAMcAHADXABwA5wAcAPcAHAAQXUEJAAcAHAAXABwAJwAcADcAHAAEcUEFAEYAHABWABwAAnG6AA0AEAAcERI5MDEXPgM3PgM1NDYnBgYjIi4CNRE3ETUUFjc2NjcRMxEUDgIHDgMHphUxLicLBgYDAQEBEUxAGTIpGUpAMR08EkkCBQkIDjI8Pxy1AwgPGhUKHiAfDAgDCAgaESEwHgEwGf7NATMzAQEaDAFl/nMTLi4qDxomGAsBAAABAB4AAAGCAbYABwAoALgAAEVYuAAALxu5AAAABT5ZuwAEAAEAAQAEK7gAABC5AAUAAfQwMTMTIzchAzMVHuTcGQEx5PYBhDL+fDIAAQAe/1MBRQMRACoAL7sAJQADAAYABCu4AAYQuAAO0LgAJRC4ABnQALgAAC+4ABUvugAfAAAAFRESOTAxBSYmJyYmNTc2JicnNjY3NzQ2NzY2NxcGBhUVFA4CBx4DFRUGHgIXAS0fSxwOFgEBNjABMDQBARYOHEofGDZDERwiEhIiHBECECEuG60JLiMSOCB/NjkMQgw5Nn8gOBIhLwovFFAvkBwtIxkICBkjLRyQFywmHwoAAQBQ/9oAmgLnAAMAFbsAAwADAAAABCsAuAACL7gAAC8wMRcRNxFQSiYC9Rj9CwAAAQAM/1MBMgMRACwAL7sAJgADAAUABCu4AAUQuAAQ0LgAJhC4AB3QALgAFy+4ACwvugALACwAFxESOTAxFz4DJzU0PgI3LgM1NTYuAic3FhYXFhYVFRQWFxUGBhUVFAYHBgYHDBsuIRACERwiEhIiHBECECEuGxgfSxsOFjUwMDUWDhtLH34KHyYsF5EcLSMZCAgZIy0ckBcsJh8KMAkuIxI4IH82OQxCDDk2gCA4EiIuCQAAAQAwAOEBagE6ABgAFwC7ABUAAQADAAQruwAQAAEACAAEKzAxAQYGIyIuAiMjIgYHJzY2MzIeAjMyNjcBahkyJBEaGRoQARYbERoZMiQRGhkaERYbEAESGRgKDQoQDiUZGAoNChAOAAAEAAoAAAINAxUADAAZACEAJQD/uAAmL7gAAy9BBQB6AAMAigADAAJdQQ8ACQADABkAAwApAAMAOQADAEkAAwBZAAMAaQADAAdduQAJAAT0ugAAAAMACRESObgAJhC4ABDQuAAQL7kAFgAE9EEPAAYAFgAWABYAJgAWADYAFgBGABYAVgAWAGYAFgAHXUEFAHUAFgCFABYAAl26AA0AEAAWERI5ugAjABAACRESOboAJAAQABYREjm6ACUAAwAJERI5uAAJELgAJ9wAuAAARVi4ABovG7kAGgAFPlm4AABFWLgAHS8buQAdAAU+WbsABgABAAwABCu7ACUAAgAbAAQruAAMELgADdC4AAYQuAAT0DAxASImNTQ2MzIWFRQGIyMiJjUmNjMyFhUUBiMBJyMHIxM3EwEzAzMBeBYeHRUWHh4VxBUgAR8UFh8eFQENQ/NIN+RH2P77AW7SAq0eFRYfHxYVHh4VFh8fFhUe/VPExAJsF/19Ah7+1QAAAAQACgABAg0DXgAUABwAKAAsAN24AC0vuAAgL7gALRC4AAXQuAAFL0EFAHoAIACKACAAAl1BDwAJACAAGQAgACkAIAA5ACAASQAgAFkAIABpACAAB124ACAQuQAPAAP0uAAFELkAJgAD9EEPAAYAJgAWACYAJgAmADYAJgBGACYAVgAmAGYAJgAHXUEFAHUAJgCFACYAAl26ACoABQAPERI5uAAPELgALNC4ACwvALgAAEVYuAAVLxu5ABUABT5ZuAAARVi4ABgvG7kAGAAFPlm7AAoAAgAjAAQruwAdAAIAAAAEK7sALAACABYABCswMQEiLgI1ND4CMzIeAhUUDgIjEycjByMTNxMDMjYnNCYjIgYVFBYXMwMzARATIhkPDxsiFBMiGQ8PGiMUr0PzSDfkR9j8FyEBHxYYIiEOAW7SAqAPGiMUEyMaDg8aIxQUIhoP/WLExAJsF/19AschFxchIRcXIan+1QAAAAABACb/RgIEAoQAQgEauwAjAAQAEgAEK7sAOgADAAYABCtBBQB6AAYAigAGAAJdQQ8ACQAGABkABgApAAYAOQAGAEkABgBZAAYAaQAGAAddQQ8ABgAjABYAIwAmACMANgAjAEYAIwBWACMAZgAjAAddQQUAdQAjAIUAIwACXQC4AABFWLgADS8buQANAAU+WbgAAEVYuAAzLxu5ADMABT5ZuwAXAAEAHgAEK7sAAwACAD8ABCu4ADMQuQAqAAH0QSEABwAqABcAKgAnACoANwAqAEcAKgBXACoAZwAqAHcAKgCHACoAlwAqAKcAKgC3ACoAxwAqANcAKgDnACoA9wAqABBdQQkABwAqABcAKgAnACoANwAqAARxQQUARgAqAFYAKgACcTAxFxYWFzI2NTQuAiMjJy4DNz4DFxYWFwcmJiMiDgIHBh4EMzI+AjcXBgYHBycWFxYWFRQOAiMiJifoEhoRER8KDxIHHwE2UzgcAgEhQGBANlwlGiNIJzJDKREBAQgRHCYyIBsrKCwdHDNlOQEBFQIkHAwZJRgUKhCBCAcBFxQLDgkDPQhDX20yOHJcOQEBGRssFxI0TlwpGT08OCsaCBEYECsoJgIWAQMCCCcaDh0YDw0IAAAAAAIAPAAAAZsDRwADAA8ASLsADQADAAQABCu4AA0QuAAI0AC4AAIvuAAARVi4AAQvG7kABAAFPlm7AAYAAQAHAAQruwAKAAEACwAEK7gABBC5AA0AAfQwMRMnNxcBESEHIxUzByMRIRWjI8Yd/tkBXxn90hq4ARACrSR2O/z0AnYy2DL++DIAAAACADwAAAIYAwcAGAAiAGm4ACMvuAAfL7gAIxC4ABzQuAAcL7kAGwAD9LgAHtC4AB4vuAAfELkAIgAD9LgAJNwAuAAARVi4ABkvG7kAGQAFPlm4AABFWLgAGy8buQAbAAU+WbsAFQACAAgABCu4AAgQuQAQAAH0MDEBBgYjIi4CIyMiBgcnNjYXMh4CMzI2NxMBESMRNwERMxEByBkyJBEaGRoQARYbEBsZMiQRGhkaERYbECP+nzM6AXAyAt4ZGAoNChAOJhkYAQoNChAO/P0CBP38Am8U/eYCDf2KAAAAAAQAHv/3Aj0DFQALABgALQBBAZu7AD0AAwAjAAQruwAVAAQADwAEK7sACQAEAAMABCu7ABkAAwAzAAQrQQUAegADAIoAAwACXUEPAAkAAwAZAAMAKQADADkAAwBJAAMAWQADAGkAAwAHXUEPAAYAFQAWABUAJgAVADYAFQBGABUAVgAVAGYAFQAHXUEFAHUAFQCFABUAAl26AAwADwAVERI5QQUAegAzAIoAMwACXUEPAAkAMwAZADMAKQAzADkAMwBJADMAWQAzAGkAMwAHXUEPAAYAPQAWAD0AJgA9ADYAPQBGAD0AVgA9AGYAPQAHXUEFAHUAPQCFAD0AAl24ABkQuABD3AC4AABFWLgAHi8buQAeAAU+WbsABgABAAAABCu7ACgAAQA4AAQruAAAELgADNC4AAYQuAAS0LgAHhC5AC4AAfRBIQAHAC4AFwAuACcALgA3AC4ARwAuAFcALgBnAC4AdwAuAIcALgCXAC4ApwAuALcALgDHAC4A1wAuAOcALgD3AC4AEF1BCQAHAC4AFwAuACcALgA3AC4ABHFBBQBGAC4AVgAuAAJxMDEBIiY1NDYzMhYVFAYjIiY1NDYzMhYXFAYjARQOAiMiLgI1ND4CMzIeAhUBMj4CNTQuAiMiDgIVFB4CAY8WHh0VFh4e2RUfHRQWHwEeFgFzI0RmQkJmRCMkRmRBQWVGJP7vLkYwGBcvRi8wRy8XGDBGAq0eFRYfHxYVHh4VFh8fFhUe/pg6d2A9PWB3OjxyWjc3WnI8/usxT2MyLl1MMDBMXS4yY08xAAAAAAMAPP/3AgMDFQAMABkALwFEuwAoAAMAJwAEK7sAFgAEABAABCu7AAkABAADAAQruwAbAAMAGgAEK0EFAHoAAwCKAAMAAl1BDwAJAAMAGQADACkAAwA5AAMASQADAFkAAwBpAAMAB126AAAAAwAJERI5QQUAVgAWAGYAFgACXUELAAYAFgAWABYAJgAWADYAFgBGABYABV1BBQB1ABYAhQAWAAJdugANABAAFhESObgAGxC4ADHcALgAAEVYuAAhLxu5ACEABT5ZuwAGAAEADAAEK7gADBC4AA3QuAAGELgAE9C4ACEQuQAsAAH0QSEABwAsABcALAAnACwANwAsAEcALABXACwAZwAsAHcALACHACwAlwAsAKcALAC3ACwAxwAsANcALADnACwA9wAsABBdQQkABwAsABcALAAnACwANwAsAARxQQUARgAsAFYALAACcTAxASImNSY2MzIWFRQGIyMiJjU0NjMyFhcUBiMFMxEUDgIjIi4CNRE3ExQWNzI2NQGJFh8BHhUWHh4UxRUfHRQWHwEeFgEIOSM+VDEwUjwjSgFMUE9YAq0eFRYfHxYVHh4VFh8fFhUeN/5gMlI7ICA7UTIBlRn+XlFeAWFPAAAAAAMAKP/3AXsClQADACYAMwEbuAA0L7gAJy+4AALQuAACL7gANBC4AA7QuAAOL7gAJxC4ABTQuAAUL7gAJxC5ACYAA/S4AA4QuQAtAAP0QQ8ABgAtABYALQAmAC0ANgAtAEYALQBWAC0AZgAtAAddQQUAdQAtAIUALQACXbgAJhC4ADXcALgAAi+4AABFWLgACS8buQAJAAU+WbsAEwACACoABCu7ACEAAgAaAAQruAAqELgAJ9C4ACcvuAAJELkAMAAC9EEhAAcAMAAXADAAJwAwADcAMABHADAAVwAwAGcAMAB3ADAAhwAwAJcAMACnADAAtwAwAMcAMADXADAA5wAwAPcAMAAQXUEJAAcAMAAXADAAJwAwADcAMAAEcUEFAEYAMABWADAAAnEwMRMnNxcTDgMnIi4CNT4DMzM1NC4CIyIGByc2NjMyHgIVByIGIwYGFRQWFzI2N4ojxh0xECkxOiEeNCYWARcpNiB3EBojEiE1HRInRC0bNSgZRxE0Gyo4OCwgNAoB+yR2O/3pEBwUDAEXJzUeIDMjEisTHxYMEA8qFRESITAeXQEBLComOwEZCwADACj/9wF7ApUAAwAmADMBH7gANC+4ACcvuAA0ELgADtC4AA4vuQAtAAP0QQ8ABgAtABYALQAmAC0ANgAtAEYALQBWAC0AZgAtAAddQQUAdQAtAIUALQACXbgAANC4AAAvuAAnELgAA9C4AAMvuAAnELgAFNC4ABQvuAAnELkAJgAD9LgANdwAuAABL7gAAEVYuAAJLxu5AAkABT5ZuwATAAIAKgAEK7sAIQACABoABCu4ACoQuAAn0LgAJy+4AAkQuQAwAAL0QSEABwAwABcAMAAnADAANwAwAEcAMABXADAAZwAwAHcAMACHADAAlwAwAKcAMAC3ADAAxwAwANcAMADnADAA9wAwABBdQQkABwAwABcAMAAnADAANwAwAARxQQUARgAwAFYAMAACcTAxEzcXBxMOAyciLgI1PgMzMzU0LgIjIgYHJzY2MzIeAhUHIgYjBgYVFBYXMjY3bh3GI00QKTE6IR40JhYBFyk2IHcQGiMSITUdEidELRs1KBlHETQbKjg4LCA0CgJaO3Yk/kgQHBQMARcnNR4gMyMSKxMfFgwQDyoVERIhMB5dAQEsKiY7ARkLAAMAKP/3AY4CoQAFACgANQETuAA2L7gAKS+4ADYQuAAQ0LgAEC+4ACkQuAAW0LgAFi+4ACkQuQAoAAP0uAAQELkALwAD9EEPAAYALwAWAC8AJgAvADYALwBGAC8AVgAvAGYALwAHXUEFAHUALwCFAC8AAl24ACgQuAA33AC4AAMvuAAARVi4AAsvG7kACwAFPlm7ABUAAgAsAAQruwAjAAIAHAAEK7gALBC4ACnQuAApL7gACxC5ADIAAvRBIQAHADIAFwAyACcAMgA3ADIARwAyAFcAMgBnADIAdwAyAIcAMgCXADIApwAyALcAMgDHADIA1wAyAOcAMgD3ADIAEF1BCQAHADIAFwAyACcAMgA3ADIABHFBBQBGADIAVgAyAAJxMDETByc3FwcTDgMnIi4CNT4DMzM1NC4CIyIGByc2NjMyHgIVByIGIwYGFRQWFzI2N+CJHKWuIg8QKTE6IR40JhYBFyk2IHcQGiMSITUdEidELRs1KBlHETQbKjg4LCA0CgJQTyp2dir+QhAcFAwBFyc1HiAzIxIrEx8WDBAPKhUREiEwHl0BASwqJjsBGQsAAAAEACj/9wF7AmUADAAYADsARgE5uwBAAAMAIwAEK7sAOwAEAAMABCu6AAAAAwA7ERI5uAA7ELgACdC4AAkvQQ8ABgBAABYAQAAmAEAANgBAAEYAQABWAEAAZgBAAAddQQUAdQBAAIUAQAACXboAEwAjAEAREjm4ABMvuQANAAT0uAA7ELkAPAAD9LgAKdC4ACkvuAA7ELgASNwAuAAARVi4AB4vG7kAHgAFPlm7AAYAAQAMAAQruwA2AAIALwAEK7sAKQACADwABCu4AAwQuAAQ0LgABhC4ABbQuAAeELkAQwAC9EEhAAcAQwAXAEMAJwBDADcAQwBHAEMAVwBDAGcAQwB3AEMAhwBDAJcAQwCnAEMAtwBDAMcAQwDXAEMA5wBDAPcAQwAQXUEJAAcAQwAXAEMAJwBDADcAQwAEcUEFAEYAQwBWAEMAAnEwMQEiJjU0NjMyFhUWBiMnFAYjIiY1NDYzMhYTDgMnIi4CNT4DMzM1NC4CIyIGByc2NjMyHgIVByMiBhUUFhcyNjcBQhYeHRQWHwEfFZEeFRUfHhQWH8sQKTE6IR40JhYBFyk2IHcQGiMSITUdEidELRs1KBlHYCo4OCwgNAoB/R4VFh8fFhUeMxUeHhUWHx/9/RAcFAwBFyc1HiAzIxIrEx8WDBAPKhUREiEwHl4tKiY7ARkLAAMAKP/3AXsCVQAXADoARQEhuABGL7gAOy+5ADoAA/S4AADQuAAAL7gARhC4ACLQuAAiL7gAOxC4ACjQuAAoL7gAIhC5AD8AA/RBDwAGAD8AFgA/ACYAPwA2AD8ARgA/AFYAPwBmAD8AB11BBQB1AD8AhQA/AAJduAA6ELgAR9wAuAAARVi4AB0vG7kAHQAFPlm7AA8AAQAIAAQruwA1AAIALgAEK7sAKAACADsABCu4AAgQuQAUAAL0uQADAAH0uAAdELkAQgAC9EEhAAcAQgAXAEIAJwBCADcAQgBHAEIAVwBCAGcAQgB3AEIAhwBCAJcAQgCnAEIAtwBCAMcAQgDXAEIA5wBCAPcAQgAQXUEJAAcAQgAXAEIAJwBCADcAQgAEcUEFAEYAQgBWAEIAAnEwMQEGBiMiLgIjIgYHJzY2MzIeAjMyNjcTDgMnIi4CNT4DMzM1NC4CIyIGByc2NjMyHgIVByMiBhUUFhcyNjcBeBkyJBEaGRoQFhsRGxkyJREaGRoQFhsRHRApMTohHjQmFgEXKTYgdxAaIxIhNR0SJ0QtGzUoGUdgKjg4LCA0CgIsGRgKDQoQDSUZGAoNChAN/fIQHBQMARcnNR4gMyMSKxMfFgwQDyoVERIhMB5eLSomOwEZCwAABAAo//cBewK8ABQANwBEAFEBhbsASwADAB8ABCu7ADsAAwAFAAQruwAPAAMAQQAEK0EFAHoAQQCKAEEAAl1BDwAJAEEAGQBBACkAQQA5AEEASQBBAFkAQQBpAEEAB126AEUAQQAPERI5uABFL7gAJdC4ACUvuABFELkANwAD9EEPAAYAOwAWADsAJgA7ADYAOwBGADsAVgA7AGYAOwAHXUEFAHUAOwCFADsAAl1BDwAGAEsAFgBLACYASwA2AEsARgBLAFYASwBmAEsAB11BBQB1AEsAhQBLAAJduABT3AC4AABFWLgAGi8buQAaAAU+WbsACgACADgABCu7AD4AAgAAAAQruwAkAAIASAAEK7sAMgACACsABCu4AEgQuABF0LgARS+4ABoQuQBOAAL0QSEABwBOABcATgAnAE4ANwBOAEcATgBXAE4AZwBOAHcATgCHAE4AlwBOAKcATgC3AE4AxwBOANcATgDnAE4A9wBOABBdQQkABwBOABcATgAnAE4ANwBOAARxQQUARgBOAFYATgACcTAxEyIuAjU0PgIzMh4CFRQOAiMTDgMnIi4CNT4DMzM1NC4CIyIGByc2NjMyHgIVAyIGFRQWNzI2JzQmIxMiBiMGBhUUFhcyNjfeEyIZDw8bIhQTIhkPDxojE5wQKTE6IR40JhYBFyk2IHcQGiMSITUdEidELRs1KBmbGCIhFxchAR8WVBE0Gyo4OCwgNAoB/Q8aIxQTIxoPDxojFBQiGg/+RhAcFAwBFyc1HiAzIxIrEx8WDBAPKhUREiEwHgFUIRcXIQEhFxch/k4BASwqJjsBGQsAAAABAB7/RgFxAcIAPgEzuAA/L7gAGC9BBQB6ABgAigAYAAJdQQ8ACQAYABkAGAApABgAOQAYAEkAGABZABgAaQAYAAdduQAJAAP0uAA/ELgAJNC4ACQvuQA1AAP0QQMABgA1AAFdQQ0AFgA1ACYANQA2ADUARgA1AFYANQBmADUABl1BBQB1ADUAhQA1AAJduAAJELgAQNwAuAAARVi4AAMvG7kAAwAFPlm4AABFWLgAHy8buQAfAAU+WbsAFQACAA4ABCu4AAMQuQA6AAL0QSEABwA6ABcAOgAnADoANwA6AEcAOgBXADoAZwA6AHcAOgCHADoAlwA6AKcAOgC3ADoAxwA6ANcAOgDnADoA9wA6ABBdQQkABwA6ABcAOgAnADoANwA6AARxQQUARgA6AFYAOgACcboAAAADADoREjkwMSUGBgcHFhUWFhUUDgIjIiYnNxYWFzI2NTQuAiMjNS4DNTQ2NzY2FhYXByYmBw4DFRQeAjMWNjcXAXEdRSoBFiUbDBklGBQqEBASGxERHgoPEgcfJDknFDEuFzg7OxoVFzgaHiwdDxAfLx8jOB4TJRMYAhIDAgUqGg4dGA8NCCQIBwEXFAsOCQM7Bio8SiY+byAQDwIRECcLDwICIzVBHx49MiEBFg4nAAMAHv/2AXsClAADACIALgBvuAAvL7gAIy+5ABkAA/S4AATQuAAEL7gAIxC4AAfQuAAHL7gALxC4AA/QuAAPL7kAGgAD9LgADNC4ABoQuAAt0LgALS+4ABkQuAAw3AC4AAIvugAaAB8AAyu7ABQAAgAoAAQruAAaELkALgAC9DAxEyc3FxMGBgcGBiYmJyYmNTQ+AjMyHgIXIQYeAjc2NjcnNC4CIyIOAgczgCPGHTsRJBYYNDUxEyQpEypDMC4/KRIB/vQDESQzHyY5HDwLFiQYGiUXDALAAfokdjv9zwsTBwcGBBERH2E4K1RCKR45UTMrRjEbAQIUDsIYLyYXFyYuGAAAAwAe//YBewKUAAMAIgAuAG+4AC8vuAAjL7kAGQAD9LgABNC4AAQvuAAjELgAB9C4AAcvuAAvELgAD9C4AA8vuQAaAAP0uAAM0LgAGhC4AC3QuAAtL7gAGRC4ADDcALgAAi+6ABoAHwADK7sAFAACACgABCu4ABoQuQAuAAL0MDEBJzcXEwYGBwYGJiYnJiY1ND4CMzIeAhchBh4CNzY2Nyc0LgIjIg4CBzMBGb8cxz4RJBYYNDUxEyQpEypDMC4/KRIB/vQDESQzHyY5HDwLFiQYGiUXDALAAfpfO3b+CgsTBwcGBBERH2E4K1RCKR45UTMrRjEbAQIUDsIYLyYXFyYuGAADAB7/9gF8AqAABQAkADAAe7gAMS+4ACUvuQAbAAP0uAAE0LgABC+4ABsQuAAG0LgABi+4ACUQuAAJ0LgACS+4ADEQuAAR0LgAES+5ABwAA/S4AA7QuAAcELgAL9C4AC8vuAAbELgAMtwAuAADL7oAHAAhAAMruwAWAAIAKgAEK7gAHBC5ADAAAvQwMRMHJzcXBxMGBgcGBiYmJyYmNTQ+AjMyHgIXIQYeAjc2NjcnNC4CIyIOAgczzokcpa4iIREkFhg0NTETJCkTKkMwLj8pEgH+9AMRJDMfJjkcPAsWJBgaJRcMAsACT08qdnYq/igLEwcHBgQRER9hOCtUQikeOVEzK0YxGwECFA7CGC8mFxcmLhgAAAAABAAe//YBewJkAAwAGAA3AEMAx7sALwADACQABCu7AAkABAADAAQrQQUAegADAIoAAwACXUEPAAkAAwAZAAMAKQADADkAAwBJAAMAWQADAGkAAwAHXboAAAADAAkREjm6ABMAJAAvERI5uAATL7kADQAE9LoAOAADAAkREjm4ADgvuQAuAAP0uAAvELgAQtC4AEIvuAAuELgARdwAugAvADQAAyu7AAYAAQAMAAQruAAMELgAENC4AAYQuAAW0LgAEBC5ACkAAfS5AD0AAvS4AC8QuQBDAAL0MDEBIiY1NDYzMhYXFAYjJxQGIyImNTQ2MzIWEwYGBwYGJiYnJiY1ND4CMzIeAhchBh4CNzY2Nyc0LgIjIg4CBzMBOBYeHRQWHgEeFZEeFRUfHhQWH9URJBYYNDUxEyQpEypDMC4/KRIB/vQDESQzHyY5HDwLFiQYGiUXDALAAfweFRYfHxYVHjMVHh4VFh8f/eMLEwcHBgQRER9hOCtUQikeOVEzK0YxGwECFA7CGC8mFxcmLhgAAAIAEgAAAPUClQADAAcALLsABwADAAQABCsAuAACL7gAAEVYuAAELxu5AAQABT5ZugAGAAQAAhESOTAxEyc3FwMRNxE1I8YdqUgB+yR2O/2mAakY/j8AAAAC//QAAADXApUAAwAHACy7AAcAAwAEAAQrALgAAS+4AABFWLgABC8buQAEAAU+WboABgAEAAEREjkwMQM3FwcDETcRDB3GI2RIAlo7diT+BQGpGP4/AAAAAv/LAAABHgKdAAUACQAsuwAJAAMABgAEKwC4AAMvuAAARVi4AAYvG7kABgAFPlm6AAgABgADERI5MDETByc3FwcDETcRcIkcpa4irEgCTE8qdnYq/gMBqRj+PwAD/9kAAAEDAmUADAAYABwAkLsADQAEABMABCu7ABwAAwAZAAQruAAcELkACQAE9LoAAAAcAAkREjm4ABwQuAAD0LgAAy9BDwAGAA0AFgANACYADQA2AA0ARgANAFYADQBmAA0AB11BBQB1AA0AhQANAAJdALgAAEVYuAAZLxu5ABkABT5ZuwAGAAEADAAEK7gADBC4ABDQuAAGELgAFtAwMRMiJjUmNjMyFhUUBiMnFAYjIiY1NDYzMhYTETcR0hYfAR4VFh4eFJEeFRUfHhQWHxBIAf0eFRYfHxYVHjMVHh4VFh8f/boBqRj+PwAAAAACADIAAAGTAlUAGAAtAHO4AC4vuAAZL7gALhC4ACLQuAAiL7kAIQAD9LgAGRC5AC0AA/S4AC/cALgAAEVYuAAZLxu5ABkABT5ZuAAARVi4ACEvG7kAIQAFPlm7ABUAAgAIAAQruAAVELkAAwAB9LgACBC5ABAAAfS4ABUQuAAd3DAxAQYGIyIuAiMjIgYHJzY2MzIeAjMyNjcDETQmBwYGBxEjETY2NzY2FxYWFREBgxkyJBEaGRoQARYbEBsZMiQRGhkaERYbEB48MB01EUkcNSMbRycoPAIsGRgKDQoQDSUZGAoNChAN/a8BKjM1AQEVDP6RAXgUHwkICQkJNy3+sQAAAAMAHv/3Aa8ClQADABcALAEnuAAtL7gAIi9BBQB6ACIAigAiAAJdQQ8ACQAiABkAIgApACIAOQAiAEkAIgBZACIAaQAiAAdduAAD0LgAAy+4AC0QuAAJ0LgACS+4ACIQuQATAAP0uAAJELkAGAAD9EEPAAYAGAAWABgAJgAYADYAGABGABgAVgAYAGYAGAAHXUEFAHUAGACFABgAAl24ABMQuAAu3AC4AAIvuAAARVi4AAQvG7kABAAFPlm7AA4AAQAnAAQruAAEELkAHQAC9EEhAAcAHQAXAB0AJwAdADcAHQBHAB0AVwAdAGcAHQB3AB0AhwAdAJcAHQCnAB0AtwAdAMcAHQDXAB0A5wAdAPcAHQAQXUEJAAcAHQAXAB0AJwAdADcAHQAEcUEFAEYAHQBWAB0AAnEwMRMnNxcDIi4CNTQ+AjMyHgIVFA4CJxQeAjMyPgI1NC4CJw4DFZwjxh13M0oyGBs0Si8vSzQbGDNMqgscLyMmLxoJDBwvIyYuGwkB+yR2O/2dKEJVLSxRPSQkPVEsLVVCKOwgQzgkJTdDIB47MSACAiAxOx4AAwAe//cBrwKVAAMAFwAsASe4AC0vuAAiL0EFAHoAIgCKACIAAl1BDwAJACIAGQAiACkAIgA5ACIASQAiAFkAIgBpACIAB124AALQuAACL7gALRC4AAnQuAAJL7gAIhC5ABMAA/S4AAkQuQAYAAP0QQ8ABgAYABYAGAAmABgANgAYAEYAGABWABgAZgAYAAddQQUAdQAYAIUAGAACXbgAExC4AC7cALgAAS+4AABFWLgABC8buQAEAAU+WbsADgABACcABCu4AAQQuQAdAAL0QSEABwAdABcAHQAnAB0ANwAdAEcAHQBXAB0AZwAdAHcAHQCHAB0AlwAdAKcAHQC3AB0AxwAdANcAHQDnAB0A9wAdABBdQQkABwAdABcAHQAnAB0ANwAdAARxQQUARgAdAFYAHQACcTAxEzcXBwMiLgI1ND4CMzIeAhUUDgInFB4CMzI+AjU0LgInDgMVfx3GI1ozSjIYGzRKLy9LNBsYM0yqCxwvIyYvGgkMHC8jJi4bCQJaO3Yk/fwoQlUtLFE9JCQ9USwtVUIo7CBDOCQlN0MgHjsxIAICIDE7HgADAB7/9wGvAp0ABQAaAC4BF7gALy+4ACovQQUAegAqAIoAKgACXUEPAAkAKgAZACoAKQAqADkAKgBJACoAWQAqAGkAKgAHXbkABgAD9LgALxC4ABDQuAAQL7kAIAAD9EEPAAYAIAAWACAAJgAgADYAIABGACAAVgAgAGYAIAAHXUEFAHUAIACFACAAAl24AAYQuAAw3AC4AAMvuAAARVi4AAsvG7kACwAFPlm7ABUAAQAbAAQruAALELkAJQAC9EEhAAcAJQAXACUAJwAlADcAJQBHACUAVwAlAGcAJQB3ACUAhwAlAJcAJQCnACUAtwAlAMcAJQDXACUA5wAlAPcAJQAQXUEJAAcAJQAXACUAJwAlADcAJQAEcUEFAEYAJQBWACUAAnEwMRMHJzcXBxMUDgIjIi4CNTQ+AjMyHgIVJw4DFRQeAjMyPgI1NC4C6ogdpa4iORkyTDMzSjIYGzRKLy9LMxvIJi4aCQwbLyMmLxoJDBwvAkxPKnZ2Kv7mLVVCKChCVS0sUT0kJD1RLKwCIDE7HiBDOCQlN0MgHjsxIAAAAAAEAB7/9wGvAmUADAAZAC0AQgGMuwAuAAMAHwAEK7sACQAEAAMABCtBBQB6AAMAigADAAJdQQ8ACQADABkAAwApAAMAOQADAEkAAwBZAAMAaQADAAddugAAAAMACRESOUENABYALgAmAC4ANgAuAEYALgBWAC4AZgAuAAZdQQMABgAuAAFdQQUAdQAuAIUALgACXboAEAAfAC4REjm4ABAvuQAWAAT0ugANABAAFhESOboAOAADAAkREjm4ADgvQQUAegA4AIoAOAACXUEPAAkAOAAZADgAKQA4ADkAOABJADgAWQA4AGkAOAAHXbkAKQAD9LgARNwAuAAARVi4ABovG7kAGgAFPlm7AAYAAQAMAAQruwAkAAEAPQAEK7gADBC4AA3QuAAGELgAE9C4ABoQuQAzAAL0QSEABwAzABcAMwAnADMANwAzAEcAMwBXADMAZwAzAHcAMwCHADMAlwAzAKcAMwC3ADMAxwAzANcAMwDnADMA9wAzABBdQQkABwAzABcAMwAnADMANwAzAARxQQUARgAzAFYAMwACcTAxASImNSY2MzIWFRQGIyMiJjU0NjMyFhcUBiMTIi4CNTQ+AjMyHgIVFA4CJxQeAjMyPgI1NC4CJw4DFQFMFh8BHhUWHh4UxRUfHRQWHwEeFmAzSjIYGzRKLy9LNBsYM0yqCxwvIyYvGgkMHC8jJi4bCQH9HhUWHx8WFR4eFRYfHxYVHv36KEJVLSxRPSQkPVEsLVVCKOwgQzgkJTdDIB47MSACAiAxOx4AAAMAHv/3Aa8CVQAXACsAQAE1uABBL7gANi+4AEEQuAAd0LgAHS+5ACwAA/RBDwAGACwAFgAsACYALAA2ACwARgAsAFYALABmACwAB11BBQB1ACwAhQAsAAJduAAL0LgACy9BBQB6ADYAigA2AAJdQQ8ACQA2ABkANgApADYAOQA2AEkANgBZADYAaQA2AAdduAA2ELkAJwAD9LgAQtwAuAAARVi4ABgvG7kAGAAFPlm7AA8AAQAIAAQruwAiAAEAOwAEK7gACBC5ABQAAvS5AAMAAfS4ABgQuQAxAAL0QSEABwAxABcAMQAnADEANwAxAEcAMQBXADEAZwAxAHcAMQCHADEAlwAxAKcAMQC3ADEAxwAxANcAMQDnADEA9wAxABBdQQkABwAxABcAMQAnADEANwAxAARxQQUARgAxAFYAMQACcTAxAQYGIyIuAiMiBgcnNjYzMh4CMzI2NwMiLgI1ND4CMzIeAhUUDgInFB4CMzI+AjU0LgInDgMVAYkZMiQRGhkaEBYbERsZMiURGhkaEBYbEYozSjIYGzRKLy9LNBsYM0yqCxwvIyYvGgkMHC8jJi4bCQIsGRgKDQoQDSUZGAoNChAN/aYoQlUtLFE9JCQ9USwtVUIo7CBDOCQlN0MgHjsxIAICIDE7HgAAAAACADL/+AGaApUAAwAXAMO4ABgvuAAEL7gAA9C4AAMvuAAEELkABQAD9LgAGBC4AA7QuAAOL7kAEQAD9LgABRC4ABncALgAAi+4AABFWLgACS8buQAJAAU+WboAEAAJAAIREjm5ABQAAvRBIQAHABQAFwAUACcAFAA3ABQARwAUAFcAFABnABQAdwAUAIcAFACXABQApwAUALcAFADHABQA1wAUAOcAFAD3ABQAEF1BCQAHABQAFwAUACcAFAA3ABQABHFBBQBGABQAVgAUAAJxMDETJzcXFzMRBgYjIi4CNRE3ERQWNzY2N5Ajxh0BSS5rQRkyKRpLQTAdNBIB+yR2O6H+hyEnDx8vIQEyGf7OMzYBARYMAAAAAgAy//gBmgKVAAMAFwDDuAAYL7gABC+4AALQuAACL7gABBC5AAUAA/S4ABgQuAAO0LgADi+5ABEAA/S4AAUQuAAZ3AC4AAEvuAAARVi4AAkvG7kACQAFPlm6ABAACQABERI5uQAUAAL0QSEABwAUABcAFAAnABQANwAUAEcAFABXABQAZwAUAHcAFACHABQAlwAUAKcAFAC3ABQAxwAUANcAFADnABQA9wAUABBdQQkABwAUABcAFAAnABQANwAUAARxQQUARgAUAFYAFAACcTAxEzcXBxczEQYGIyIuAjURNxEUFjc2NjdsHcYjJUkua0EZMikaS0EwHTQSAlo7diRC/ochJw8fLyEBMhn+zjM2AQEWDAAAAAIAMv/4AZoCnQAFABkAv7gAGi+4AAYvuQAHAAP0uAAE0LgABC+4ABoQuAAQ0LgAEC+5ABMAA/S4AAcQuAAb3AC4AAMvuAAARVi4AAsvG7kACwAFPlm6ABIACwADERI5uQAWAAL0QSEABwAWABcAFgAnABYANwAWAEcAFgBXABYAZwAWAHcAFgCHABYAlwAWAKcAFgC3ABYAxwAWANcAFgDnABYA9wAWABBdQQkABwAWABcAFgAnABYANwAWAARxQQUARgAWAFYAFgACcTAxEwcnNxcHBzMRBgYjIi4CNRE3ERQWNzY2N+eIHaWuISNJLmtBGTIpGktBMB00EgJMTyp2dipE/ochJw8fLyEBMhn+zjM2AQEWDAADADL/+AGaAmUADAAZAC0BIbsAJwADACQABCu7AAkABAADAAQrQQUAegADAIoAAwACXUEPAAkAAwAZAAMAKQADADkAAwBJAAMAWQADAGkAAwAHXboAAAADAAkREjm6ABAAJAAnERI5uAAQL7kAFgAE9LoADQAQABYREjm6ABoAAwAJERI5uAAaL7kAGwAD9LgAL9wAuAAARVi4AB8vG7kAHwAFPlm7AAYAAQAMAAQruAAMELgADdC4AAYQuAAT0LgAHxC5ACoAAvRBIQAHACoAFwAqACcAKgA3ACoARwAqAFcAKgBnACoAdwAqAIcAKgCXACoApwAqALcAKgDHACoA1wAqAOcAKgD3ACoAEF1BCQAHACoAFwAqACcAKgA3ACoABHFBBQBGACoAVgAqAAJxMDEBIiY1NDYzMhYXFAYjIyImNSY2MzIWFRQGIxczEQYGIyIuAjURNxEUFjc2NjcBThYeHRQWHgEeFcQVIAEfFBYfHhXJSS5rQRkyKRpLQTAdNBIB/R4VFh8fFhUeHhUWHx8WFR5E/ochJw8fLyEBMhn+zjM2AQEWDAAAAAEALf92AekCqwALAEm7AAsAAwAAAAQruAAAELgABNC4AAsQuAAG0AC4AAUvuAAAL7sABAABAAEABCu4AAQQuAAH0LoACAAAAAUREjm4AAEQuAAJ0DAxFxEjNTM1MxUzByMR3bCwSMQZq4oCLTTU1DT97AAAAgAyAf0A7wK8ABQAIQCjuAAiL7gAHi+4ACIQuAAF0LgABS9BBQB6AB4AigAeAAJdQQ8ACQAeABkAHgApAB4AOQAeAEkAHgBZAB4AaQAeAAdduAAeELkADwAD9LgABRC5ABgAA/RBDwAGABgAFgAYACYAGAA2ABgARgAYAFYAGABmABgAB11BBQB1ABgAhQAYAAJduAAPELgAI9wAuwAbAAIAAAAEK7sACgACABUABCswMRMiLgI1ND4CMzIeAhUUDgIjNyIGFRQWNzI2JzQmI48TIhkPDxsiFBMiGQ8PGiMTARgiIRcXIQEfFgH9DxojFBMjGg8PGiMUFCIaD5chFxchASEXFyEAAQAe/6IBcQIfACgAergAKS+4AAEvuAApELgABtC4AAYvuAABELgADdC4AAEQuQAnAAP0uAAP0LgABhC5ABsAA/RBDwAGABsAFgAbACYAGwA2ABsARgAbAFYAGwBmABsAB11BBQB1ABsAhQAbAAJdALgAAC+4AABFWLgADy8buQAPAAk+WTAxFzUuAzU0PgI3Njc1NxcWFwcmJgcOAxUUHgIzFjY3FwYGBxe+JjspFg0YIxcdJD4BNCsVFzgaHiwdDxAfLx8jOB4TGToiAV5WBCo9TCcfPDYtEBQGSxZfBhsnCw8CAiM1QR8ePTIhARYOJhAWBUIAAAABACj//gILAtQAHQB8uwAbAAMAAgAEK7gAAhC4AAbQuAAbELgAFtAAuAAKL7gAAEVYuAAFLxu5AAUABz5ZuAAARVi4ABcvG7kAFwAHPlm4AABFWLgAAC8buQAAAAU+WbkAAQAB9LgAFxC5AAMAAfS4AATQuAAZ0LgAGtC4AAEQuAAb0LgAHNAwMRc1MzUjNTM1NDYXMhYXByYmJyYOAhUVMwcjFTMXKKaPj2hYFyIVDwgVCDI5Hgi8F6XcGAJI8kZ8cWkBCgkvAwcCBxswPh2ARvJIAAIAMv/1AZwClABKAGMBG7sAVgADACcABCu7AAgAAwAZAAQrQQUAegAZAIoAGQACXUEPAAkAGQAZABkAKQAZADkAGQBJABkAWQAZAGkAGQAHXUEPAAYAVgAWAFYAJgBWADYAVgBGAFYAVgBWAGYAVgAHXUEFAHUAVgCFAFYAAl26AC8AJwBWERI5uAAvL7kAPwAD9LgACBC4AGXcALgAAEVYuAANLxu5AA0ABT5ZuwA0AAEAOgAEK7gADRC5ABQAAfRBIQAHABQAFwAUACcAFAA3ABQARwAUAFcAFABnABQAdwAUAIcAFACXABQApwAUALcAFADHABQA1wAUAOcAFAD3ABQAEF1BCQAHABQAFwAUACcAFAA3ABQABHFBBQBGABQAVgAUAAJxMDEBFA4CBxYWFQ4DIyImJzcWFjMyPgInNC4CJyYmJyYmJyYmNTQ+AjcmJjU0PgIzMhYXByYjIg4CFRQWFxYXFhYXFhYHBy4DMSYmJwYGFRQWFxYWFxcWFhc2NjUBmw8WGgwMDwEfMT0fJkocGxY9HhIkHRIBDhQaDAoUChQpERIYDRUaDAsOGis4HSI/HhwxMA8fGA8TESMtFCgSEhgBSAEKCgkjOCIbHBMRESkVAg4MCyAXAVAXKyIaBw4pFyM0IRAbFiwSFQgSHRQQFQ8KBQQIAwgRDQ4mHxcsJRwHDCEXIDEhEhYRLBwIEBkREhYIEBEIEQ4OKB4EChALBRUSCw43FRIWCAgRCAEFBAMQNhYAAAAAAQA8AKABYwHHABMACwC4AAovuAAALzAxNyIuAjU0PgIzMh4CFRQOAtAfNigXFyg2Hx81KBcYJzagFyg2Hh82KBcXKDYeHzYoFwAAAAEAHv+OAagCdgARAEW4ABIvuAAAL7gAEhC4AATQuAAEL7kAAwAD9LgABBC4AA/QuAAAELkAEQAD9LgAE9wAuAADL7gAES+7ABAAAgABAAQrMDEFESMRJxEiLgI1ND4CMzMRAWBNSCQ/LxsbLz8k3VoCo/1FGAFzHC8/JCQ/MBz9GAAAAAEAFP9/AgUCewBFAIu4AEYvuAAsL7gARhC4AADQuAAAL7gABNBBBQB6ACwAigAsAAJdQQ8ACQAsABkALAApACwAOQAsAEkALABZACwAaQAsAAdduAAsELgAEtC4ABIvuAAsELgAFNC4ABQvuAAsELkAHQAD9LgAABC5AEUAA/S4AB0QuABH3AC4AAAvuwAEAAIAAQAEKzAxFxEjNTM3NjY3NjY3NhceAxUGBwYGBwYWFxYWFxYOAgcGJic3FhY3NjY3NC4CJyYmJyY2Nz4CJicmJgYGBwYGFRFkUFABARsgGTIUGBYbMyYWAQgHGxkbBCI+RgEBHzVGJyE7GRcSJxQ6QwEEESAbJCMDAhYVExgEFBgLHh4ZBh0UgQH5LzopPxMPDAICAwIPHjAjFRIQIwwOIgkRSUYoQjAeBAMICS8HCAMISjcOHxwZCQwhGhQmDgwnKCULBQICBQILMBz9tgAEADL/5AMGAuAAEwAnADkARAEJuwAjAAMABQAEK7sAMwADAD0ABCu7ACsAAwAsAAQruwAPAAMAGQAEK0EFAHoAGQCKABkAAl1BDwAJABkAGQAZACkAGQA5ABkASQAZAFkAGQBpABkAB11BDwAGACMAFgAjACYAIwA2ACMARgAjAFYAIwBmACMAB11BBQB1ACMAhQAjAAJdugA4AAUADxESOboAOQAFAA8REjlBBQB6AD0AigA9AAJdQQ8ACQA9ABkAPQApAD0AOQA9AEkAPQBZAD0AaQA9AAdduAArELgAQ9C4AA8QuABG3AC7ABQAAgAAAAQruwAKAAIAHgAEK7sALgACAEIABCu7AEQAAgAqAAQruAAqELgAONAwMQUiLgI1ND4CMzIeAhUUDgInMj4CNTQuAiMiDgIVFB4CNycjFSMRMzIeAhUUDgIjFwMyNjc0LgIjIxUBnEyEYjg4YoRMS4RiOTlihEtCb1EuLlFvQkJwUS0tUXCdfyY6lx0yJRYTIi4bgZUnMAEOFx8SVxw7aItQUItoOztoi1BQi2g7LjZbekVFels2Nlt6RUV6WzZq4OAB4xQkMBwbLyEU4AEJMyUQIBgPrwADADL/8QMFAu4AFAAoAEoA1bsAJAADAAUABCu7AEIAAwAxAAQruwAPAAMAGgAEK0EFAHoAGgCKABoAAl1BDwAJABoAGQAaACkAGgA5ABoASQAaAFkAGgBpABoAB11BDwAGACQAFgAkACYAJAA2ACQARgAkAFYAJABmACQAB11BBQB1ACQAhQAkAAJdQQ8ABgBCABYAQgAmAEIANgBCAEYAQgBWAEIAZgBCAAddQQUAdQBCAIUAQgACXbgADxC4AEzcALgAFC+7ABUAAQAAAAQruwAKAAEAHwAEK7sARwACACwABCswMQUiLgI1ND4CMzIeAhUUDgIjNTI+AjU0LgIjIg4CFRQeAjcGBiciLgI1NDY3NjYWFhcHJiYHDgMVFB4CFxY2NwGbTIRhODhig0xMhGI4OGKETD9sTiwsTmw/QGtOLCxOa9QgUTAqQi4YMS4XODs7GhUXOBoeLB0PEB8vHyM4Hg47aIpQUIxnPDtojFBQi2c8OjNZdkNDdlg0NFh2Q0N2WTOOFRkBJz9QKT5vIBAOARIQJwsPAgIjNUAfHj0zIAEBFg8AAgAeAcAB+QLQAAwAFAB9ugAUAA0AAyu6AAUABgADK7oADAAAAAMrugAJAA0ADBESObgADBC4ABbcALgACC+4AAovuAAQL7gAAC+4AAMvuAAFL7gADS+6AAEAAwAIERI5ugAEAAMACBESOboACQADAAgREjm4ABAQuAAL0LgAEBC5AA8AAvS4ABLQMDEBNQcHJxUjETcXNzMRITUjNzMVIxUB104dURkhXFMn/nRPDLJMAcTMxgrJxQEBC9rU/vruGBjuAAEAPAH7AR8ClQADAAsAuAAAL7gAAi8wMRMnNxdfI8YdAfskdjsAAAACADsB/QFoAmUADAAZALW4ABovuAADL0EFAHoAAwCKAAMAAl1BDwAJAAMAGQADACkAAwA5AAMASQADAFkAAwBpAAMAB125AAkABPS6AAAAAwAJERI5uAAaELgAENC4ABAvuQAWAAT0QQ8ABgAWABYAFgAmABYANgAWAEYAFgBWABYAZgAWAAddQQUAdQAWAIUAFgACXboADQAQABYREjm4AAkQuAAb3AC7AAYAAQAMAAQruAAMELgADdC4AAYQuAAT0DAxASImNTQ2MzIWFxQGIyMiJjUmNjMyFhUUBiMBNhYeHRQWHgEeFcQVIAEfFBYfHhUB/R4VFh8fFhUeHhUWHx8WFR4AAAABADwAAQJeAkUAEwBMALgACy+4AABFWLgAAS8buQABAAU+WbsAEQABAAAABCu7AAoAAQAHAAQruAAAELgAA9C4ABEQuAAF0LgAChC4AA3QuAAHELgAD9AwMSUHJzcjNTM3ISchNxcHMxUjBzMXAURZNVCzzDr+/RoBN1A2SJavO+caurkSpzV5NagSljV5NQACAAoAAALpAncADwASAGu7AA0AAwAAAAQruAANELgACNC4AAAQuAAQ0AC4AAYvuAAARVi4AAAvG7kAAAAFPlm4AABFWLgAAy8buQADAAU+WbsABQABAAgABCu7ABIAAgABAAQruwAKAAEACwAEK7gAABC5AA0AAfQwMSE1IwcjASUHIxUzByMRIRUBAzMBisZ5QQGAAV8a/NIauAEQ/qerq8TEAnYBM9gy/vgyAg7+5QAAAAADAB7/ZgI8AwAAHQAqADcBXLgAOC+4ACUvuAA4ELgABtC4AAYvQQUAegAlAIoAJQACXUEPAAkAJQAZACUAKQAlADkAJQBJACUAWQAlAGkAJQAHXbgAJRC5ABUAA/S6ACoABgAVERI5uAAGELkAMgAD9EEPAAYAMgAWADIAJgAyADYAMgBGADIAVgAyAGYAMgAHXUEFAHUAMgCFADIAAl26ADcABgAVERI5uAAVELgAOdwAuAAOL7gAHS+4AABFWLgAGi8buQAaAAU+WbgAAEVYuAAcLxu5ABwABT5ZuwALAAEALQAEK7gAGhC5ACAAAfRBIQAHACAAFwAgACcAIAA3ACAARwAgAFcAIABnACAAdwAgAIcAIACXACAApwAgALcAIADHACAA1wAgAOcAIAD3ACAAEF1BCQAHACAAFwAgACcAIAA3ACAABHFBBQBGACAAVgAgAAJxugAqAB0ADhESOboANwAdAA4REjkwMRc3LgM1ND4CMzIXNxcHHgMVFA4CIyInBzcWMzI+AjU0LgInJyYjIg4CFRQeAheJLyY5JxQkRmVBIyAoQCkiNCQSI0VlQhwbLT4UEi5GMBkKEx4UOxgaMEYvFwsXIRaEmhZDUVksPHJaNwmFFokVPktTKzp3YD0Gl88FMU9jMh49OTIUJQgwTF0uI0Q/NhMAAQAeAAACOQKDABwAprsAAQADAAIABCu4AAIQuAAG0LoADgACAAEREjm4AAEQuAAZ0AC4AA0vuAATL7gAAEVYuAAKLxu5AAoABz5ZuAAARVi4ABUvG7kAFQAHPlm4AABFWLgAAS8buQABAAU+WbsAGgACAAAABCu4AAAQuAAD0LgAGhC4AAXQuAAVELkACAAC9LgACdC6AAsAAQANERI5ugAOABUACBESObgAF9C4ABjQMDElFSM1IzUzNScjJzMnNxM2Njc2NxcHMwcjBxUzFwFHScrKEbcYtIxGpRM3Gh4gL4usAcYV2Rm0tLQwQR0w9xr+3CNkLjY5E/4wJjgwAAEAMv8dAZoBwQASAMO4ABMvuAAJL7gAExC4AADQuAAAL7kAEgAD9LgAAtC4AAIvuAAJELkADAAD9LgAFNwAuAAAL7gAAi+4AABFWLgADy8buQAPAAU+WbkABgAC9EEhAAcABgAXAAYAJwAGADcABgBHAAYAVwAGAGcABgB3AAYAhwAGAJcABgCnAAYAtwAGAMcABgDXAAYA5wAGAPcABgAQXUEJAAcABgAXAAYAJwAGADcABgAEcUEFAEYABgBWAAYAAnG6ABEADwAGERI5MDEXETcRFBY3NjY3ETMRBgYjIicVMktBMB00Ekkua0EkIeMCixn+zjM2AQEWDAFv/ochJw/qAAAAAAMAKADxAXcCqwAdACEALAENuAAtL7gALC+4AC0QuAAI0LgACC+4ACwQuAAM0LgADC+4ACwQuQAdAAP0uAAIELkAJgAD9EEPAAYAJgAWACYAJgAmADYAJgBGACYAVgAmAGYAJgAHXUEFAHUAJgCFACYAAl24AB0QuAAu3AC4AABFWLgAKS8buQApAAc+WbsAHwABAB4ABCu7ABcAAgAQAAQruwAMAAIAIgAEK7gAKRC5AAMAAvRBBQBJAAMAWQADAAJxQSEACAADABgAAwAoAAMAOAADAEgAAwBYAAMAaAADAHgAAwCIAAMAmAADAKgAAwC4AAMAyAADANgAAwDoAAMA+AADABBdQQkACAADABgAAwAoAAMAOAADAARxMDEBBgYnIi4CNTY2MzM1NCYjIgYHJzY2MzIeAhUVBTUhFwMjIgYXFBYXMjY3AUYXSzEWJx4QAUEwWSwbGScWDh0zIhUnHhP+4QE1GmZJICkBKiAYJwcBixchAhEdJxYwNx8dIwwLIBAMDRkkF76bNDQBEiIfHS0BFAgAAAMAKADzAXcCqQAUABgALAEtuAAtL7gAKC+4AC0QuAAA0LgAAC9BBQB6ACgAigAoAAJdQQ8ACQAoABkAKAApACgAOQAoAEkAKABZACgAaQAoAAdduAAoELkACgAD9LgAF9C4ABcvuAAAELkAHgAD9EEPAAYAHgAWAB4AJgAeADYAHgBGAB4AVgAeAGYAHgAHXUEFAHUAHgCFAB4AAl24AAoQuAAu3AC4AABFWLgAIy8buQAjAAc+WbsAFgABABUABCu7AAUAAgAZAAQruAAjELkADwAC9EEFAEkADwBZAA8AAnFBIQAIAA8AGAAPACgADwA4AA8ASAAPAFgADwBoAA8AeAAPAIgADwCYAA8AqAAPALgADwDIAA8A2AAPAOgADwD4AA8AEF1BCQAIAA8AGAAPACgADwA4AA8ABHEwMRM0PgIzMh4CFRQOAiMiLgI1AzUhFwMOAxUUHgIzMj4CNTQuAjIVJzgjIzgmFBImOCYmOSUSCgE1GrAcIxQHCRUjGx0jFAYJFSMCBCE8LRsbLjwhIkAxHh4xQCL+8DQ0AZICGCQtFhgzKhobKjIYFi0kGAAAAAADACj/9gKWAcEAOgBGAFEBSbsASwADABIABCu7ADEAAwBHAAQruwAwAAMAOwAEK7gARxC4ABjQuAAYL7oAKABHADEREjm4ADEQuABF0LgARS9BDwAGAEsAFgBLACYASwA2AEsARgBLAFYASwBmAEsAB11BBQB1AEsAhQBLAAJduAAwELgAU9wAuAAlL7gAKy+4AABFWLgADS8buQANAAU+WbsARgACADAABCu4AEYQuAAX0LgAFy+4ACsQuQBAAAL0uAAe0LgAHi+6ACgADQAlERI5uAANELkANgAC9EEhAAcANgAXADYAJwA2ADcANgBHADYAVwA2AGcANgB3ADYAhwA2AJcANgCnADYAtwA2AMcANgDXADYA5wA2APcANgAQXUEJAAcANgAXADYAJwA2ADcANgAEcUEFAEYANgBWADYAAnG4ADAQuABH0LgARy+4ADYQuABO0DAxJQYGBwYGJiYnJicGBicuAzU+AzMzNTQuAiMiBgcnNjYzMhYXNjYzMh4CFyEGHgI3NjY3Fyc0LgIjIg4CBzMFIyIGFRQWFzI2NwKVESQWGDQ1MRMOCiBcOx40JhYBFyk2IHcQGiMSITUdEidELSZFFBU+LC4/KRIB/vQDESQzHyY5HBJOCxcjGRolFwwBwP7tYCo4OCwgNAooCxMHBwYFEhEKDhskAQEXJzQeIDMjEisTHxYMEA8qFREhHxwhHjlRMytGMRsBAhQOI+UYLyYXFyYuGCwtKiY7ARkLAAAAAwAe/8ABrwH2AB0AKAA0AWi4ADUvuAAlL7gANRC4AAbQuAAGL0EFAHoAJQCKACUAAl1BDwAJACUAGQAlACkAJQA5ACUASQAlAFkAJQBpACUAB124ACUQuQAVAAP0ugAoAAYAFRESObgABhC5ADEAA/RBDwAGADEAFgAxACYAMQA2ADEARgAxAFYAMQBmADEAB11BBQB1ADEAhQAxAAJdugA0AAYAFRESObgAFRC4ADbcALgADi+4AB0vuAAARVi4ABovG7kAGgAFPlm4AABFWLgAHC8buQAcAAU+WbsACwACACwABCu4AAsQuAAN0LgADS+4ABoQuQAgAAL0QSEABwAgABcAIAAnACAANwAgAEcAIABXACAAZwAgAHcAIACHACAAlwAgAKcAIAC3ACAAxwAgANcAIADnACAA9wAgABBdQQkABwAgABcAIAAnACAANwAgAARxQQUARgAgAFYAIAACcboAKAAdAA4REjm6ADQAHQAOERI5MDEXNy4DNTQ+AjMyFzcXBx4DFRQOAiMiJwc3FjMyPgI1NCYnJyYmJyIOAhUUFhd5ER0pGgwcM0ovExQQNxIbKRsOGTNLMhQSEh8MDiYvGgkTHDMGDAUkLxsLExsuOw8wOT8fLFE9JAM4EjgPLDU7Hi5VQScDO2gDJTlCHiVOGhsCAgEgMj0dJ1keAAAAAgAn//EBrQLLAAsALABjuwAJAAQAAwAEK0EFAHoAAwCKAAMAAl1BDwAJAAMAGQADACkAAwA5AAMASQADAFkAAwBpAAMAB126AB4AAwAJERI5uAAeL7oAIAADAAkREjm5ACEAA/QAuwAGAAEAAAAEKzAxASImNTQ2MzIWFRQGEwYGJy4DJyY+Ajc2NzY2NzU3FSMiDgIWFhcWNjcBHBYeHhQWHh18JmI7J0U1IAEBFSUyGwwMCxkMTDArPiMGFzctKk4bAmMfFhUeHhUWH/3NGyQGBB0xRSwpPi0gCwQDAgQBfRnPKDxIQTAGBh0UAAAAAgBGAAAArALMAAwAEACMuwADAAQACQAEK0EPAAYAAwAWAAMAJgADADYAAwBGAAMAVgADAGYAAwAHXUEFAHUAAwCFAAMAAl26AAAACQADERI5ugANAAkAAxESObgADS+6AA4ACQADERI5uQAQAAP0ALgADC+4AABFWLgADS8buQANAAU+WboAAAANAAwREjm6AA4ADQAMERI5MDETMhYVFAYjBiYnNDY3AxEXEXgWHh0UFh4BHhUlSgLLHhQWIAEgFhUeAf00Ah0Z/fwAAQAK/3UBogK/ABgAJQC4AAgvuAAAL7sABAABAAEABCu4AAQQuAAU0LgAARC4ABbQMDEXEyM1Mzc2NjMyFhcHJicmDgIHBzMHIwMKZi85Chd7WBEXDBgEBjFAJxUFCmUBbmGLAg0zMnJmBQUsAQIJGzJAHDcz/gwAAQAUAAACOgK/AC4Am7gALy+4AAAvuAAvELgABNC4AAQvuQADAAP0uAAEELgACNC4AAMQuAAX0LgAABC4ABnQuAAAELkALgAD9LgAKdAAuAAML7gAHS+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAADLxu5AAMABT5ZuwAZAAEAAQAEK7gAARC4AAXQuAAFL7gAGRC4AAfQuAAZELgAKtC4AAEQuAAs0DAxIREnESMRBzUzNTQ2MzIWFwcmIyYOAhUVMzU0NjMyFhcHJiYjJg4CFRUzFScRAUS4SS8vaFgRGA0QCAIyOx4IuGhYERgNEAMFAzI6HghmZgGBAf5+AYIBNDJxZwUFLAIJGjJAHTYycWcFBSwBAQkaMkAdNjQB/n4AAgAyADQBvwIPAAUACwAtALgAAC+4AAYvuAAARVi4AAIvG7kAAgAJPlm4AABFWLgACC8buQAIAAk+WTAxJSc3FwcXByc3FwcXAYeoqDiMjOanpziMjDTu7SPKyyPu7SPKywAAAAIAMgA0Ab8CDwAFAAsALQC4AAUvuAALL7gAAEVYuAADLxu5AAMACT5ZuAAARVi4AAkvG7kACQAJPlkwMTc3JzcXByc3JzcXB9+MjDmnp+aMjDinp1fLyiPt7iPLyiPt7gAAAAADADv/9wJiAF8ADAAZACYBULgAJy+4AB3QuAAdL7gAENxBAwC/ABAAAV1BAwD/ABAAAV1BAwAwABAAAV1BAwBwABAAAV24AAPcQQMAvwADAAFdQQMA/wADAAFdQQMAcAADAAFdQQMAMAADAAFduQAJAAT0ugAAAAMACRESOboADQAQAAMREjm4ABAQuQAWAAT0ugAaAB0AEBESObgAHRC5ACMABPS4AAkQuAAo3AC4AABFWLgAAC8buQAAAAU+WbgAAEVYuAANLxu5AA0ABT5ZuAAARVi4ABovG7kAGgAFPlm4AAAQuQAGAAH0QSEABwAGABcABgAnAAYANwAGAEcABgBXAAYAZwAGAHcABgCHAAYAlwAGAKcABgC3AAYAxwAGANcABgDnAAYA9wAGABBdQQcABwAGABcABgAnAAYAA3FBAwA3AAYAAXFBBQBGAAYAVgAGAAJxuAAT0LgAINAwMQUiJjUmNjMyFhUUBiMjIiY1JjYzMhYVFAYjIyImNSY2MzIWFRQGIwIxFh8BHhUWHh4U3xYfAR4VFh4eFN8WHwEeFRYeHhQJHhUWHx8WFR4eFRYfHxYVHh4VFh8fFhUeAAAAAAMACgAAAg0DRwADAAsADwA9ALgAAS+4AABFWLgABC8buQAEAAU+WbgAAEVYuAAHLxu5AAcABT5ZuwAPAAIABQAEK7oADQAEAAEREjkwMRM3FwcTJyMHIxM3EwEzAzOSHcYjbUPzSDfkR9j++wFu0gMMO3Yk/VPExAJsF/19Ah7+1QAAAAMACgAAAg0DBwAYACAAJABDALgAAEVYuAAZLxu5ABkABT5ZuAAARVi4ABwvG7kAHAAFPlm7ABAAAQAIAAQruwAkAAIAGgAEK7gACBC5ABUAAvQwMQEGBiMiLgIjIyIGByc2NhcyHgIzMjY3EycjByMTNxMBMwMzAb4ZMiQRGhkaEAEWGxEaGTIkERoZGhEWGxAcQ/NIN+RH2P77AW7SAt4ZGAoNChAOJhkYAQoNChAO/P3ExAJsF/19Ah7+1QAAAAMAHv/3Aj0DBwAYAC0AQQEtuABCL7gAMy9BBQB6ADMAigAzAAJdQQ8ACQAzABkAMwApADMAOQAzAEkAMwBZADMAaQAzAAdduQAZAAP0uABCELgAI9C4ACMvuQA9AAP0QQ8ABgA9ABYAPQAmAD0ANgA9AEYAPQBWAD0AZgA9AAddQQUAdQA9AIUAPQACXbgAGRC4AEPcALgAAEVYuAAeLxu5AB4ABT5ZuwAQAAEACAAEK7sAKAABADgABCu4AAgQuQAVAAL0uQADAAH0uAAeELkALgAB9EEhAAcALgAXAC4AJwAuADcALgBHAC4AVwAuAGcALgB3AC4AhwAuAJcALgCnAC4AtwAuAMcALgDXAC4A5wAuAPcALgAQXUEJAAcALgAXAC4AJwAuADcALgAEcUEFAEYALgBWAC4AAnEwMQEGBiMiLgIjIyIGByc2NhcyHgIzMjY3ExQOAiMiLgI1ND4CMzIeAhUBMj4CNTQuAiMiDgIVFB4CAcsZMiQRGhkaEAEWGxAbGTIkERoZGhEWGxCMI0RmQkJmRCMkRmRBQWVGJP7vLkYwGBcvRi8wRy8XGDBGAt4ZGAoNChAOJhkYAQoNChAO/kI6d2A9PWB3OjxyWjc3WnI8/usxT2MyLl1MMDBMXS4yY08xAAAAAAIAHP//AuwCdwAcACkAtbgAKi+4AB0vuAAqELgACtC4AAovuAAdELgAEtC4AB0QuQAVAAP0uAAZ0LgAChC5ACMABPRBDwAGACMAFgAjACYAIwA2ACMARgAjAFYAIwBmACMAB11BBQB1ACMAhQAjAAJdALgADy+4ABIvuAAARVi4AAAvG7kAAAAFPlm4AABFWLgABS8buQAFAAU+WbsAFwABABgABCu4ABIQuQAdAAH0uAAU0LgAFC+4AAAQuQAaAAH0MDEFIiImIiMiLgI3PgMzMjIXJQcjFTMHIxEhFQEjIg4CBwYeAjMzAZ8PHSAlFz1eQCACASFAX0AgNRkBXxr80hq4ARD+p2IyQykRAQESKkIvZgEBPV9zNjhtVzYBATPYMv74MgJAMEpZKSZdUTYAAAAAAwAo//UCzQG/AC4AOgBPAX27ADsAAwASAAQruwAmAAMARQAEK7sAIgADAC8ABCtBBQB6AEUAigBFAAJdQQ8ACQBFABkARQApAEUAOQBFAEkARQBZAEUAaQBFAAddugAKAEUAJhESOboAGgBFACYREjm4ACYQuAAk0LgAJC+4ACYQuAA50LgAOS9BDwAGADsAFgA7ACYAOwA2ADsARgA7AFYAOwBmADsAB11BBQB1ADsAhQA7AAJduAAiELgAUdwAuAAXL7gAHS+4AABFWLgADS8buQANAAU+WbsAOQACACMABCu6AAoADQAXERI5ugAaAA0AFxESObgADRC5ACsAAvRBIQAHACsAFwArACcAKwA3ACsARwArAFcAKwBnACsAdwArAIcAKwCXACsApwArALcAKwDHACsA1wArAOcAKwD3ACsAEF1BCQAHACsAFwArACcAKwA3ACsABHFBBQBGACsAVgArAAJxugAvACMAORESObgAHRC5AEoAAvS4ADTQuAA0L7gAKxC4AEDQMDElBgYHBgYmJicmJwYGIyIuAjU0PgIzMhYXNjYzMh4CFyEzFAceAzc2NjcnNC4CIyIOAgczBRQeAjMyPgI1NC4CJw4DFQLNEygXGDQ1MRMWERlPODNKMhgbNEsvNU8aFUMyLj8pEgH+9gEDAhYjLhsmPCBDCxcjGRolFwwBwP4ACxwvIyYvGgkMHC8jJi4bCSgNEgcHBgURERMcJi8oQlUtLFA9JCwlIyweOVEzFBMjNycVAQITD8MYLyYXFyYuGCwgQzgkJTdDIB47MSACAiAxOx4AAAAAAQA8ALoCRwDvAAMADQC7AAEAAQAAAAQrMDE3NSEXPAHxGro1NQAAAAEAPAEBAvsBNgADAA0AuwABAAEAAAAEKzAxEzUhFzwCpRoBATU1AAACADsBtAE5AnkAGgA0AMQAuAAGL7gANC+4AABFWLgAAC8buQAAAAk+WbgAAEVYuAAMLxu5AAwACT5ZuAAARVi4ACAvG7kAIAAJPlm4AABFWLgALi8buQAuAAk+WbgADBC5ABIAAfRBBQBJABIAWQASAAJxQSEACAASABgAEgAoABIAOAASAEgAEgBYABIAaAASAHgAEgCIABIAmAASAKgAEgC4ABIAyAASANgAEgDoABIA+AASABBdQQkACAASABgAEgAoABIAOAASAARxuAAm0DAxEzY2NzY2NxcOAzEyFhUUBiMiJicmNTQ2NycGBgcGBzIWFRYGIyImJyY1NDY3NjY3NjY31QYXEAgPDBAOEwsEFh4dFBQeAgEBAjgOFAUHAxYfAR4VFB4CAQECBhcQCA8LAhUXIhAJCwcWChgWDx4VFh8bFAkJCBAITgoYCw0NHhUWHxsUCQkIEAgXIhAJCwcAAAIAOwG0ATkCegAaADQAXQC4ABovuAA0L7gAAEVYuAAFLxu5AAUACT5ZuAAARVi4ABMvG7kAEwAJPlm4AABFWLgAIC8buQAgAAk+WbgAAEVYuAAuLxu5AC4ACT5ZuAAFELkACwAB9LgAJtAwMRM+AzEiJjU0NjcyFhcWFRQGBzMGBgcGBgcnNjY3NjciJjUmNjcyFhcWFRQGBwYGBwYGB9cOEwsEFh4dFBQeAgEBAgEGFxAIDwynDhMGBgQWHwEeFRQeAgEBAgYXEAgPCwHKChgWDx4VFh8BHBQJCQgRBxciEAkLBxYKGAsMDh4VFh8BHBQJCQgRBxciEAkLBwAAAAABADsBtACjAnkAGQAtALgAGS+4AAsvuAAARVi4AAUvG7kABQAJPlm4AABFWLgAEy8buQATAAk+WTAxEwYGBwYHMhYVFgYjIiYnJjU0Njc2Njc2NjeeDhQFBwMWHwEeFRQeAgEBAgYXEAgPCwJjChgLDQ0eFRYfGxQJCQgQCBciEAkLBwABADsBtACjAnoAGQAtALgACy+4ABkvuAAARVi4AAUvG7kABQAJPlm4AABFWLgAEy8buQATAAk+WTAxEzY2NzY3IiY1JjY3MhYXFhUUBgcGBgcGBgdADhMGBgQWHwEeFRQeAgEBAgYXEAgPCwHKChgLDA4eFRYfARwUCQkIEQcXIhAJCwcAAAAAAgAUAAACpwK/AAwAPgDCuwAUAAMAFQAEK7sAEAADABEABCu7AD0AAwAMAAQruAA9ELkADQAD9LgAFRC4ABnQuAAUELgAKNC4ABEQuAAq0LgAEBC4ADrQuAA9ELgAQNwAuAAdL7gALi+4AABFWLgADS8buQANAAU+WbgAAEVYuAAQLxu5ABAABT5ZuAAARVi4ABQvG7kAFAAFPlm7AAMAAQAJAAQruwA8AAEADgAEK7gADhC4ABLQuAAOELgAFtC4ADwQuAAY0LgAPBC4ACnQMDEBNDYzMhYVFAYjIiY1ExEjESMRIxEjESM1MzU0NjMyFhcHJiMmDgIVFTM1NDYzMhYXByYmIyYOAhUVMzcRAkgcFBQbHBQUGwzHSbhJLy9oWBEYDRAIAjI7Hgi4aFgRGA0QAwUDMjoeCMZJAk8UGxwUFBsbFP2yAYL+fgGC/n4BgjMycWcFBSwCCRoyQB02MnFnBQUsAQEJGjJAHTYM/j8AAAAAAgAU//IDBAK/AAkAOACyuwANAAMADgAEK7sAOAADAAoABCu7AAYAAwADAAQruAAOELgAEtC4AA0QuAAh0LgAChC4ACPQuAA4ELgAM9C4AAYQuAA63AC4AAUvuAAWL7gAJy+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAAKLxu5AAoABT5ZuAAARVi4AA0vG7kADQAFPlm7ACMAAQALAAQruAALELgAD9C4ACMQuAAR0LgAIxC4ADTQuAALELgANtAwMQUGJjURNxEUFhcFESMRIxEjNTM1NDYzMhYXByYjJg4CFRUzNTQ2MzIWFwcmJiMmDgIVFTMVIxEDBElQRywm/kC4SS8vaFgRGA0QCAIyOx4IuGhYERgNEAMFAzI6HghlZQcHPDkCOxf9sCwcAh8Bgv5+AYIzMnFnBQUsAgkaMkAdNjJxZwUFLAEBCRoyQB02M/5+AAMAPP8dAasCZgAMABkARgFHuwAyAAMALwAEK7sACQAEAAMABCtBBQB6AAMAigADAAJdQQ8ACQADABkAAwApAAMAOQADAEkAAwBZAAMAaQADAAddugAAAAMACRESOboAEAAvADIREjm4ABAvuQAWAAT0ugANABAAFhESOboAOQADAAkREjm4ADkvuAAk0LgAJC+4ADkQuAAn0LgAJy+4ADkQuQA8AAP0uABI3AC4AEYvuAAARVi4ACovG7kAKgAFPlm7AAYAAQAMAAQruAAMELgADdC4AAYQuAAT0LgAKhC5ADYAAfRBIQAHADYAFwA2ACcANgA3ADYARwA2AFcANgBnADYAdwA2AIcANgCXADYApwA2ALcANgDHADYA1wA2AOcANgD3ADYAEF1BCQAHADYAFwA2ACcANgA3ADYABHFBBQBGADYAVgA2AAJxugAnACoANhESOTAxASImNTQ2MzIWFxQGIyMiJjUmNjMyFhUUBiMTPgM3PgM1NDYnBgYjIi4CNRE3ETUUFjc2NjcRMxEUDgIHDgMHAVcWHh0UFh4BHhXEFSABHxQWHx4VHxUxLicLBgYDAQEBEUxAGTIpGUpAMR08EkkCBQkIDjI8PxwB/h4VFh8fFhUeHhUWHx8WFR79TQMIDxoVCh4gHwwIAwgIGhEhMB4BMBn+zQEzMwEBGgwBZf5zEy4uKg8aJhgLAQAAAAADABQAAAHQAxUACwAYACUA0LsAFQAEAA8ABCu7AAkABAADAAQrQQUAegADAIoAAwACXUEPAAkAAwAZAAMAKQADADkAAwBJAAMAWQADAGkAAwAHXUEPAAYAFQAWABUAJgAVADYAFQBGABUAVgAVAGYAFQAHXUEFAHUAFQCFABUAAl26AAwADwAVERI5uAAVELgAGdC4ABkvuAAVELkAJQAD9LoAHQAVACUREjm4AAkQuAAn3AC4AABFWLgAGS8buQAZAAU+WbsABgABAAAABCu4AAAQuAAM0LgABhC4ABLQMDEBIiY1NDYzMhYVFAYjIiY1NDYzMhYXFAYjExEDNxM2Njc2NxcDEQFZFh4dFRYeHtkVHx0UFh8BHhY5uEalEzcaHiAvuwKtHhUWHx8WFR4eFRYfHxYVHv1TASUBRBr+3CNkLjY5E/6s/uQAAAH/7P9oAgAC/gADAAsAuAABL7gAAy8wMQcBFwEUAdc9/imDA4EV/H8AAAAAAQAyADQBEQIPAAUAGAC4AAAvuAAARVi4AAIvG7kAAgAJPlkwMTcnNxcHF9mnpziMjDTu7SPKywABADIANAERAg8ABQAYALgABS+4AABFWLgAAy8buQADAAk+WTAxNzcnNxcHMoyMOKenV8vKI+3uAAIAFAAAAaYCvwAMACgAh7sAEAADABEABCu7ACcAAwAMAAQruAAnELkADQAD9LgAERC4ABXQuAAQELgAJNC4ACQvuAAnELgAKtwAuAAZL7gAAEVYuAANLxu5AA0ABT5ZuAAARVi4ABAvG7kAEAAFPlm7AAMAAQAJAAQruwAmAAEADgAEK7gADhC4ABLQuAAmELgAFNAwMQE0NjMyFhUUBiMiJjUTESMRIxEjNTM1NDYzMhYXByYnJg4CFQczNxEBRxwUFBscFBQbDMdJLy9oWBEYDRAEBjI6HggBx0gCTxQbHBQUGxsU/bIBgv5+AYIzMnFnBQUsAQIJGzJAHDcM/j8AAAAAAgAU//ICAgK/AAkAIgB/uAAjL7gAAy+5AAYAA/S4ACMQuAAK0LgACi+4AA7QuAAKELkAIgAD9LgAHdC4AB0vuAAGELgAJNwAuAAFL7gAEi+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAAKLxu5AAoABT5ZuwAOAAEACwAEK7gADhC4AB7QuAALELgAINAwMQUGJjURNxEUFhcFESM1MzU0NjMzMhYXBycmDgIVBzMVIxECAklQSCsm/kEvL2hYARAYDRAJMzoeCAFlZQcHPDkCOxf9sCwcAh8BgjMycWcFBSwDCRsyQBw3M/5+AAABACj/dgHkAqsAFQB9uwAVAAMAAAAEK7gAABC4AATQuAAAELgACdC4ABUQuAAL0LgAFRC4ABDQALgACi+4AAAvuwAIAAEABQAEK7sABAABAAEABCu4AAgQuAAN0LoADgAAAAoREjm4AAUQuAAP0LgABBC4ABHQugASAAAAChESObgAARC4ABPQMDEXESM1MzUjNTM1NTMVFTMHIxUzByMR2LCwsLBIxBmrxBmrigFbNJ40AtLSAjSeNP6+AAEAOwDWAKIBPgAMAE+7AAkABAADAAQrQQUAegADAIoAAwACXUEPAAkAAwAZAAMAKQADADkAAwBJAAMAWQADAGkAAwAHXboAAAADAAkREjkAuwAGAAEADAAEKzAxNyImNSY2MzIWFRQGI3EWHwEeFRYeHhTWHhUWHx8WFR4AAAAAAQA7/58AowBlABkALQC4AAsvuAAZL7gAAEVYuAAFLxu5AAUABT5ZuAAARVi4ABMvG7kAEwAFPlkwMRc+AzEiJjUmNjcyFhcWFRQGBwYGBwYGB0AOEwsFFh8BHhUUHgIBAQIGFxAJDgtLChgWEB4UFh8BHBQJCQgRBxchEAkLCAACADv/nwFlAGUAGgA0AMQAuAAaL7gANC+4AABFWLgABS8buQAFAAU+WbgAAEVYuAATLxu5ABMABT5ZuAAARVi4ACAvG7kAIAAFPlm4AABFWLgALi8buQAuAAU+WbgABRC5AAsAAfRBIQAHAAsAFwALACcACwA3AAsARwALAFcACwBnAAsAdwALAIcACwCXAAsApwALALcACwDHAAsA1wALAOcACwD3AAsAEF1BCQAHAAsAFwALACcACwA3AAsABHFBBQBGAAsAVgALAAJxuAAm0DAxBT4DMSImNTQ2NzIWFxYVFAYHMwYGBwYGByc+AzEiJjUmNjcyFhcWFRQGBwYGBwYGBwEDDhMLBBYeHRQUHgIBAQIBBhcQCQ4M0w4TCwUWHwEeFRQeAgEBAgYXEAkOC0sKGBYQHhQWHwEcFAkJCBEHFyEQCQsIFgoYFhAeFBYfARwUCQkIEQcXIRAJCwgABwAo//ID/QKvABQAKQAtAEEAVQBpAH0B4LsAbwADADMABCu7AD0AAwB5AAQruwAkAAMAZQAEK7sARwADAAUABCu7AFsAAwAaAAQruwAPAAMAUQAEK0EFAHoABQCKAAUAAl1BDwAJAAUAGQAFACkABQA5AAUASQAFAFkABQBpAAUAB126ACoAMwAPERI5ugAsADMADxESOUEPAAYAPQAWAD0AJgA9ADYAPQBGAD0AVgA9AGYAPQAHXUEFAHUAPQCFAD0AAl1BBQB6AFEAigBRAAJdQQ8ACQBRABkAUQApAFEAOQBRAEkAUQBZAFEAaQBRAAddQQ8ABgBbABYAWwAmAFsANgBbAEYAWwBWAFsAZgBbAAddQQUAdQBbAIUAWwACXUEFAHoAZQCKAGUAAl1BDwAJAGUAGQBlACkAZQA5AGUASQBlAFkAZQBpAGUAB11BDwAGAG8AFgBvACYAbwA2AG8ARgBvAFYAbwBmAG8AB11BBQB1AG8AhQBvAAJduAAPELgAf9wAuAArL7gAOC+4AAAvuAAVL7gAAEVYuAAqLxu5ACoABT5ZuwAfAAEAQgAEK7sAdAACAC4ABCu4AB8QuAAK0LgACi+4ABUQuAAU0LoALAAAADgREjm4ABUQuQBgAAL0uABM0LgATC+4AEIQuABW0LgAVi8wMQUiLgI1ND4CMzIeAhUUDgIjISIuAjU0PgIzMh4CFRQOAiMlATMBAyIuAjU0PgIzMh4CFRQOAgUOAxUUHgIzMj4CNTQuAiUOAxUUHgIzMj4CNTQuAgEOAxUUHgIzPgM1NC4CA3EkNCIREyQ0ISE0IxMRIzQk/rwkNCIREyQ1ISE0IxMRIzQk/nYBTkn+sTkkNCIREyQ0ISE0IxMRIzQCmhccEQYHEhwVFx0RBgcSHf6nFxwRBgcSHBUXHREFBxIc/nEXHBEGBxIcFRcdEQYHEh0OHjA+ISA7LRscLTsgID4wHR4wPiEgOy0bGy08ICA+MB0MAqn9VwFgHjA+ICA7LRscLTsgID4wHVACFCAoFRcsJBYXIy0XFSgfFQICFCAoFRcsJBYXIy0XFSgfFQFvAhQgKRUXLCQVARYjLBcVKCAUAAAAAwAKAAACDQNKAAUADQARAD0AuAADL7gAAEVYuAAGLxu5AAYABT5ZuAAARVi4AAkvG7kACQAFPlm7ABEAAgAHAAQrugAPAAYAAxESOTAxAQcnNxcHEycjByMTNxMBMwMzARCIHaWuIiND80g35EfY/vsBbtIC+E4pd3cp/VbExAJsF/19Ah7+1QAAAAACADwAAAGbA0oABQARAEi7AAoAAwAHAAQruAAKELgADtAAuAADL7gAAEVYuAAGLxu5AAYABT5ZuwAHAAEACgAEK7sADAABAA0ABCu4AAYQuQAPAAH0MDETByc3FwcBAyUHIxUzByMRIRXriB2lriL+xgEBXxn90hq4ARAC+E4pd3cp/VYCdgEz2DL++DIAAAADAAoAAAINA0cAAwALAA4AMwC4AAIvuAAARVi4AAQvG7kABAAFPlm4AABFWLgABy8buQAHAAU+WbsADgACAAUABCswMRMnNxcTJyMHIxM3EwEDM7Ujxh1KQ/NIN+RH2P78btICrSR2O/z0xMQCbBf9fQIe/tUAAAADADwAAAGbAxUACwAYACQAxrsAHQADABoABCu7AAkABAADAAQrQQUAegADAIoAAwACXUEPAAkAAwAZAAMAKQADADkAAwBJAAMAWQADAGkAAwAHXboADwAaAB0REjm4AA8vuQAVAAT0ugAMAA8AFRESOboAHwADAAkREjm4AB0QuAAh0LgACRC4ACbcALgAAEVYuAAZLxu5ABkABT5ZuwAGAAEAAAAEK7sAGgABAB0ABCu7AB8AAQAgAAQruAAAELgADNC4AAYQuAAS0LgAGRC5ACIAAfQwMQEiJjU0NjMyFhUUBiMiJjU0NjMyFhcUBiMDAyUHIxUzByMRIRUBTxYeHRUWHh7ZFR8dFBYfAR4WTAEBXxn90hq4ARACrR4VFh8fFhUeHhUWHx8WFR79UwJ2ATPYMv74MgACADwAAAGbA0cAAwAPAEi7AAgAAwAFAAQruAAIELgADNAAuAACL7gAAEVYuAAELxu5AAQABT5ZuwAFAAEACAAEK7sACgABAAsABCu4AAQQuQANAAH0MDEBJzcXAQMlByMVMwcjESEVATS/HMf+5QEBXxn90hq4ARACrV87dv0vAnYBM9gy/vgyAAAAAAIAJQAAAQgDRwADAAcALLsABwADAAQABCsAuAACL7gAAEVYuAAELxu5AAQABT5ZugAGAAQAAhESOTAxEyc3FwMRNxFII8YdukoCrSR2O/z0AmkZ/X4AAAAC/8sAAAEeA0oABQAJACy7AAkAAwAGAAQrALgAAy+4AABFWLgABi8buQAGAAU+WboACAAGAAMREjkwMRMHJzcXBwMRNxFwiRylriKuSgL4Til3dyn9VgJpGf1+AAP/5AAAAQ8DFQAMABkAHQDQuwAWAAQAEAAEK7sACQAEAAMABCtBBQB6AAMAigADAAJdQQ8ACQADABkAAwApAAMAOQADAEkAAwBZAAMAaQADAAddugAAAAMACRESOUEPAAYAFgAWABYAJgAWADYAFgBGABYAVgAWAGYAFgAHXUEFAHUAFgCFABYAAl26AA0AEAAWERI5uAAWELgAGtC4ABovuAAWELkAHQAD9LgACRC4AB/cALgAAEVYuAAaLxu5ABoABT5ZuwAGAAEADAAEK7gADBC4AA3QuAAGELgAE9AwMRMiJjUmNjMyFhUUBiMjIiY1NDYzMhYXFAYjExE3Ed4WHwEeFRYeHhTFFR8dFBYfAR4WN0oCrR4VFh8fFhUeHhUWHx8WFR79UwJpGf1+AAAC//EAAADUA0cAAwAHACy7AAcAAwAEAAQrALgAAS+4AABFWLgABC8buQAEAAU+WboABgAEAAEREjkwMQM3FwcDETcRDx3GI2NKAww7diT9UwJpGf1+AAAAAwAe//cCPQNHAAMAGAAsARy4AC0vuAAeL0EFAHoAHgCKAB4AAl1BDwAJAB4AGQAeACkAHgA5AB4ASQAeAFkAHgBpAB4AB125AAQAA/S4AC0QuAAO0LgADi+5ACgAA/RBAwAGACgAAV1BDQAWACgAJgAoADYAKABGACgAVgAoAGYAKAAGXUEFAHUAKACFACgAAl24AAQQuAAu3AC4AAIvuAAARVi4AAkvG7kACQAFPlm7ABMAAQAjAAQruAAJELkAGQAB9EEhAAcAGQAXABkAJwAZADcAGQBHABkAVwAZAGcAGQB3ABkAhwAZAJcAGQCnABkAtwAZAMcAGQDXABkA5wAZAPcAGQAQXUEJAAcAGQAXABkAJwAZADcAGQAEcUEFAEYAGQBWABkAAnEwMRMnNxcTFA4CIyIuAjU0PgIzMh4CFQEyPgI1NC4CIyIOAhUUHgLbI8YdoSNEZkJCZkQjJEZkQUFlRiT+7y5GMBgXL0YvMEcvFxgwRgKtJHY7/jk6d2A9PWB3OjxyWjc3WnI8/usxT2MyLl1MMDBMXS4yY08xAAAAAwAe//cCPQNKAAUAGgAuARy4AC8vuAAgL0EFAHoAIACKACAAAl1BDwAJACAAGQAgACkAIAA5ACAASQAgAFkAIABpACAAB125AAYAA/S4AC8QuAAQ0LgAEC+5ACoAA/RBAwAGACoAAV1BDQAWACoAJgAqADYAKgBGACoAVgAqAGYAKgAGXUEFAHUAKgCFACoAAl24AAYQuAAw3AC4AAMvuAAARVi4AAsvG7kACwAFPlm7ABUAAQAlAAQruAALELkAGwAB9EEhAAcAGwAXABsAJwAbADcAGwBHABsAVwAbAGcAGwB3ABsAhwAbAJcAGwCnABsAtwAbAMcAGwDXABsA5wAbAPcAGwAQXUEJAAcAGwAXABsAJwAbADcAGwAEcUEFAEYAGwBWABsAAnEwMQEHJzcXBxMUDgIjIi4CNTQ+AjMyHgIVATI+AjU0LgIjIg4CFRQeAgEriB2lriGEI0RmQkJmRCMkRmRBQWVGJP7vLkYwGBcvRi8wRy8XGDBGAvhOKXd3Kf6bOndgPT1gdzo8clo3N1pyPP7rMU9jMi5dTDAwTF0uMmNPMQAAAAABACj/8ANJArIASACruABJL7gAAC+4AEkQuAAb0LgAGy+5ADAABPS4AAvQuAALL7gAGxC4ABbQuAAAELkASAAE9LgAOdC4ADkvuABIELgAQ9C4AEgQuABK3AC4ABEvuAAARVi4AAAvG7kAAAAFPlm4AABFWLgAHC8buQAcAAU+WbsAKQACACoABCu6ADMABgADK7gAKhC4ACzQugAwAAYAMxESOboAOQAGADMREjm4AAYQuAA90DAxITU0LgIjIg4CFRUUDgIjIi4CNSY0NDY1AREXPgM3PgMzMxUjMyIGFQc2NjMyFhcWFhc2NjcVIyIOAhUcAxUCaw4TFAYVGxAHDxggERIgGA8BAf7wKAcgJiUMEx8qPzPAEQEwMQETSDEdKxcNCwkRKxcMEhoQCf0ZHxAFERsiEKkSHhcMDBceEkx8dnxL/bkBMUgNRFNRGihDMhwZLSXrLy0PEwsVDSMgBWcTHyYTITUzNSEAAwAe//cCPQNHAAMAGAAsARy4AC0vuAAeL0EFAHoAHgCKAB4AAl1BDwAJAB4AGQAeACkAHgA5AB4ASQAeAFkAHgBpAB4AB125AAQAA/S4AC0QuAAO0LgADi+5ACgAA/RBAwAGACgAAV1BDQAWACgAJgAoADYAKABGACgAVgAoAGYAKAAGXUEFAHUAKACFACgAAl24AAQQuAAu3AC4AAIvuAAARVi4AAkvG7kACQAFPlm7ABMAAQAjAAQruAAJELkAGQAB9EEhAAcAGQAXABkAJwAZADcAGQBHABkAVwAZAGcAGQB3ABkAhwAZAJcAGQCnABkAtwAZAMcAGQDXABkA5wAZAPcAGQAQXUEJAAcAGQAXABkAJwAZADcAGQAEcUEFAEYAGQBWABkAAnEwMQEnNxcTFA4CIyIuAjU0PgIzMh4CFQEyPgI1NC4CIyIOAhUUHgIBeL8dxqAjRGZCQmZEIyRGZEFBZUYk/u8uRjAYFy9GLzBHLxcYMEYCrV87dv50OndgPT1gdzo8clo3N1pyPP7rMU9jMi5dTDAwTF0uMmNPMQAAAgA8//cCAwNHAAMAGQC3uAAaL7gABC+5AAUAA/S4ABoQuAAR0LgAES+5ABIAA/S4AAUQuAAb3AC4AAIvuAAARVi4AAsvG7kACwAFPlm6ABIACwACERI5uQAWAAH0QSEABwAWABcAFgAnABYANwAWAEcAFgBXABYAZwAWAHcAFgCHABYAlwAWAKcAFgC3ABYAxwAWANcAFgDnABYA9wAWABBdQQkABwAWABcAFgAnABYANwAWAARxQQUARgAWAFYAFgACcTAxEyc3FxczERQOAiMiLgI1ETcTFBY3MjY12SPGHTE5Iz5UMTBSPCNKAUxQT1gCrSR2O5b+YDJSOyAgO1EyAZUZ/l5RXgFhTwAAAAACADz/9wIDA0oABQAbAL+4ABwvuAAGL7gAHBC4ABPQuAATL7kAFAAD9LgAAtC4AAIvuAAGELkABwAD9LgAHdwAuAADL7gAAEVYuAANLxu5AA0ABT5ZugAUAA0AAxESObkAGAAB9EEhAAcAGAAXABgAJwAYADcAGABHABgAVwAYAGcAGAB3ABgAhwAYAJcAGACnABgAtwAYAMcAGADXABgA5wAYAPcAGAAQXUEJAAcAGAAXABgAJwAYADcAGAAEcUEFAEYAGABWABgAAnEwMQEHJzcXBxczERQOAiMiLgI1ETcTFBY3MjY1ASSJHKWuIho5Iz5UMTBSPCNKAUxQT1gC+E4pd3cpNP5gMlI7ICA7UTIBlRn+XlFeAWFPAAIAPP/3AgMDRwADABkAt7gAGi+4AAQvuQAFAAP0uAAaELgAEdC4ABEvuQASAAP0uAAFELgAG9wAuAABL7gAAEVYuAALLxu5AAsABT5ZugASAAsAARESObkAFgAB9EEhAAcAFgAXABYAJwAWADcAFgBHABYAVwAWAGcAFgB3ABYAhwAWAJcAFgCnABYAtwAWAMcAFgDXABYA5wAWAPcAFgAQXUEJAAcAFgAXABYAJwAWADcAFgAEcUEFAEYAFgBWABYAAnEwMRM3FwcXMxEUDgIjIi4CNRE3ExQWNzI2NbEdxiNZOSM+VDEwUjwjSgFMUE9YAww7diQ3/mAyUjsgIDtRMgGVGf5eUV4BYU8AAAAAAQBQAAAAmAHBAAMAIrsAAwADAAAABCsAuAACL7gAAEVYuAAALxu5AAAABT5ZMDEzETcRUEgBqRj+PwAAAQAlAf0BeQKdAAUADwC4AAMvuAABL7gABS8wMRMHJzcXB8uJHaauIgJMTyp2dioAAQA+AfsBeAJVABcAFwC7ABQAAQADAAQruwAPAAEACAAEKzAxAQYGIyIuAiMiBgcnNjYzMh4CMzI2NwF4GTIkERoZGhAWGxEbGTIlERoZGhAWGxECLBkYCg0KEA0lGRgKDQoQDQAAAAABADgB/gGHAjIAAwANALsAAQABAAAABCswMRM1IRc4ATUaAf40NAAAAQAlAf0BeQKdAAUADwC4AAAvuAACL7gABC8wMRMnNxc3F8umHYmMIgH9dylOTikAAQBLAlEAtgK9AAsAQ7sAAAAEAAYABCtBBQB6AAYAigAGAAJdQQ8ACQAGABkABgApAAYAOQAGAEkABgBZAAYAaQAGAAddALoACQADAAMrMDETFAYjIiY1NDYzMha2IBYVICEXFR4ChxYgIBYWICAAAAIAQQH9AP4CvAAUACEAo7gAIi+4AB4vuAAiELgAANC4AAAvQQUAegAeAIoAHgACXUEPAAkAHgAZAB4AKQAeADkAHgBJAB4AWQAeAGkAHgAHXbgAHhC5AAoAA/S4AAAQuQAYAAP0QQ8ABgAYABYAGAAmABgANgAYAEYAGABWABgAZgAYAAddQQUAdQAYAIUAGAACXbgAChC4ACPcALsAGwACAA8ABCu7AAUAAgAVAAQrMDETND4CMzIeAhUUDgIjIi4CNTciBhUUFjM2NjU0JiNBDxsjFBMiGQ4PGiMUEyIZD2EXISAVFiAeFQJdEyMaDw8aIxQUIhoPDxoiFDcgFhYfAR8WFiAAAAEAV/9GAQcAEwAdACW7ABUABAAMAAQruAAVELkABgAD9AC4AA0vuwADAAIAGgAEKzAxFxYWFzI2NTQuAiMjNTMVJxYVFhYVFA4CIyImJ2cSGxERHgoPEQcgLwEWJRsMGSQYFCoRgQgHARcUCw4JA1QuAQMCBSoaDh0YDw0IAAAAAgAZAfoBXwLQAAMABwATALgAAS+4AAUvuAADL7gABy8wMRM3FwcnNxcHtXQ2ec10NnoCCMgnrw7IJ68AAQBX/0YBBwAgABoAEQC4AA0vuwAXAAIAAwAEKzAxBQYGIyIuAjU0NjcnNxcHBgYHBh4CMzI2NwEHECoUGCUZDBckAR0lHhIRBAUEDRQLERsSpQgNDxgdDho0IAEZHxkPGQwOGRILBwgAAAAAAQAo//oCNAKEADwAwwC4AABFWLgAAy8buQADAAU+WbsAGgABACEABCu7AAwAAQAJAAQruwAVAAEAEgAEK7gAFRC4ACbQuAASELgAKNC4AAwQuAAv0LgACRC4ADHQuAADELkANwAB9EEhAAcANwAXADcAJwA3ADcANwBHADcAVwA3AGcANwB3ADcAhwA3AJcANwCnADcAtwA3AMcANwDXADcA5wA3APcANwAQXUEJAAcANwAXADcAJwA3ADcANwAEcUEFAEYANwBWADcAAnEwMSUGBiMjIi4CJyM1MyYmNzQ2NyM1Mz4DFxYWFwcmJiMiDgIHMwcjBhQVBhYXMwcjHgMzMj4CNwI0N2M+ATBPPCkLRDsBAQEBATxFCik+UjQ2XCUaI0gnJjgoGgf0DO8CAQEC2wvHBxsoNSIbJyYoHUorJSdBVCw1DBcLCREJNS1UQSUBARkbLBcSHjA/ITUJEgkLFgw1ID4xHggRGBAAAAADABL/+gG4AxYADAAZAFQBjLsASgADADsABCu7AAkABAADAAQrQQUAegADAIoAAwACXUEPAAkAAwAZAAMAKQADADkAAwBJAAMAWQADAGkAAwAHXboAAAADAAkREjlBAwAGAEoAAV1BDQAWAEoAJgBKADYASgBGAEoAVgBKAGYASgAGXUEFAHUASgCFAEoAAl26ABAAOwBKERI5uAAQL7kAFgAE9LoADQAQABYREjm6ADIAAwAJERI5uAAyL0EFAHoAMgCKADIAAl1BDwAJADIAGQAyACkAMgA5ADIASQAyAFkAMgBpADIAB125AFQAA/S4AFbcALgAAEVYuAAgLxu5ACAABT5ZuwAGAAEADAAEK7sAQAABAEcABCu4AAwQuAAN0LgABhC4ABPQuAAgELkAKwAB9EEhAAcAKwAXACsAJwArADcAKwBHACsAVwArAGcAKwB3ACsAhwArAJcAKwCnACsAtwArAMcAKwDXACsA5wArAPcAKwAQXUEJAAcAKwAXACsAJwArADcAKwAEcUEFAEYAKwBWACsAAnEwMQEiJjUmNjMyFhUUBiMjIiY1NDYzMhYVFAYjARQGBwYGIyIuAic3HgMzMj4CNzY1NCYnJyYnJiY1ND4CMzIWFwcmJiMiBgcGFhcXFhYXFhYVATkWHwEeFRYeHhTFFR8eFBYfHhYBRi0qHkMrHDgzLBAhDCQrMBcSGhUSCi80OD9THhQRHTVLLjNLISAZOyg6QAEBNDdHKjQTExACrh4VFh8fFhUeHhUWHx8WFR7+CS1PHBQRDRUcDzYLGBMNAwYKByQzKjETFRwgFTMeKEIwGiIYMRIaNjAjLBIXDiAWFzgeAAAAAgAQ//QBYwKiAAUAQAEnuABBL7gAEi+4AEEQuAAg0LgAIC+4AALQuAACL0EFAHoAEgCKABIAAl1BDwAJABIAGQASACkAEgA5ABIASQASAFkAEgBpABIAB124ACAQuQAwAAP0QQ8ABgAwABYAMAAmADAANgAwAEYAMABWADAAZgAwAAddQQUAdQAwAIUAMAACXbgAEhC5ADsAA/S4AELcALgAAi+4AAQvuAAARVi4AAYvG7kABgAFPlm7ACUAAQArAAQruAAGELkADQAB9EEhAAcADQAXAA0AJwANADcADQBHAA0AVwANAGcADQB3AA0AhwANAJcADQCnAA0AtwANAMcADQDXAA0A5wANAPcADQAQXUEJAAcADQAXAA0AJwANADcADQAEcUEFAEYADQBWAA0AAnEwMRMnNxc3FwMiJic3FhYzMj4CJzQuAicmJicmJicmJjU0PgIzMhYXByYjIg4CFRQWFxYXFhYXFhYHFA4CI7WlHYiMIrYmShwbFj0eEiQdEgEOFBoMChQKFCkREhgaKzgdIj8dGzEwDx8YDxMRIy0UKBESGAEfMT4fAgJ3KU5OKf18GxYsEhUIEh0UEBUPCgUECAMIEQ0OJh8gMSESFhEsHAgQGRESFggQEQgRDg4qHyM0IhAAAAAAAv/5AAABtQNHAAMAEAA2uwAQAAMABAAEK7oACAAEABAREjkAuAACL7gAAEVYuAAELxu5AAQABT5ZugAIAAQAAhESOTAxEyc3FwMRAzcTNjY3NjcXAxGPJMcdnrhGpRM3Gh4gL7sCrSR2O/z0ASUBRBr+3CNkLjY5E/6s/uQAAAAAAAEAAQEBAQEADAD4CP8ACAAI//0ACQAI//0ACgAJ//0ACwAK//0ADAAL//wADQAM//wADgAN//wADwAO//wAEAAP//sAEQAP//sAEgAQ//sAEwAR//sAFAAS//oAFQAT//oAFgAU//oAFwAV//oAGAAW//kAGQAW//kAGgAX//kAGwAY//kAHAAZ//gAHQAa//gAHgAb//gAHwAc//gAIAAd//cAIQAd//cAIgAe//cAIwAf//cAJAAg//YAJQAh//YAJgAi//YAJwAj//YAKAAk//UAKQAk//UAKgAl//UAKwAm//UALAAn//QALQAo//QALgAp//QALwAq//QAMAAr//MAMQAr//MAMgAs//MAMwAt//MANAAu//IANQAv//IANgAw//IANwAx//IAOAAy//EAOQAy//EAOgAz//EAOwA0//EAPAA1//AAPQA2//AAPgA3//AAPwA4/+8AQAA5/+8AQQA6/+8AQgA6/+8AQwA7/+4ARAA8/+4ARQA9/+4ARgA+/+4ARwA//+0ASABA/+0ASQBB/+0ASgBB/+0ASwBC/+wATABD/+wATQBE/+wATgBF/+wATwBG/+sAUABH/+sAUQBI/+sAUgBI/+sAUwBJ/+oAVABK/+oAVQBL/+oAVgBM/+oAVwBN/+kAWABO/+kAWQBP/+kAWgBP/+kAWwBQ/+gAXABR/+gAXQBS/+gAXgBT/+gAXwBU/+cAYABV/+cAYQBW/+cAYgBW/+cAYwBX/+YAZABY/+YAZQBZ/+YAZgBa/+YAZwBb/+UAaABc/+UAaQBd/+UAagBd/+UAawBe/+QAbABf/+QAbQBg/+QAbgBh/+QAbwBi/+MAcABj/+MAcQBk/+MAcgBk/+MAcwBl/+IAdABm/+IAdQBn/+IAdgBo/+IAdwBp/+EAeABq/+EAeQBr/+EAegBr/+EAewBs/+AAfABt/+AAfQBu/+AAfgBv/98AfwBw/98AgABx/98AgQBy/98AggBz/94AgwBz/94AhAB0/94AhQB1/94AhgB2/90AhwB3/90AiAB4/90AiQB5/90AigB6/9wAiwB6/9wAjAB7/9wAjQB8/9wAjgB9/9sAjwB+/9sAkAB//9sAkQCA/9sAkgCB/9oAkwCB/9oAlACC/9oAlQCD/9oAlgCE/9kAlwCF/9kAmACG/9kAmQCH/9kAmgCI/9gAmwCI/9gAnACJ/9gAnQCK/9gAngCL/9cAnwCM/9cAoACN/9cAoQCO/9cAogCP/9YAowCP/9YApACQ/9YApQCR/9YApgCS/9UApwCT/9UAqACU/9UAqQCV/9UAqgCW/9QAqwCW/9QArACX/9QArQCY/9QArgCZ/9MArwCa/9MAsACb/9MAsQCc/9MAsgCd/9IAswCd/9IAtACe/9IAtQCf/9IAtgCg/9EAtwCh/9EAuACi/9EAuQCj/9EAugCk/9AAuwCk/9AAvACl/9AAvQCm/88AvgCn/88AvwCo/88AwACp/88AwQCq/84AwgCr/84AwwCs/84AxACs/84AxQCt/80AxgCu/80AxwCv/80AyACw/80AyQCx/8wAygCy/8wAywCz/8wAzACz/8wAzQC0/8sAzgC1/8sAzwC2/8sA0AC3/8sA0QC4/8oA0gC5/8oA0wC6/8oA1AC6/8oA1QC7/8kA1gC8/8kA1wC9/8kA2AC+/8kA2QC//8gA2gDA/8gA2wDB/8gA3ADB/8gA3QDC/8cA3gDD/8cA3wDE/8cA4ADF/8cA4QDG/8YA4gDH/8YA4wDI/8YA5ADI/8YA5QDJ/8UA5gDK/8UA5wDL/8UA6ADM/8UA6QDN/8QA6gDO/8QA6wDP/8QA7ADP/8QA7QDQ/8MA7gDR/8MA7wDS/8MA8ADT/8MA8QDU/8IA8gDV/8IA8wDW/8IA9ADW/8IA9QDX/8EA9gDY/8EA9wDZ/8EA+ADa/8EA+QDb/8AA+gDc/8AA+wDd/8AA/ADe/78A/QDe/78A/gDf/78A/wDg/78AFAA1AC4ASQBlAAAACgFwABACEQAMAkkABgAAuAAALEu4AAlQWLEBAY5ZuAH/hbgARB25AAkAA19eLbgAASwgIEVpRLABYC24AAIsuAABKiEtuAADLCBGsAMlRlJYI1kgiiCKSWSKIEYgaGFksAQlRiBoYWRSWCNlilkvILAAU1hpILAAVFghsEBZG2kgsABUWCGwQGVZWTotuAAELCBGsAQlRlJYI4pZIEYgamFksAQlRiBqYWRSWCOKWS/9LbgABSxLILADJlBYUViwgEQbsEBEWRshISBFsMBQWLDARBshWVktuAAGLCAgRWlEsAFgICBFfWkYRLABYC24AAcsuAAGKi24AAgsSyCwAyZTWLBAG7AAWYqKILADJlNYIyGwgIqKG4ojWSCwAyZTWCMhuADAioobiiNZILADJlNYIyG4AQCKihuKI1kgsAMmU1gjIbgBQIqKG4ojWSC4AAMmU1iwAyVFuAGAUFgjIbgBgCMhG7ADJUUjISMhWRshWUQtuAAJLEtTWEVEGyEhWS0AuAAAKwC6AAEAAgACKwG6AAMAAgACKwG/AAMATAA+ADAAIwASAAAACCu/AAQANwAtACMAGQASAAAACCsAvwABAGgAXABIADQAHwAAAAgrvwACAHgAXABIADQAHwAAAAgrALoABQAEAAcruAAAIEV9aRhEAAAAAAD3AQEBAUwBAQEBMwEBAUQ7OwEBOwEBAQEBAUwBAUxMTEwBTEwBAQEBAQEBATsBTAEBREwBOwEBHDs7TDtMOwFMAQEBAQEBATMBAQEzMwFMOwFMMwEBAQEvN0wvOwFMAUwBAQE3AQEBAQEzAQEBOy9MNzdMRDdEOzs7TEwBAQEBN0xMTExMTExMTAE7AQFMAUxMMzdMATcBATsBTExMTEwBAQEBAQFMAQE7AUQBAQEBAQFETERMAQEBOyIBAQEBRAEBATcBAQFMATs7RDtMTEwBAQEBAQE7AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAURMAQAAAQAAAAoAHgAsAAFsYXRuAAgABAAAAAD//wABAAAAAWtlcm4ACAAAAAEAAAABAAQAAgAAAAEACAABCo4ABAAAAEsAoACqALQAwgD8AR4BSAHKAdAB1gHcAe4B+AIGAgwCFgIgAlICbAKKArQCygM8A1IDWANmA2wDvgP4A/4EBARCBKQEzgTwBSIFsAXaBmAGygdoB/YIcAh6CJwIqgi0CLoIyAkSCSAJLgk0CToJQAlGCVwJZgl4CYoJlAmaCawJtgnMCdYJ7An2CgQKDgowCkIKVApqCoAAAgAq/9gASv/oAAIAKv/QAEH/7AADABIAKgBP//AAUwBYAA4ALP/sAC3/7AAw/+wAOP/sADr/7AA9/84AP//sAED/7ABC/84AS//wAFD/8ABY//YAX//iAGD/7AAIAB3/2AAq/+gAPf/YAD//6ABB/9AAQv/IAEP/2ABh/+gACgAr/+wALP/iADD/7AA4/+wAPf/OAD//7ABA/+wAQv/YAF//4ABg/+gAIAAZ/9gAGv/gABv/yAAc/9AAHf+IAB7/4AAf/+gAIv/YACr/sAA4/+wAPP/sAD0AHgA/ABQAQAAUAEIAHgBK/9AATP/QAE3/2ABO/9gAUP/IAFb/0ABX/+AAWP/YAFn/0ABa/9AAW//QAFz/2ABe/+AAX//oAGD/4ABh/9AAYv/oAAEARf/QAAEARf/oAAEARf/QAAQAFv/gABgAEAAg//AARf/AAAIAGAAgAEX/2AADABb/8AAYABgARf/IAAEARf/wAAIAGP/wAB3/sAACABgAEABF/9gADAAL/9gAEP/YABb/6AA4/+wAPf/EAD7/7AA//84AQP/sAEL/zgBF/8gAX//oAGD/6AAGAAv/7AA9/84AQf/OAEL/zgBD/+wARf/gAAcALP/xADj/7AA9//YAQP/sAEH/4gBC/+wAQ//sAAoAFf/sABf/4gAz/+IAPf/iAD7/9gA//+wAQf/OAEL/2ABD/+IARf/oAAUAOv/2AD8AFABAABQAQgAUAEUAIAAcABX/4gAX/9gAMP/sADP/4gA4/+wAOv/sAD8AFABAABQAQf/iAEIAFABFACgASv/QAEz/4ABN/+gATv/oAFD/6ABW/+gAV//oAFj/6ABZ/+AAWv/gAFv/6ABc/+gAXv/wAF//+ABh//AAYv/oAGP/8AAFAD3/7AA///YAQf/iAEL/9gBD//YAAQBB/+wAAwA4//YAQf/sAEr/8AABACr/7AAUABb/4AAs/+wAMP/YADj/4AA6/+gAPP/4AD7/8ABK/+gATP/gAE3/6ABO//AAUP/YAFX/8ABX//gAWP/oAFr/4ABb//gAXv/yAF//5QBg/+UADgAL/+wALf/2ADD/7AA4/+gAOv/wAD3/2AA+/+gAP//YAED/8ABC/+gAUP/4AFj/8ABf//AAYP/wAAEAQf/oAAEAQf/oAA8AFf/sABf/7AAY/+wAKv/sAC7/9gAz/9gAPf/oAD//7ABA/+wAQf/EAEL/7ABD/84ARf/oAEr/8ABh//AAGAAV/+IAFv/oABf/4gAY/9gAKv/EAC3/9gAz/9AAOf/4ADr/+AA8//gAPf/4AEH/yABD/9gASv/QAEz/6ABN/+gATv/gAFD/4ABW/+gAV//4AFj/4ABZ//gAW//oAFz/8AAKABX/7AAz/+AAPf/gAD//8ABB/8AAQv/oAEP/2ABK//AAXP/4AGH/8AAIAD7/+ABB/9gAQv/wAEr/8ABM//AATv/wAFD/8ABY//AADAAL/+wAEP/sADP/8AA9/+gAP//wAEH/2ABC//AAQ//gAF//8ABg//AAYf/wAGP/+AAjABX/4gAW/9gAF//YABj/2AAq/8QALP/2ADD/7AAz/+IAOP/xADr/8AA8//gAPwAYAEAAGABB/+gAQgAYAEUAKABK/6gATP+4AE3/wABO/7AAUP+4AFb/sABX/7AAWP+oAFn/qABa/7AAW/+4AFz/uABd//AAXv+2AF//uABg/8gAYf/AAGL/wABj/7gACgAY/+wAKv/sAC7/7AAv//YAM//sADn/+AA6//gAPf/oAEH/2ABD/9gAIQAV/+wAFv/gABf/7AAY/84AKv/OADD/7AAz/8QAOP/sADr/8AA9ABAAPwAUAEAAFABB/+IAQgAUAEP/4gBFABAASv/IAEz/0ABN/9gATv/YAFD/0ABW/9gAV//YAFj/yABZ/8gAWv/QAFv/2ABc/9gAXv/wAF//+ABh/+gAYv/YAGP/4AAaABX/7AAX/+wAGP/YACr/7AAz/9gAOP/sAD0AEAA/ABQAQAAUAEH/7ABCABQARQAQAEr/0ABM/+gATf/YAE7/4ABQ/9gAVv/wAFf/4ABY/+AAW//YAFz/4ABe/+gAYf/oAGL/6ABj/+AAJwAQ/+wAFv/QACv/zgAs/84ALf/iAC7/7AAv/+IAMP/EADH/7AAy/+wANf/4ADb/+AA3/+gAOP/EADn/6AA6/8AAO//oADz/2AA9/+AAPv/YAD//4gBA/+wAQf/YAEL/7ABD/+IASv/QAEv/6ABM/9gATf/iAE7/4gBQ/+IAWP/dAFn/7ABa/+IAXf/iAF7/4gBf/+IAYP/iAGL/5QAjABX/2AAW/9AAF//iABj/2AAq/84ALP/sADD/7AAz/9gAOP/sADr/6AA8//gAPQAQAD8AFABAABQAQf/sAEP/7ABFABgASv/AAEz/uABN/8gATv/QAFD/wABW/8gAV//YAFj/wABZ/8AAWv/AAFv/yABc/8AAXv/QAF//4ABg/9gAYf/YAGL/2ABj/+AAHgAW/+AALP/iAC3/4gAu/+wAL//2ADD/xAAx//YAOP/OADr/2AA7//gAPP/4AD3/4AA+/9gAP//iAED/7ABB/+IAQv/sAEP/7ABL//AATP/oAE3/6ABO//AAT//wAFD/8ABR//AAWP/oAFn/+ABa//AAX//gAGD/6AACAEYABwBTAEAACAA4//AAPf/IAD7/6AA//8gAQP/IAEL/yABQ//gAX//gAAMAC//gAEL/wABF/9gAAgBC/9AARf/oAAEARf/YAAMAPf/QAEL/yABF/9gAEgALAEAAEAAUABIAUAAV/+gAF//oAC8AHQAxABgANAAIADUAMAA9ACgAPgAeAD8AOABAADgAQwAYAEUAaABGADgASv/2AGYAMAADAAv/8ABC/9AARf/oAAMAC//wAEL/0ABF/+gAAQBTACgAAQBC/+gAAQBF/9gAAQBF/+gABQAV//YAQ//gAEX/4ABh/+wAY//lAAIAQ//gAEX/4AAEAEP/4ABTAE8AXv/zAGH/8wAEABX/7AAX//AAQ//gAE8ADwACABb/8ABD/+AAAQBD/+AABAAV/+wAF//oABj/8ABD/+AAAgAV/+wAF//oAAUAFv/oAEz/5QBY/+wAWf/zAFr/5QACAEX/8ABTABoABQAQ//AARf/gAE3/5QBY/+UAWf/lAAIAT//oAGYAJAADAHsAPAB8ADIAfQBJAAIAfAA+AH0ANQAIAHoAPQB7AC0AfAB8AH0AcgDDABIAxAASAMUAEgDGABIABAB6ACoAewA6AHwAZwB9AFwABAB8AA4AxAA8AMUATwDGAEsABQB8AA0AwwAxAMQAfQDFAGkAxgArAAUAfAANAMMAJgDEAHIAxQBeAMYASQADAHwADQDEAD8AxQArAAIADAALAAsAAAAQABEAAQAVACAAAwAiACIADwAqAEUAEABKAEwALABOAFEALwBTAFQAMwBWAFwANQBeAGQAPAB6AH0AQwDDAMYARwAA') format('truetype');
   font-weight: normal;
   font-style: normal; }
-
 /*@font-face {
     font-family: 'Flux-BoldItalic';
     src: url('../fonts/FluxBoldItalic.eot');
@@ -3581,7 +3594,6 @@ span.highlighted {
   src: url("../fonts/FluxBold.eot?#iefix") format("embedded-opentype"), url("../fonts/FluxBold.woff") format("woff"), url('data:font/truetype;base64,AAEAAAAQAQAABAAAR1BPUwXlBEYAANnkAAALEkxUU0jgPqE2AADY6AAAAPtPUy8yb6Vi+gAAAWQAAABgVkRNWGnecWUAANEEAAAF4GNtYXB1vQdaAAABxAAABbJjdnQgAPwGlwAA1uQAAAAaZnBnbQZZnDcAANcAAAABc2dseWaAIurwAAAShAAAvoBoZWFk8zfz/QAAASwAAAA2aGhlYQb6A+YAAAd4AAAAJGhtdHjJDyAyAAAHnAAAA9xsb2NhY8KS6gAAEJQAAAHwbWF4cAMJAk8AAAEMAAAAIG5hbWVFWS8NAAALeAAAAttwb3N0LXuX3gAADlQAAAI/cHJlcEaEPUoAANh0AAAAcgABAAAA9wBvAAcAAAAAAAEAAAAAAAoAAAIAAd8AAAAAAAEAAAABGZlAw7uRXw889QAbA+gAAAAAxA+SMAAAAADMZwTe/4j/AwQKA20AAAAJAAIAAAAAAAAAAwGHAZAABQAEArwCigAAAIwCvAKKAAAB3QAyAPoAAAIACAYFAAACAASAAACvQAAgSgAAAAAAAAAAdDI2IABAACD7AgLj/vsAggNXARMgAAADAAAAAAH0ArwAAAAgAAIAAAADAAAAAwAAABwAAQAAAAACZAADAAEAAANqAAQCSAAAAFQAQAAFABQAIAB+AKMArAD/ATEBQgFTAWEBeAF+AZICxwLdA5QDqQO8A8AgFCAaIB4gIiAmIDAgOiBEIKwhIiEmIgIiBiIPIhIiGiIeIisiSCJgImUlyvsC//8AAAAgACEAoAClAK4BMQFBAVIBYAF4AX0BkgLGAtgDlAOpA7wDwCATIBggHCAgICYgMCA5IEQgrCEiISYiAiIGIg8iESIaIh4iKyJIImAiZCXK+wH//wAA/+kAAAAAAAD/nf+c/1b/lP87/of/DgAAAAD9U/1B/N39LOCXAAAAAAAA4H7gjeB84HDgLd9w38Te7d7h3t4AAN7O3tXewN5Z3jUAANrnBbYAAQBUAAAAUgBYAGYAAAAAAAAAAAAAAAAAAAD6APwAAAAAAAAAAAAAAPwBAAEEAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAAAAAAAAAAAA7AAAAAAAAAADANoAnwCKAIsAmAAGAIwAlACRAJoAogDpAJAA0QCJAPIA5gDlAJMAmQCOALoA1QDjAJsAowDiAOEA5ACeAKUAwAC+AKYAaABpAJYAagDCAGsAvwDBAMYAwwDEAMUA2wBsAMoAxwDIAKcAbQAIAJcAzQDLAMwAbgD2AN8AjwBwAG8AcQBzAHIAdACcAHUAdwB2AHgAeQB7AHoAfAB9ANwAfgCAAH8AgQCDAIIAsACdAIUAhACGAIcACQDgALIAzwDYANIA0wDUANcA0ADWAK4ArwC7AKwArQC8AIgAuQCNAO4ABwDxAPAAAAEGAAABAAAAAAAAAAECAAAAAgAAAAAAAAAAAAAAAAAAAAEAAAMKCwwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnAGhpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYaHiImKi4yNjo+QkZKTlJWWl/Py8fCYme/u7ezrmpvqnJ2en+nooKHnoqOkA6Wmp6ipqqusra6vsLGys7TZtba3uLm6u7y9vr/AwcLDxMXGx8gAysvMzc7P0NHS09TV1tfYAAQCSAAAAFQAQAAFABQAIAB+AKMArAD/ATEBQgFTAWEBeAF+AZICxwLdA5QDqQO8A8AgFCAaIB4gIiAmIDAgOiBEIKwhIiEmIgIiBiIPIhIiGiIeIisiSCJgImUlyvsC//8AAAAgACEAoAClAK4BMQFBAVIBYAF4AX0BkgLGAtgDlAOpA7wDwCATIBggHCAgICYgMCA5IEQgrCEiISYiAiIGIg8iESIaIh4iKyJIImAiZCXK+wH//wAA/+kAAAAAAAD/nf+c/1b/lP87/of/DgAAAAD9U/1B/N39LOCXAAAAAAAA4H7gjeB84HDgLd9w38Te7d7h3t4AAN7O3tXewN5Z3jUAANrnBbYAAQBUAAAAUgBYAGYAAAAAAAAAAAAAAAAAAAD6APwAAAAAAAAAAAAAAPwBAAEEAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAAAAAAAAAAAA7AAAAAAAAAADANoAnwCKAIsAmAAGAIwAlACRAJoAogDpAJAA0QCJAPIA5gDlAJMAmQCOALoA1QDjAJsAowDiAOEA5ACeAKUAwAC+AKYAaABpAJYAagDCAGsAvwDBAMYAwwDEAMUA2wBsAMoAxwDIAKcAbQAIAJcAzQDLAMwAbgD2AN8AjwBwAG8AcQBzAHIAdACcAHUAdwB2AHgAeQB7AHoAfAB9ANwAfgCAAH8AgQCDAIIAsACdAIUAhACGAIcACQDgALIAzwDYANIA0wDUANcA0ADWAK4ArwC7AKwArQC8AIgAuQCNAO4ABwDxAPAAAAABAAAC4/77AIIEMv+I/8EECgABAAAAAAAAAAAAAAAAAAAA9wEoAAAAAAAAASgAAAEoAAACIQAUAbQAEAEFAF0CDgAiAf4AUAHlADgBBgBGAXQARgJiADIB8wAeAtwAHgJlAC0A9wBQAUsAPAFLAAoBhQAeAdsAMgDxADwBRQA8APIAPAFjAAAB2gAoARwAHgHEACgBtgAoAeAAFAG9ADIB7gAmAagADwHQAB4B5gAcAQYARgEHAEYBbAAoAqIAMgFsADIB1QAoAxMAMgIuAAoCDQA8AikAHAIqADwB2AA8AcMAPAIxABwCRQA8AOoARgFnAAoCDgA8AZYAPALVADwCYgA8AmkAHgHhADwCaQAeAe0APAHzAB4B6AAKAkMANwIUAAoDEQAKAmYAKAHoAAoCVgAoAR4APAFiAAABHwAfAngAPAIrABQBZQAtAaoAHgHjADwBoAAeAd0AHgGqAB0BLAAeAeoAKAHWADwA8gA8AOj/iAG+ADwA9wA8AqIAMgHJADIB2wAeAeQAPAHvACMBXgA8AZIAKAEhAB4B1QAyAcYADwJ/AA8B1AAeAeIAMgHAAB4BdQAeAPgAUAF2AB4BtQAyAi4ACgIuAAoCPQAmAdgAPAJiADwCaQAeAk0APAG+ACgBvgAoAcoAKAG+ACgBvgAoAb4AKAGgAB4BtQAeAbUAHgG2AB4BtQAeAPMAEgD3//QA9//LAO7/2QHTADIB2wAeAdsAHgHbAB4B2wAeAdsAHgHaADIB2gAyAdoAMgHaADICKwAtAS8AMgGqAB4CRgAoAd8AMgGuADwB/QAeAjkAFANGADIDRgAyAkkAHgFzADwBsQA8ArYAPAM5AAoCaQAeAnMAHgHaADIBtAAoAbQAKALQACgB2wAeAdUAKAEGAEYBwgAKAi0AFAIGADICBgAyAq4AOwIuAAoCLgAKAmkAHgMpABwC/QAeApkAPANNADwBgwA7AYIAPADsADsA7AA8AvEAFAMnABQB9gA8AfwAFAHl/+wBWAAyAVgAMgHxABQCJgAUAiEAKADsADwA7AA8Aa8APAQyACgCLgAKAdgAPAIuAAoB2AA8AdgAPAD5ACUA+f/LAO3/5AD5//ECaQAeAmkAHgNxACgCaQAeAk0APAJNADwCTQA8AN8ASQGeABoBsQAzAagAMQGeABoBAQBCAT8AOgFfAE0BeAAMAV8AUQMKAAACfQAoASgAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAAB9AAAAfQAAAH0AAABzgAIAXgABQGo/+0AAAAPALoAAQABAAAAAQAAAAAAAQABAAAABAAJAhgAAwABBAkAAAByAKoAAwABBAkAAQAAAAAAAwABBAkAAgACAfIAAwABBAkAAwBKATgAAwABBAkABAAUAfIAAwABBAkABQBmARwAAwABBAkABgASAgYAAwABBAkABwBUAYIAAwABBAkACAAaAJAAAwABBAkACQAaAJAAAwABBAkACgCqAAAAAwABBAkACwAcAdYAAwABBAkADgAAAAAAMQA5ADkANgAgAFsAVAAtADIANgBdACAAQwBoAGkAYwBhAGcAbwAgAHcAdwB3AC4AdAAyADYALgBjAG8AbQAgADcANwAzAC4AOAA2ADIALgAxADIAMAAxACAAVAAwADIAMQA2ACAASQBEACMANQAwADYAOAA4ADgANgAgAGQAZQBzAGkAZwBuAGUAcgA6ACAATQBvAG4AaQBiACAATQBhAGgAZABhAHYAaQBDAG8AcAB5AHIAaQBnAGgAdAAgACgAYwApACAAMQA5ADkANgAgAGIAeQAgAE0AbwBuAGkAYgAgAE0AYQBoAGQAYQB2AGkALgAgAEEAbABsACAAcgBpAGcAaAB0AHMAIAByAGUAcwBlAHIAdgBlAGQALgBWAGUAcgBzAGkAbwBuACAAMQAuADEAMAAwADsAYwBvAG0ALgBtAHkAZgBvAG4AdABzAC4AdAAyADYALgBmAGwAdQB4AC4AYgBvAGwAZAAuAHcAZgBrAGkAdAAyAC4AZABwAFMAcABGAGwAdQB4ACAAQgBvAGwAZAAgAGkAcwAgAGEAIAB0AHIAYQBkAGUAbQBhAHIAawAgAG8AZgAgAE0AbwBuAGkAYgAgAE0AYQBoAGQAYQB2AGkALgBoAHQAdABwADoALwAvAHQAMgA2AC4AYwBvAG0mHgBGAGwAdQB4ACAAQgBvAGwAZABGAGwAdQB4AC0AQgBvAGwAZEZsdXggQm9sZAAAAgAAAAAAAP9uABgAAAAAAAAAAAAAAAAAAAAAAAAAAAD3AAABAgACAAMA5gDnAOgA7wDwAOwABAAFAAYABwAIAAkACgALAAwADQAOAA8AEAARABIAEwAUABUAFgAXABgAGQAaABsAHAAdAB4AHwAgACEAIgAjACQAJQAmACcAKAApACoAKwAsAC0ALgAvADAAMQAyADMANAA1ADYANwA4ADkAOgA7ADwAPQA+AD8AQABBAEIAQwBEAEUARgBHAEgASQBKAEsATABNAE4ATwBQAFEAUgBTAFQAVQBWAFcAWABZAFoAWwBcAF0AXgBfAGAAYQBiAGMAZABlAGYAZwBoAGkAagBrAGwAbQBuAG8AcABxAHIAcwB0AHUAdgB3AHgAeQB6AHsAfAB9AH4AfwCAAIEAggCDAIQAhQCGAIcAiACJAIoAiwCMAI0AjgCPAJAAkQCWAJcAnQCeAKAAoQCiAKMApgCnAKkAqgCrAK0ArgCvALAAsQCyALMAtAC1ALYAtwC4ALkAugC7ALwAvgC/AMAAwQDCAQMAxADFAMYAxwDIAMkAygDLAMwAzQDOAM8A0ADRANIA0wDUANUA1gDXANgA2QEEANsA3ADdAN4A3wDgAOEBBQEGAOkA6gDiAOMA7QDuAPQA9QDxAPYA8wDyAQcApQCkAJ8AnACbAJoAmQCYAJUAlACTAJIA5ADlAOsFLm51bGwOcGVyaW9kY2VudGVyZWQGbWFjcm9uBEV1cm8HdW5pMDBBMAVEZWx0YQAAAAAAAAAAAAAAAJgAzgD6ARQBOAHYAkoCZgLMA54EwgV8BZAF5gZCBqIG2AcWBy4HigeeCEgIagi8CSIJdgnwCpwKtgvCDFAMyg0oDUANYA14DhgPJg9aEAYQchEIEUgRghIiEm4SjBLGEwYTKhOME9gUiBTwFZYWEBbQFvoXZBeMF9QYFhhQGHgYohi4GOYZCBkcGTQZ4BqGGwAbqBwiHG4dNh2YHeweSh6GHqQfFh9kIBQgvCFeIZ4iXCKkIwwjNCN8I8AkYCSGJOIk+iVWJZImRCb8J7QoACiEKYYqRCsCK8Asei1iLkQvRi+6MEQwzjFWMigyVDKAMq4zNjPANHw1ODX2Nuw3zDhEOLw5NDnqOiQ6nDsMO3Y8bDySPOA9ej5EPzA/lD+sQBxAZEDCQahCKEJ6QzRD7kTqRapGLkaCRrpHUkeER7ZIaEikSQpJ7kqES6JLtkvKTC5Mfky2TOJNok5YTzZPxk/cT/hQFFC0UShRhFG8UfJSVFPiVCBUblSqVUJVjlW6VehWZlaSV0xYCFi+WXhZ7lpqWuBa/lsWW1JbZlt+W5xcElxSXHBcpFykXUpdSl1KXUpdSl1KXUpdSl1KXUpdSl1KXUpdSl1KXUpdSl1KXUpdSl1KXUpdSl1KXUpdSl1KXk5fAF9AAAMAFP/+AhoDIwAMABkAIQC+uAAiL7gAAy9BBQBKAAMAWgADAAJdQQkACQADABkAAwApAAMAOQADAARduQAJAAT0uAAiELgAENC4ABAvuQAWAAT0QQkABgAWABYAFgAmABYANgAWAARdQQUARQAWAFUAFgACXboAGwADAAkREjm6AB8AEAAWERI5uAAJELgAI9wAuAAGL7gAEy+4AABFWLgAGi8buQAaAAU+WbsAHgABABsABCu4ABMQuQAZAAH0uAAA0LgAGhC5AB8AAfQwMQEiJjc0NjMyFhcUBiMHIiYnJjYzMhYVFAYjAwEhNyEBIRUBehojASEaGiMBIxrBGSQBASQaGiQjGqUBWP69JAG3/qgBbgKmJBoaJSUaGSQCJBoaJSUZGiT9WAI/R/3CSAACABAAAAGOArMABQANADAAuAACL7gABC+4AABFWLgABi8buQAGAAU+WbsACgABAAcABCu4AAYQuQALAAH0MDETJzcXNxcBEyM3IQMzFdSwJ4mMLv6C39YjAUTf6QH6gDlPTzn9hgGAR/6ARwACAF3/1wCoAwkAAwAHAC27AAcAAwAEAAQruAAEELgAANC4AAAvuAAHELgAAtC4AAIvALgAAi+4AAcvMDETETcRAxEzEV9JS0oBnwFGJP6W/lwBSP6UAAAAAQAiAU0B5gGPAAMAGgC4AABFWLgAAS8buQABAAc+WbkAAAAC9DAxEzUhFyIBnyUBTUJCAAEAUABHAbABvAALABMAuAAGL7gACC+4AAAvuAACLzAxJScHJzcnNxc3FwcXAXBxcT50dD5xcUB2dUd6ejqAfzx7ezuAfwAAAAIAOP8dAbYCqAADACsAtrgALC+4AB4vuAAM0LgADC+4AB4QuQAhAAP0ugANAB4AIRESObgALBC4ABXQuAAVL7kAGAAD9LgAIRC4AC3cALgAAi+4ACsvuAAARVi4ABAvG7kAEAAFPlm5ABsAAfRBGQAHABsAFwAbACcAGwA3ABsARwAbAFcAGwBnABsAdwAbAIcAGwCXABsApwAbALcAGwAMXUEFAMYAGwDWABsAAl26AA0AEAAbERI5ugAXACsAAhESOTAxEyc3FwM+Azc2NjU3BgYjIi4CNRE3ERQWNzY2NxEzERQOAgcOAwejMdgmyRQxMCgLCgMBI0UoGjQsG143LBk0El4CBQoJDzQ/RB8B8zOCT/0GAwcOGBQTQRkCDg4SIzQhATYf/sItLQEBFQsBZ/5tEy4wLBAcJxkMAQAAAgBG//8AwALJAAMADwCquwAEAAQACgAEK0EJAAYABAAWAAQAJgAEADYABAAEXUEFAEUABABVAAQAAl26AAAACgAEERI5uAAAL7kAAwAD9AC4AAEvuAAARVi4AAcvG7kABwAFPlm6AAMABwABERI5uQANAAH0QRkABwANABcADQAnAA0ANwANAEcADQBXAA0AZwANAHcADQCHAA0AlwANAKcADQC3AA0ADF1BBQDGAA0A1gANAAJdMDE3ETMRFxQGIyImNTQ2MzIWW1QRIxoaIyMaGiPSAff96ncaIyMaGiMjAAAAAgBGAdkBLgLTAAMABwATALgAAC+4AAQvuAABL7gABS8wMRMnMxUHJzMV7yFgxyFgAdn64Br64AACADL/5wIwApAAGwAfAGcAuAAOL7gAEi+4AAAvuAAEL7sAHwABAAEABCu7AAwAAQAJAAQruAABELgABdC4AB8QuAAH0LgADBC4AA/QuAAMELgAE9C4AAkQuAAV0LgAHxC4ABfQuAABELgAGdC4AAkQuAAc0DAxBTcjBwc3IzUzNyM1Mzc3BzM3NwczFSMHMxUjBwMjBzMBLh5gHV0eXmsQXWsaXx5hFWQdXWoQXWsaJGAQXxnGnijGVnJXoSPEmirEV3JWpQFtcgAAAAADAB7/jAHVAvYAKwAyADsA67sALwADAA4ABCu7ACsAAwAAAAQruwAkAAQAOAAEK7gAABC4AAjQuAAAELgAE9C4ACsQuAAV0LgAKxC4AB3QuAAAELgALNC6AC0ADgAkERI5QQkABgAvABYALwAmAC8ANgAvAARdQQUARQAvAFUALwACXboAMgAOACQREjm4ACsQuAAz0EEFAEoAOABaADgAAl1BCQAJADgAGQA4ACkAOAA5ADgABF26ADsADgAkERI5uAAkELgAPdwAuAAAL7gAFS+6AC0AAAAVERI5ugAyAAAAFRESOboAMwAAABUREjm6ADsAAAAVERI5MDEXNSYmJzcWFhc1JiYnJjU0PgI3NTcVFhYXByYmJxUWFhcWFhUUBgcGBgcVAzUGBxQWFxM2NzY2NTQmJ9Q0YCIsGkomH0gYJxgrPSZTJj4gKhgqGCdFHRQRMCoUKRdTPAIbI1MOCxQWHyR0bQUwIUcYKAbXCx4aK0ElPzAgBkocZQYhGEMSFgW9DB8iGD0eL1MdDg8FVQKQARRAGCMP/rsGChAmGB0pEAAFAB7/9AK+Ar4AFAAYAC0APgBNAWO7AEIAAwAeAAQruwAoAAMASgAEK7sAMwADAAUABCu7AA8AAwA7AAQrQQUASgAFAFoABQACXUEJAAkABQAZAAUAKQAFADkABQAEXboAFQAeAA8REjm6ABcAHgAPERI5QQkABgAoABYAKAAmACgANgAoAARdQQUARQAoAFUAKAACXUEFAEoAOwBaADsAAl1BCQAJADsAGQA7ACkAOwA5ADsABF1BCQAGAEIAFgBCACYAQgA2AEIABF1BBQBFAEIAVQBCAAJduAAPELgAT9wAuAAWL7gAIy+4AABFWLgAFS8buQAVAAU+WbgAAEVYuAAALxu5AAAABT5ZuwAKAAEAPgAEK7sARwACABkABCu6ABcAAAAjERI5uAAAELkAOAAC9EEZAAcAOAAXADgAJwA4ADcAOABHADgAVwA4AGcAOAB3ADgAhwA4AJcAOACnADgAtwA4AAxdQQUAxgA4ANYAOAACXTAxBSIuAjU0PgIzMh4CFRQOAiMlATMBAyIuAjU0PgIzMh4CFRQOAiMFIg4CFRQeAjM2NjU0JicBBgYVFB4CMzY2NTQmJwIoJzgkERQmOCQkNyUUEiQ4J/5oAVVf/qs/JzckERQmOCQkNyUTEiQ4JwF0EhgOBgcQFxElGh0i/oglGQcQGBElGh4iDCAzQSEhPjAdHTA+ISFBMyAMArj9SAFeIDNBISE+MBwdMD0hIUEzIE4RHCUVFyofEgFCLyk7AwFqAzspFyofEgFCLyg8AgAAAAIALf//AlECgwAqADcAy7gAOC+4ADcvuQABAAP0uAA4ELgAENC4ABAvuQAfAAP0QQkABgAfABYAHwAmAB8ANgAfAARdQQUARQAfAFUAHwACXboADQAQAB8REjm4ADcQuAAZ0LgAGS+4ADcQuAAl0LgAARC4ACfQuAAnL7gAARC4ADncALgAAEVYuAABLxu5AAEABT5ZuAAARVi4AAYvG7kABgAFPlm7ABUAAQAcAAQruwAkAAEALAAEK7gALBC4AADQuAAAL7oADQAsACQREjm4ACQQuAAo0DAxAQMiBiIiJy4DNjY3JiYnJj4CMzIWFwcmJgcGBhUUHgIzMzU3FTMVIyciDgIVFhYXFjY3AegBEjhARB84UzIQFDgwGhcBARwuOh4iRyUfHTcYICYKFB0TaF1pxmskMyEOATc1JEgYAVP+rQECAzBJWFRJFRQyISY4JRISFzgODgEBLh0PHhgQTSBtSQEYKDMaMkoFBAMBAAAAAAEAUAHaAKcC0wADAAsAuAABL7gAAC8wMRMnMxdjE1YBAdr54QAAAAABADz/VwFBAwMAIwA3uwAbAAMACQAEK0EJAAYAGwAWABsAJgAbADYAGwAEXUEFAEUAGwBVABsAAl0AuAAAL7gAES8wMQUmJicmJicmJjU0NzY2NzY2NxcGBgczDgMHFB4CFxYWFwEPHDoaIy4KBAQJCy0jGjkcMi49DgEPEQoEAQMLEg4PPS2pFzUhLGxJH0QmTDxJbCwhNBcuK0UjIj5BSCwsR0E/IiNFKgAAAQAK/1gBDwMEACQAP7sAGgADAAgABCtBBQBKAAgAWgAIAAJdQQkACQAIABkACAApAAgAOQAIAARduAAaELgAJtwAuAARL7gAJC8wMRc2Njc+Azc0LgInJiYnNxYWFxYWFxYWFRQGBzUGBgcGBgcKLjwODhELBAEDCxIODz0tMhw5GiMvCgUDBAUKLiMaORx6K0UjIj5BSCwrSEE/IiNFKy4XNSEsbEgfRCYmRR8BSWwsITQXAAAAAAEAHgGCAWcC0QARAHy7AAEAAwACAAQruAACELgACdC4AAkvuAABELgAC9C6AAwAAgABERI5ALgACi+4AABFWLgAAS8buQABAAc+WboAAAABAAoREjm6AAMAAQAKERI5ugAGAAEAChESOboACQABAAoREjm6AAwAAQAKERI5ugAPAAEAChESOTAxExcjNwcnNyc3FyczBzcXBxcH5gJPAlUoWFglWQNPAlgpW1knAelnZzVFMSxIMmVlNUQzMEYAAAEAMgAlAakB3gALAD+7AAEAAwACAAQruAACELgABtC4AAEQuAAI0AC4AAgvuAACL7sACQABAAAABCu4AAAQuAAD0LgACRC4AAXQMDElFQc1IzUzNTcVMxUBGFmNjVmR1Y0jsFmNI7BZAAAAAAEAPP+ZALcAdQASADe7AAwABAAGAAQrQQkABgAMABYADAAmAAwANgAMAARdQQUARQAMAFUADAACXQC4AAkvuAASLzAxFzY2NyYmNTQ2MzIWFxYGBwYGBz0RGAcVHCEaGCMCAxkaCRISQgwdFAQhFholIBgpPxoKDQsAAAABADwA5QEJAUAABAAVALsAAQABAAAABCu4AAEQuAAD0DAxNzUzMxU8J6blW1sAAAABADz/+QC2AHQACwCIuwAAAAQABgAEK0EJAAYAAAAWAAAAJgAAADYAAAAEXUEFAEUAAABVAAAAAl0AuAAARVi4AAMvG7kAAwAFPlm5AAkAAfRBGQAHAAkAFwAJACcACQA3AAkARwAJAFcACQBnAAkAdwAJAIcACQCXAAkApwAJALcACQAMXUEFAMYACQDWAAkAAl0wMTcUBiciJjU0NhcyFrYjGhojIxoaIzYaIwEjGhojASMAAAAAAQAA/2MBYwMSAAMACwC4AAEvuAADLzAxFQEXAQEQU/7vgAOSHfxuAAIAKP/4AbIB0AATACcA3rgAKC+4ACMvuAAoELgABdC4AAUvQQUASgAjAFoAIwACXUEJAAkAIwAZACMAKQAjADkAIwAEXbgAIxC5AA8AA/S4AAUQuQAZAAP0QQkABgAZABYAGQAmABkANgAZAARdQQUARQAZAFUAGQACXbgADxC4ACncALgAAEVYuAAALxu5AAAABT5ZuwAKAAEAFAAEK7gAABC5AB4AAfRBGQAHAB4AFwAeACcAHgA3AB4ARwAeAFcAHgBnAB4AdwAeAIcAHgCXAB4ApwAeALcAHgAMXUEFAMYAHgDWAB4AAl0wMRciLgI1ND4CFzIeAhUUDgIDDgMVFB4CMzI+AjU0LgLsM0owFxszSS8vSTIaGDFKMx8nFwgKGCcdHygXCAsYJwgqRFcuLVM/JgEmP1MtLVhEKQGRAh0rNx0gPzEeHzE+IB03LBwAAAABAB4AAADRAdUABQAiuwAFAAMAAAAEKwC4AAQvuAAARVi4AAAvG7kAAAAFPlkwMTMRByc3EXZAGLMBZw09Pv4rAAAAAAEAKAAAAZwB0AAoACgAuAAARVi4AAAvG7kAAAAFPlm7ABkAAQASAAQruAAAELkAJgAB9DAxMyYmJz4DNz4DJy4DIyIGByc2NhcyHgIXFg4CBwYGBzMVTQgUCR8qJCMZGiYXBwQEFBkbDBQ8GCAiTyEcOjEjBgQEFScgHEEc5BEnGBUcGBoSEyAfIRQUGA4FFAs3FhcBDBstIRgrKisYFioRWQAAAQAo/x0BmgHRAC8AO7sAKgADAAUABCtBBQBKAAUAWgAFAAJdQQkACQAFABkABQApAAUAOQAFAARduAAqELgAMdwAuAAvLzAxFz4DNTQmJyYmIiIjNTY2NzYnJiYnJgYHJz4CFhceAxUGBgcWFgcOAwdXNFI6ID41ChYeKh0dMgxoCQUtHRc0HRodQkI9GBEWDAQCIxc+QwICQFtlJ6YPHyw8LDNIBQEBRAICBB5EIB0CAhEONRMWBQ4RDB0dHAopMxEXZj5IXTgcCAAAAgAU/xkBzAHUAAkADABxuwAJAAMAAAAEK7gACRC4AATQuAAAELgACtC4AAkQuAAO3AC4AAQvuAAAL7gAAEVYuAABLxu5AAEABT5ZuAAARVi4AAcvG7kABwAFPlm6AAIAAAAEERI5uQAFAAH0ugAKAAAABBESObgAC9C4AAzQMDEFNSEBNxEzFSMVAwczASD+9AEOW09PXYyM5+UBuB7+ckjGAfLkAAAAAQAy/xwBoAHHACAAj7gAIS+4AAUvQQUASgAFAFoABQACXUEJAAkABQAZAAUAKQAFADkABQAEXbgAIRC4AA3QuAANL7gABRC5ABoAA/S6AA8ABQAaERI5uAANELkAEgAD9LgAGhC4ACLcALgAIC+7AA8AAQAQAAQruwAVAAEADQAEK7gADRC4AArQuAAKL7gAFRC4ABLQuAASLzAxFz4DNTQuAicmBiMRIQcjFTIWMx4DBwYGBwYGB2A0UjofEB0pGhRNPAE5JLkWGhUyTTQaAQI9LSpdM6UOICs9LBkwJRgCAgEBIUeNAQEmPEwnSFocGhwMAAIAJv/3AdICrAAkADUAsLsAJQADAAYABCtBCQAGACUAFgAlACYAJQA2ACUABF1BBQBFACUAVQAlAAJduAAlELgAF9C4ABcvALgADi+4AABFWLgAAC8buQAAAAU+WbsAGgABADEABCu6ABcAMQAaERI5uAAAELkAKgAC9EEZAAcAKgAXACoAJwAqADcAKgBHACoAVwAqAGcAKgB3ACoAhwAqAJcAKgCnACoAtwAqAAxdQQUAxgAqANYAKgACXTAxFyImJyYmNz4DNzY2NxcOAwcGBgc2NhceAwcOAyMDBh4CFxY+AiYmJyYOAvJCXxYKCwMDESZBMh0/KRgqSjsnBwMFAhtHJDJKLxUCAhk1UjtsBQ4fLBooNh0DFzEmFCkiGglGQh1rPzJgVkYXDg4FPwgVJjkrEB8PERYBAic/UCsrTToiATs/XT0eAQIqQUxDLgIBDBARAAAAAQAP/xoBmQHHAAUAEQC4AAUvuwAEAAEAAQAEKzAxFxMhNyEBPub+6y0BXf7pzAI0X/1TAAMAHv/3AbICkQAhADYASgFGuwBGAAMADQAEK7sAHQADADEABCtBBQBKADEAWgAxAAJdQQkACQAxABkAMQApADEAOQAxAARdugAAADEAHRESOboAPAAxAB0REjm4ADwvQQUASgA8AFoAPAACXUEJAAkAPAAZADwAKQA8ADkAPAAEXbkAAwAD9EEJAAYARgAWAEYAJgBGADYARgAEXUEFAEUARgBVAEYAAl26ABMADQBGERI5uAATL7kAJwAD9LoAEAATACcREjm4AAMQuABM3AC4AABFWLgACC8buQAIAAU+WbsAGAACACIABCu7ACwAAQBBAAQrugAAAEEALBESOboAEABBACwREjm4AAgQuQA3AAL0QRkABwA3ABcANwAnADcANwA3AEcANwBXADcAZwA3AHcANwCHADcAlwA3AKcANwC3ADcADF1BBQDGADcA1gA3AAJdMDEBFhYVFA4CIyIuAjU0NjcmJjU0PgIzMh4CFRQOAiciDgIVFB4CMzI+AjU0LgIjAzI+Ajc0LgIjIg4CFR4DAUU5NBYxTTc3TTAVNTkmIxotPSIiPC0aCBIccBIdFgwMFR4TEx4VDAwWHhIDHygZCgEMGigbGygbDAEJGCcBdhtiNiRJOyQkO0kkN2IbFkkgIjooFxcoOiIQJCMe1RAaIRESIx0SEh0kEhEhGhD93xkpMhoWMigbGykxFhoyKRkAAAAAAgAc/xgBygHOACQANQBvuwAiAAMAJQAEK0EFAEoAJQBaACUAAl1BCQAJACUAGQAlACkAJQA5ACUABF26AAAAJQAiERI5uAAlELgAD9C4AA8vuAAiELgAN9wAuAAGL7sAHAACACoABCu7ADEAAQASAAQrugAPABIAMRESOTAxBQYGBwYGByc+Azc2NjcGBicuAzc+Azc2FhcWFgcGByc2LgInJg4CFhYXFj4CAa0VUS8dPygZKko7JwgDBQEbRyQtSDIZAgIZNVI8Ql8WCg0DAxdHBA0fLBooNh0DFzEmFCkiGhlFUxYODgU/BxYmOSsQHw8RFQEBJj9RKytNOSIBAUZCHWs/U0auP109HgEBKUFNQy4CAQwQEQAAAAACAEb/+QDAAZYACwAXAKa7AAAABAAGAAQrQQkABgAAABYAAAAmAAAANgAAAARdQQUARQAAAFUAAAACXbgAABC4AAzQuAAGELgAEtAAuAAARVi4AA8vG7kADwAFPlm7AAkAAQADAAQruAAPELkAFQAB9EEZAAcAFQAXABUAJwAVADcAFQBHABUAVwAVAGcAFQB3ABUAhwAVAJcAFQCnABUAtwAVAAxdQQUAxgAVANYAFQACXTAxExQGIyImNTQ2MzIWERQGIyImNTQ2MzIWwCMaGiMjGhojIxoaIyMaGiMBWRojIxoaIyP+wxojIxoaIyMAAAAAAgBG/5kAwQGeAAsAHgBVuwAYAAQAEgAEK0EJAAYAGAAWABgAJgAYADYAGAAEXUEFAEUAGABVABgAAl24ABgQuAAA0LgAAC+4ABIQuAAG0LgABi8AuAAeL7sACQABAAMABCswMRMUBiciJjU0NhcyFgM2NjcmJjU0NjMyFhcWBgcGBgfBIxoaIyMaGiN6ERgHFRwhGhgjAgMZGgkSEgFgGiMBIxoaIwEj/kQMHRQEIRYaJSAYKT8aCg0LAAABACgAKgE6AjwABQALALgAAC+4AAIvMDE3AxMXBxfxyclJpaUqAQkBCS7b2gAAAAACADIAugJwAawAAwAHABcAuwAFAAEABAAEK7sAAQABAAAABCswMRMnIRUFNSEXVyUCIP3+AfslAWNJSalJSQAAAQAyACoBRAI8AAUACwC4AAMvuAAFLzAxNzcnNxMDMqamScnJWdrbLv73/vcAAAAAAgAo//gBtwLbACAALAC3uwAhAAQAJwAEK0EJAAYAIQAWACEAJgAhADYAIQAEXUEFAEUAIQBVACEAAl26AAAAJwAhERI5uAAAL7kAIAAD9AC4AABFWLgAAS8buQABAAc+WbgAAEVYuAAkLxu5ACQABT5ZugAAACQAARESObkAKgAB9EEZAAcAKgAXACoAJwAqADcAKgBHACoAVwAqAGcAKgB3ACoAhwAqAJcAKgCnACoAtwAqAAxdQQUAxgAqANYAKgACXTAxNzUzMj4CJiYnJgYHJzY2Fx4DFxQOAgczBgcGBxUXFAYnIiY1NDYzMhaTOSY3IAYVMigmSR8qLGQ7J0Y2IAEWJjEbAQYJDiMOIxoaIyMaGiOr2SQ3QTsrBgUcFzYgJwYEHjNILypALyEKAgIEBWyXGiMBIxoaIyQAAAACADL/+wLjAsQAWQBkAQC7ABMAAwAmAAQruwBeAAMAQQAEK7sAAAADAGQABCu4AAAQuQAGAAT0QQkABgATABYAEwAmABMANgATAARdQQUARQATAFUAEwACXbgAZBC4AEfQuABHL0EJAAYAXgAWAF4AJgBeADYAXgAEXUEFAEUAXgBVAF4AAl0AuAAARVi4ACEvG7kAIQAFPlm7ACsAAQAOAAQruwBhAAIAPAAEK7sAVAACAEsABCu7AEcAAgBaAAQruAAhELkAGAAB9EEZAAcAGAAXABgAJwAYADcAGABHABgAVwAYAGcAGAB3ABgAhwAYAJcAGACnABgAtwAYAAxdQQUAxgAYANYAGAACXTAxARYWNzY2NzYuAicmJiMiDgIVFB4CMzI2NxYWFwYGIyIuAjU0PgIzMhYXHgIGBwYGBwYmJwYGJy4DNTQ+AjMzNTQmIyIGByc+AzMyHgIVByMiBgcUFhcyNjcCFQcbDCQmAwEPGiMTIU4rOmVMLCxMZjpCeC0PGg43k1VKgmI4OGGCSjloLCk7GwYXFDQmFyYTG08zGi4jExYkMBtSJRkYKiAZFCIgIRIYLiQXUz8dIwElHRQiCAErBwwCBDI8HTgyKAwXGStMZjo6ZkwsPTgNEw5FTzhhgUpKgmE4Ih4dVF9hKiQmCAIFChchAQEUIi4bHC4fERQXHw0QOQsOCQQPHSwcWB4aGSgBDwcAAAACAAoAAAIkApQABwAKADMAuAAGL7gAAEVYuAAALxu5AAAABT5ZuAAARVi4AAMvG7kAAwAFPlm7AAoAAQABAAQrMDEhJyMHIxM3EwEHMwHBQuFHTehV3f7xXbHCwgJ5G/1sAgL8AAAAAAMAPP/1AfAChQAYACUANAC4uwAmAAMABQAEK7sADAADAB4ABCtBBQBKAB4AWgAeAAJdQQkACQAeABkAHgApAB4AOQAeAARdugAOAB4ADBESOboALwAeAAwREjm4AC8vQQUASgAvAFoALwACXUEJAAkALwAZAC8AKQAvADkALwAEXbkAEwAD9LgAJhC4ACTQuAATELgANtwAuAAARVi4AAAvG7kAAAAFPlm7AAcAAQAjAAQruwAZAAEANAAEK7oADgA0ABkREjkwMQUGJicmJxEzMh4CBwYHHgMVFg4CBwMyPgI1NC4CIyMVFRceAzc2NjU0LgIjASgzViAlHs0eOy4cAQEyGSsgEwEgN0knHhAYEAgMFRwQZwEJGyIlEjU9DyAzJAYFGRIUHQI0EyY5JkEnDCAtOyYqSTcjBAGdEBkgEA8cFg2mRekHEQ0HAwhMMRcyKRsAAAAAAQAc//sCCwKSACIAagC4AABFWLgAAy8buQADAAU+WbsADgABABUABCu4AAMQuQAcAAH0QRkABwAcABcAHAAnABwANwAcAEcAHABXABwAZwAcAHcAHACHABwAlwAcAKcAHAC3ABwADF1BBQDGABwA1gAcAAJdMDElBgYjIyIuAjc+AxcWFhcHJiYjIgYGHgIzMjY3NjY3Ags9cD8BQGFBIAIBIkBiQjdhLSUoRiY4SCMCJUYzJjcgCxsVUzAoQWR3Njh0XzoBAhogPBoSTHGDcUsSEgYPDAAAAgA8//kCDAKGABEAIADGuAAhL7gAGy+4ACEQuAAF0LgABS9BBQBKABsAWgAbAAJdQQkACQAbABkAGwApABsAOQAbAARduAAbELkADAAD9LoAAAAFAAwREjm4AAUQuQATAAP0uAAMELgAItwAuAAARVi4AAAvG7kAAAAFPlm7AAYAAQASAAQruAAAELkAFgAB9EEZAAcAFgAXABYAJwAWADcAFgBHABYAVwAWAGcAFgB3ABYAhwAWAJcAFgCnABYAtwAWAAxdQQUAxgAWANYAFgACXTAxBSIuAicRMzIeAhUUDgIjAxEWFjMyPgI1NC4CIwEMHzw1LhLSQ2E9HSRCXzxwETYbKj8qFREsTT0GDxcdDgI7PWB3OjtyWjgCRf4pDhcrRFYqM2BMLgAAAQA8AAABsAKFAAsAVbsACQADAAAABCu4AAkQuAAE0AC4AABFWLgABS8buQAFAAc+WbgAAEVYuAAALxu5AAAABT5ZuwACAAEAAwAEK7gABRC5AAcAAfS4AAAQuQAJAAH0MDEzESEHIxUzByMVIRU8AXQk89QksAEKAoVHwEfwRwABADwAAAGvAoUACQBLuwAJAAMAAAAEK7gACRC4AATQALgAAEVYuAAFLxu5AAUABz5ZuAAARVi4AAAvG7kAAAAFPlm7AAIAAQADAAQruAAFELkABwAB9DAxMxEhByMVMwcjETwBcyTz1SWwAoVIv0j+ygAAAAEAHP/7Af8CkgAqAL64ACsvuAAAL7kAAwAD9LgAKxC4AA/QuAAPL7kAIgAE9EEJAAYAIgAWACIAJgAiADYAIgAEXUEFAEUAIgBVACIAAl24AAMQuAAs3AC4AABFWLgACS8buQAJAAU+WbsAFAABAB0ABCu7AAMAAQAAAAQruAAJELkAJwAB9EEZAAcAJwAXACcAJwAnADcAJwBHACcAVwAnAGcAJwB3ACcAhwAnAJcAJwCnACcAtwAnAAxdQQUAxgAnANYAJwACXTAxASM3MxMOAyMjIi4CNz4DFzIeAhcHJiYjIg4CBwYeAjMyNjcBoYIivQEdNjY4HwFAYUEgAgEiQGJCGzEuMBslKEYlLT4mEgEBEig9KyM1GgEhRf7rFyAVCkFkdjY4dV47AQYOFhI9GhMvSlgqJlpOMxIQAAAAAQA8AAACCQKVAAsAZ7gADC+4AAAvuAAMELgABNC4AAQvuQADAAP0uAAG0LgAABC4AAjQuAAAELkACwAD9LgADdwAuAAGL7gAAEVYuAAALxu5AAAABT5ZuAAARVi4AAMvG7kAAwAFPlm7AAgAAQABAAQrMDEhESERIxE3ESERMxEBq/7vXl4BEV4BKP7YAnUg/tsBFf17AAABAEYAAACkApUAAwAiuwADAAMAAAAEKwC4AAIvuAAARVi4AAAvG7kAAAAFPlkwMTMRNxFGXgJ0If1rAAABAAr/9wErApYAFAAquwAPAAMADAAEK7gADxC4ABbcALgADi+4AABFWLgAAC8buQAAAAU+WTAxFyImJzcWFhcWPgI1ETcRFA4CI2UZKhgWDxYIKzQaCF0cNEotCQ4LQQUHAgYXLDodAZ8g/kI6VDcbAAAAAAEAPAAAAfoClgALAEm7AAMAAwAEAAQruAADELgABtAAuAAGL7gACC+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAADLxu5AAMABT5ZugAHAAAABhESOTAxIQMHESMRNxETFwcTAYnOIl1d+zjP/QE3JP7tAnYg/ukBFi/n/oEAAAAAAQA8AAABggKVAAUAKLsAAwADAAAABCsAuAACL7gAAEVYuAAALxu5AAAABT5ZuQADAAH0MDEzETcRMxc8XMYkAnUg/bRJAAAAAQA8//QCmQKUAAwAirgADS+4AAAvuAANELgABtC4AAYvuQAFAAP0uAAAELkADAAD9LoACQAGAAwREjm4AA7cALgACC+4AABFWLgAAy8buQADAAU+WbgAAEVYuAAALxu5AAAABT5ZuAAARVi4AAUvG7kABQAFPlm6AAEAAwAIERI5ugAEAAMACBESOboACQADAAgREjkwMSERAwcDESMRNxMTMxECO7FMukhY2sVmAdX+OhsB0P48AnYe/foB9/17AAAAAAEAPAAAAiYCkwAJAGm4AAovuAAGL7gAChC4AAPQuAADL7kAAgAD9LgABdC4AAYQuQAJAAP0uAAL3AC4AAUvuAAARVi4AAAvG7kAAAAFPlm4AABFWLgAAi8buQACAAU+WboAAQAAAAUREjm6AAYAAAAFERI5MDEhAREjETcBETMRAc/+tUhIAVtHAeb+GgJ7GP4CAfD9ewAAAgAe//cCSwKTABMAKADouAApL7gAIy+4ACkQuAAF0LgABS9BBQBKACMAWgAjAAJdQQkACQAjABkAIwApACMAOQAjAARduAAjELkADwAD9LoAFAAFAA8REjm4AAUQuQAZAAP0QQkABgAZABYAGQAmABkANgAZAARdQQUARQAZAFUAGQACXbgADxC4ACrcALgAAEVYuAAALxu5AAAABT5ZuwAKAAEAKAAEK7gAABC5AB4AAfRBGQAHAB4AFwAeACcAHgA3AB4ARwAeAFcAHgBnAB4AdwAeAIcAHgCXAB4ApwAeALcAHgAMXUEFAMYAHgDWAB4AAl0wMQUiLgI1ND4CMzIeAhUUDgIDIg4CFRQeAjMyPgI1NC4CIwE0RWhGIyVHZ0NDaEclI0doRCtCLBYXLUEqKUEtFxYsQisJP2J5Ozx2XDk4XXY8O3liPwJPLEdZLTJfSi0tSl4yLVlILAAAAAIAPAAAAcMChgAOABkAfrgAGi+4ABIvuAAaELgAANC4AAAvQQUASgASAFoAEgACXUEJAAkAEgAZABIAKQASADkAEgAEXbgAEhC5AAcAA/S4AAAQuQAOAAP0uAAY0LgABxC4ABvcALgAAEVYuAAALxu5AAAABT5ZuwACAAEAFwAEK7sADwABAAwABCswMTMRMzIeAhUUDgIjIxETMjY3NC4CIyMVPM4nRDIcGi5BJXxmLzgBEBwmFWcChhwwQSUmQC8b/twBazswFCUdEdIAAAACAB7/cwJLApMAHwA0ALe4ADUvuAAvL7gANRC4AArQuAAKL0EFAEoALwBaAC8AAl1BCQAJAC8AGQAvACkALwA5AC8ABF24AC8QuQAUAAP0ugAfAC8AFBESOboAIAAKABQREjm4AAoQuQAlAAP0QQkABgAlABYAJQAmACUANgAlAARdQQUARQAlAFUAJQACXbgAFBC4ADbcALgAAEVYuAAFLxu5AAUABT5ZuAAARVi4ABkvG7kAGQAFPlm7AA8AAQAgAAQrMDEFBi4CJy4DNTQ+AjMyHgIVFA4CByMeAjIzAyIOAhUUHgIzMj4CNTQuAiMB1CNAMyMGPV0+HyVHZ0NDaEclHTpVOQEJJCwuEsorQiwWFy1BKilBLRcWLEIriwIRIzMfB0Ngcjc8dlw5OF12PDVuX0QLFRUJAn4sSFktMl9KLS1KXzItWUgsAAIAPAAAAc8ChgARABwAl7gAHS+4ABUvQQUASgAVAFoAFQACXUEJAAkAFQAZABUAKQAVADkAFQAEXbgAANC4AAAvuAAdELgABNC4AAQvuQADAAP0uAAVELkACwAD9LoAEAAEAAsREjm4AAMQuAAb0LgACxC4AB7cALgAAEVYuAAALxu5AAAABT5ZuAAARVi4AAMvG7kAAwAFPlm7AAYAAQAaAAQrMDEhAyMRIxEzMh4CFRQOAgcTAxY2NTQuAiMjFQFgpSJdzSdEMh0XKjkiqNAvOBAcJRVnAST+3AKGHDBCJiM9LhwD/tsBagE/LRQlHRLSAAABAB7/+QHVApMAOQDWuAA6L7gAES9BBQBKABEAWgARAAJdQQkACQARABkAEQApABEAOQARAARduAA6ELgAHNC4ABwvuQArAAP0QQkABgArABYAKwAmACsANgArAARdQQUARQArAFUAKwACXbgAERC5ADYAA/S4ADvcALgAAEVYuAADLxu5AAMABT5ZuwAhAAEAKAAEK7gAAxC5AAwAAfRBGQAHAAwAFwAMACcADAA3AAwARwAMAFcADABnAAwAdwAMAIcADACXAAwApwAMALcADAAMXUEFAMYADADWAAwAAl0wMSUGBiMiLgInNxYWMzI2NzY1NCYnLgMnJiY1ND4CMzIWFwcmJiMiBgcUFhceAxcWFhUUBgcBeyBDLR05NS8TKiBYKyIjESsuNhUyMSwPFRIfN00vNFAnKx45JTc4ASw2GTMxLBIUEDAqIBQTDRgfEkMaLAsOIC8kLhIHDxQZERY1HypGMhskHUIXGjIqHSkRCA8UHRUYPB4vUh0AAAABAAoAAAHeAoUABwAwuwAHAAMAAAAEKwC4AABFWLgAAC8buQAAAAU+WbsAAwABAAIABCu4AAIQuAAF0DAxMxEjNyEVIxHKwCIBsrYCP0ZG/cEAAAABADf/9wIMApYAFQCIuAAWL7gAAC+5AAEAA/S4ABYQuAAN0LgADS+5AA4AA/S4AAEQuAAX3AC4AA4vuAAARVi4AAcvG7kABwAFPlm5ABIAAfRBGQAHABIAFwASACcAEgA3ABIARwASAFcAEgBnABIAdwASAIcAEgCXABIApwASALcAEgAMXUEFAMYAEgDWABIAAl0wMQEzERQOAiMiLgI1ETcTFBY3MjY1Ab9NJEBWMzFVPiReAUZKSFEChP5aM1Y9ISI9VTMBlyH+U01WAVlLAAAAAAEACv/0AgoClAAGACYAuAACL7gABC+4AABFWLgAAC8buQAAAAU+WboAAwAAAAIREjkwMRcDNxMTFwPt41uysULYDAJ/If4PAfEZ/ZMAAAAAAQAK//QDBwKUAAwATwC4AAUvuAAIL7gACi+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAADLxu5AAMABT5ZugABAAAABRESOboABgAAAAUREjm6AAkAAAAFERI5MDEFAwMHAzcTEzcTExcDAhiSf0i1W4R8WIWFQKgMAf/+GxoCfyH+IwG+Hv4kAdwN/YgAAAAAAQAoAAACPgKTAAsASwC4AAYvuAAIL7gAAEVYuAAALxu5AAAABT5ZuAAARVi4AAIvG7kAAgAFPlm6AAEAAAAGERI5ugAFAAAABhESOboABwAAAAYREjkwMSEDAyMTAzcXNxcDEwHOpK1V2L9emaFFu9sBBv76AUgBLR719Br+5P6kAAAAAQAKAAAB3gKUAAwAOrsADAADAAAABCu6AAQAAAAMERI5ALgAAy+4AAkvuAAARVi4AAAvG7kAAAAFPlm6AAQAAAAJERI5MDEzEQM3EzY2NzY3FwMRxLpanBQ1GBweQ70BKgFJIP7oJWAsMzUb/qn+3gAAAAABACgAAAIuAoQABwAoALgAAEVYuAAALxu5AAAABT5ZuwAEAAEAAQAEK7gAABC5AAUAAfQwMTMBITchASEVKAFY/r0kAbf+qAFuAj1H/cRIAAEAPP90AQAC+wAHAC+7AAUAAwAAAAQruAAAELkABwAE9AC4AAAvuwAGAAEABwAEK7sAAgABAAMABCswMRcRMwcjETMVPMQhSVmMA4dI/QpIAAAAAAEAAP9jAWIDEgADAAsAuAACL7gAAC8wMQUBNwEBEP7wUgEQnQOSHfxuAAAAAQAf/3QA4wL7AAcAN7sABwAEAAAABCu4AAcQuQACAAP0uAAHELgACdwAuAAHL7sAAQABAAAABCu7AAYAAQADAAQrMDEXNTMRIyczES9aSSHEi0gC9kj8eQAAAAABADwBVwI8AtgABgAZALgABC+4AAAvuAACL7oAAQAAAAQREjkwMQEDAycTMxMB7LCxT9xI3AFXARD+8B4BY/6cAAAAAAEAFP+DAhf/xAADAA0AuwABAAIAAAAEKzAxFychFS4aAgN9QUEAAAABAC0B+QEpAqgAAwAVALgAAi+4AAAvugADAAAAAhESOTAxEyc3F/jLJtYB+WJNfgACAB7/9wGCAdAAIQAsANK4AC0vuAAiL7gALRC4AAXQuAAFL7gAIhC4AAvQuAALL7gAIhC5AB0AA/S4AAUQuQAmAAP0QQkABgAmABYAJgAmACYANgAmAARdQQUARQAmAFUAJgACXbgAHRC4AC7cALgAAEVYuAAALxu5AAAABT5ZuwAYAAEADwAEK7sACgABACMABCu4AAAQuQApAAH0QRkABwApABcAKQAnACkANwApAEcAKQBXACkAZwApAHcAKQCHACkAlwApAKcAKQC3ACkADF1BBQDGACkA1gApAAJdMDEXLgM1ND4CMzM1NCYjIgYHJz4DMzIeAhUXBgYnNycmBhUUFhcyNje1HzcpGBorOiFqMSAfNCQaFycnJxccNysaASNnQ3FTJi8xJhotCggBGCk3ICI2JhQfICgQEjwMEQsEEiM0If4jLgLlAQEqIyE1ARUJAAAAAAIAPP/2AcUCzAAVACcA0LgAKC+4ACIvuAAoELgABdC4AAUvuQAaAAP0uAAH0EEFAEoAIgBaACIAAl1BCQAJACIAGQAiACkAIgA5ACIABF24ACIQuQAQAAP0ugAIAAUAEBESObgAKdwAuAAHL7gAAEVYuAAALxu5AAAABT5ZuwALAAEAJwAEK7oACAAnAAsREjm4AAAQuQAdAAH0QRkABwAdABcAHQAnAB0ANwAdAEcAHQBXAB0AZwAdAHcAHQCHAB0AlwAdAKcAHQC3AB0ADF1BBQDGAB0A1gAdAAJdMDEFLgMnETcRNjYXHgMVFA4CJwMiBgcRFhY3PgM1NC4CIwEOOE8yGAFbGzshMEUtFRguRC0QHTgSCTspGyQVCQcVJx8JAhkeGQICYh/+5w8RAQIoP1EqMFpFKQIBkRIK/uwIFwIBIjI8HBw5Lh0AAQAe//cBggHQACEAiLsAGQADAAgABCtBCQAGABkAFgAZACYAGQA2ABkABF1BBQBFABkAVQAZAAJdALgAAEVYuAADLxu5AAMABT5ZuQAeAAH0QRkABwAeABcAHgAnAB4ANwAeAEcAHgBXAB4AZwAeAHcAHgCHAB4AlwAeAKcAHgC3AB4ADF1BBQDGAB4A1gAeAAJdMDElBgYjIi4CNTQ2NzY2FhYXByYmBw4DFRQeAjMWNjcBgidTMSxFLxkyLxg6P0AeHh03GBknGw0PHCobIzkfKxkbKUJSKj5zIREPAhQTOA4PAgIfMD0eHTkuHQEYDwAAAAIAHv/4AasCzQATACQA4LgAJS+4ACQvuAAlELgABdC4AAUvuAAkELkAEAAD9LoAAAAFABAREjm4ACQQuAAN0LgADS+4AAUQuQAcAAP0QQkABgAcABYAHAAmABwANgAcAARdQQUARQAcAFUAHAACXbgAEBC4ACbcALgADy+4AABFWLgAEy8buQATAAU+WbsACgABABcABCu6AA0AFwAKERI5uAATELkAIQAC9EEZAAcAIQAXACEAJwAhADcAIQBHACEAVwAhAGcAIQB3ACEAhwAhAJcAIQCnACEAtwAhAAxdQQUAxgAhANYAIQACXTAxFyIuAjU0PgIzMhYXNTcRBgYjEyYmIyIOAhUUHgIzMjY30zBFKxUXLkcwIDocWzFqPn8ZLh0eKBoLCxgnHB04FAcsRVMnKFVFLQ4M9R/9fCYrAXQQESIyPRsaOzIgFw0AAAIAHf/3AYwBzAAeACkAbrgAKi+4AB8vuAAqELgAC9C4AAsvuAAfELkAFQAD9LgACxC5ABYAA/S4ACnQuAApL7gAFRC4ACvcALgAAEVYuAAkLxu5ACQABz5ZugAWABsAAyu4ACQQuQAQAAL0uAAkELkAHwAB9LkAFQAC9DAxJQYGBwYGJiYnJiY3ND4CMzIeAhchBh4CNzY2NycuAyMiDgIHAYwXJxcYNjYyFSUqARMrRTMwQykTAf75AhIgLRojNyRMAQoUHRMVHhQMAy0PFAYHBgQSEiBjOStWRSshPlc3Jz0rFgEBFRG9FiceEREeJxYAAAABAB4AAAFUAs4AFwBMuwAXAAMAAAAEK7gAABC4AATQuAAXELgAEtAAuAAIL7gAAEVYuAAALxu5AAAABT5ZuwAEAAEAAQAEK7gABBC4ABPQuAABELgAFdAwMTMRIzUzNTQ2FzIWFwcXJg4CFRUzFSMRTC4ubFoRHRQWAS87IQtiYgF+SChzbQEGBz8BDA4qPyQrSP6CAAAAAAIAKP8dAbgBzgAmADcA7rgAOC+4ACcvuQAgAAP0ugAAACcAIBESObgAJxC4AA7QuAAOL7gAJxC4ABDQuAAQL7gAOBC4ABjQuAAYL7kALwAD9EEJAAYALwAWAC8AJgAvADYALwAEXUEFAEUALwBVAC8AAl24ACAQuAA53AC4AAUvuAAARVi4ABMvG7kAEwAFPlm7AB0AAQAqAAQrugAAAAUAExESObgAExC5ADQAAfRBGQAHADQAFwA0ACcANAA3ADQARwA0AFcANABnADQAdwA0AIcANACXADQApwA0ALcANAAMXUEFAMYANADWADQAAl26ABAAEwA0ERI5MDEFDgMHJz4DNzY2NTQ3BgYjIi4CNTQ+AjMyFhcRFA4CBwMmJiMiDgIVFB4CMzI2NwGeDzQ/RB8QFDEvKAsKBAEePSYwRCwWFS1DLzR1MwIFCglDGS4dHigZCwsYJxweMhh6HCcZDAFBAwcOGBQTQRkIAxISLENTJyVURy8oLf6vFCssKBAB4hASIDI8Gxs5MB8ZDgABADwAAAGuAssAFwBzuAAYL7gAAC+4ABgQuAAL0LgACy+5AAoAA/S4AA3QugAOAAsAChESObgAABC5ABcAA/S4ABncALgADS+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAAKLxu5AAoABT5ZuwARAAEABgAEK7oADgAGABEREjkwMSERNC4CIyIGBxEjETcDNjYzMh4CFREBUAkSGxIeNxpdXQEfRScfNCQUASISIxsRHBP+rAKtHv7WFBUXJzYe/sgAAAAAAgA8AAAAtwKPAAwAEABmuwAGAAQAAAAEK0EFAEoAAABaAAAAAl1BCQAJAAAAGQAAACkAAAA5AAAABF26AA4AAAAGERI5uAAOL7kADwAD9LgABhC4ABLcALgAAEVYuAANLxu5AA0ABT5ZuwADAAEACQAEKzAxEzQ2MzIWBxQGIyImNRMDNxE9IxoaIwEjGhojEAFeAlIaIyMaGiMjGv2uAbcf/ioAAAAAAv+I/wMAtgKQAAsAHQBbuwAAAAQABgAEK0EFAEoABgBaAAYAAl1BCQAJAAYAGQAGACkABgA5AAYABF26ABQABgAAERI5uAAUL7oAFgAGAAAREjm5ABcAA/QAuAAaL7sACQABAAMABCswMRMUBiMiJjU0NjMyFgEWFhcWPgI1ETcRFAYjIiYntiMaGiMjGhoj/ugPFgcrNBoIXWtbGSUcAlMaIyMaGiMj/O4FCAEHFys6HQHXIP4OdG0LDAABADwAAAG0AswACwBFuwADAAMABAAEK7gAAxC4AAbQALgABi+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAADLxu5AAMABT5ZugAHAAAABhESOTAxIScHFSMRNxE3FwcTAUaSG11dvjKPuuMZygKsIP5erjCE/twAAAABADz/8gDjAssACQARuwAGAAMAAwAEKwC4AAUvMDEXBiY1ETcRFBYX41BXWSQqBghAPwI9Hf2nJRcCAAABADIAAAJ6AdEAJQBuuwASAAMAEwAEK7sACAADAAsABCu7ACUAAwAAAAQruAAlELgAJ9wAuAAZL7gAHy+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAAJLxu5AAkABT5ZuAAARVi4ABIvG7kAEgAFPlm4AB8QuQAOAAH0MDEhETQmJgYHFhURIwM0JgcGBgcRIxE+AzM2Fhc2NjMyHgIVEQIcHi42GANeASszECEIXRksLDEgHTkVIEEqGjMpGgEwJyoNDREODv6sATAuLwMBEQj+kAGCEx0TCwEVFBMUESEvHv6wAAABADIAAAGhAdQAFgBNuAAXL7gAAC+4ABcQuAAJ0LgACS+5AAgAA/S4AAAQuQAWAAP0uAAY3AC4AABFWLgAAC8buQAAAAU+WbgAAEVYuAAILxu5AAgABT5ZMDEhETQmBwYGBxEjETY2NzY2Fx4DFREBRDMsGS0QXR83IxtIKRUmHRIBMS0uAQERC/6SAYIXIAoICQkFEx4oGf6sAAACAB7/+AG9AdAAEwAoAOi4ACkvuAAjL7gAKRC4AAXQuAAFL0EFAEoAIwBaACMAAl1BCQAJACMAGQAjACkAIwA5ACMABF24ACMQuQAPAAP0ugAUAAUADxESObgABRC5ABkAA/RBCQAGABkAFgAZACYAGQA2ABkABF1BBQBFABkAVQAZAAJduAAPELgAKtwAuAAARVi4AAAvG7kAAAAFPlm7AAoAAQAUAAQruAAAELkAHgAC9EEZAAcAHgAXAB4AJwAeADcAHgBHAB4AVwAeAGcAHgB3AB4AhwAeAJcAHgCnAB4AtwAeAAxdQQUAxgAeANYAHgACXTAxFyIuAjU0PgIzMh4CFRQOAgMOAxUUHgIzPgM1NC4CJ+w1TTMZHDZNMTFNNRwZNE80ISoYCQsZKh8hKhgJCxoqHwgqRFcuLVNAJSY/Uy0uV0UpAZECHSs3HSA/Mx8BHzI+IB03LRwCAAAAAgA8/xcBxgHQABUAKQDOuAAqL7gAJC+4ACoQuAAA0LgAAC9BBQBKACQAWgAkAAJdQQkACQAkABkAJAApACQAOQAkAARduAAkELkACwAD9LgAABC5ABUAA/S4ABvQuAALELgAK9wAuAAVL7gAAEVYuAAQLxu5ABAABT5ZuwAGAAEAKQAEK7gAEBC5AB8AAfRBGQAHAB8AFwAfACcAHwA3AB8ARwAfAFcAHwBnAB8AdwAfAIcAHwCXAB8ApwAfALcAHwAMXUEFAMYAHwDWAB8AAl26ABQAEAAfERI5MDEXET4DNzYeAhUUDgIHFQYmJxUTJg4CBxEWFjc+AzU0LgInPAEZM084MEQsFhUtRTAhOxtsFCIdFAUTOB0fJhQGBxMkHcgCRAIaHhgBASlFWTAqUT8pAQEBEQ/8AnIBBwoLBP7xCxcCAh4tOBwcPDIhAQAAAgAj/xcBswHPABIAIwDSuAAkL7gAAC+4ACQQuAAJ0LgACS+4AAAQuQASAAP0uAAAELgAE9C4AAkQuQAbAAP0QQkABgAbABYAGwAmABsANgAbAARdQQUARQAbAFUAGwACXbgAEhC4ACXcALgAAC+4AABFWLgABC8buQAEAAU+WbsADgABABYABCu4AAQQuQAgAAH0QRkABwAgABcAIAAnACAANwAgAEcAIABXACAAZwAgAHcAIACHACAAlwAgAKcAIAC3ACAADF1BBQDGACAA1gAgAAJdugABAAQAIBESOTAxBREGBgciLgI1ND4CMzIWFxEDJiYjIg4CFRQeAjMyNjcBVRw3KjBFKxUXL0gyNXIpXhYxHR4nGAoKFyYcHjIY6QEEEhMBLEVTJypVRSstKf3BAi0PEyAyPBwbOjAgGg8AAAAAAQA8AAABSgHVABAAQLsAEAADAAAABCsAuAAARVi4AAkvG7kACQAHPlm4AABFWLgADC8buQAMAAc+WbgAAEVYuAAALxu5AAAABT5ZMDEzETY3NjYXBgYHJiYHIgYHETwsQCFJOAsSCBEXByAtEQF1MhcMCwsXIxMDBAETDv6eAAABACj/9AF1AdMAOADWuAA5L7gACC9BBQBKAAgAWgAIAAJdQQkACQAIABkACAApAAgAOQAIAARduAA5ELgAFdC4ABUvuQAkAAP0QQkABgAkABYAJAAmACQANgAkAARdQQUARQAkAFUAJAACXbgACBC5ADAAA/S4ADrcALgAAEVYuAA1Lxu5ADUABT5ZuwAaAAEAIQAEK7gANRC5AAMAAfRBGQAHAAMAFwADACcAAwA3AAMARwADAFcAAwBnAAMAdwADAIcAAwCXAAMApwADALcAAwAMXUEFAMYAAwDWAAMAAl0wMTcWFjMyPgI1NC4CJyYmJy4DNTQ+AjMyFhcHJiYjIgYVFBYXFhYXFhYXFhYHDgMjIiYnTBw7HBEhGQ8NExcKChQKFy0jFRwtOR4jQiUjHy4XHS4PDxEpFBQpEhQaAQEhM0AfKE0jaBYVCBAYEQ0TDQgEBAkECRMdKR4iNCMSFxU9EQ8dHA4RCAgPCAgSDg8tIiY3IxEeGwAAAAEAHv/zAPkCXQARAFa7AA4AAwADAAQruAADELgAB9C4AA4QuAAJ0LgAAxC5ABEABPS4AAvQALgAAEVYuAAJLxu5AAkACz5ZuwAHAAEABAAEK7gABxC4AArQuAAEELgADNAwMRcGJjURIzUzNTcVMxUjERQWF/lRWjAwXE9PJSoFCEA+ARJEdSGWRP7wJRgCAAEAMv/4AagB1AATAIi4ABQvuAAAL7kAAQAD9LgAFBC4AArQuAAKL7kADQAD9LgAARC4ABXcALgADC+4AABFWLgABS8buQAFAAU+WbkAEAAB9EEZAAcAEAAXABAAJwAQADcAEABHABAAVwAQAGcAEAB3ABAAhwAQAJcAEACnABAAtwAQAAxdQQUAxgAQANYAEAACXTAxATMRBgYjIi4CNRE3ERQWNzY2NwFLXTFtQho1KxxfOCwZLBEBx/5+JCkQITMjATUg/sQtMAEBEQsAAAABAA//8gG3AdsABgAmALgAAi+4AAQvuAAARVi4AAAvG7kAAAAFPlm6AAMAAAACERI5MDEXAzcTExcDybpVkIQ/oQ4BxST+pAFWHv5VAAAAAAEAD//2AnAB0gAMAE8AuAAFL7gACC+4AAovuAAARVi4AAAvG7kAAAAFPlm4AABFWLgAAy8buQADAAU+WboAAQAAAAUREjm6AAYAAAAFERI5ugAJAAAABRESOTAxBQMDBwM3ExM3ExMXAwGralVLklZoT1NnWUF7CgFB/tgZAb4e/sgBHBz+yAE4Fv5TAAAAAAEAHgABAbYByQALAFUAuAAGL7gACC+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAACLxu5AAIABT5ZugABAAAABhESOboABQAAAAYREjm6AAcAAAAGERI5ugAJAAAABhESOTAxJScHIzcnNxc3FwcXAUdnaVmWjFlpaUqGnwGZmdzPHZ2bGcTpAAABADL/HQGwAdQAKADAuAApL7gAIC+5ACMAA/S6AAAAIAAjERI5uAAgELgADtC4AA4vugAPACAAIxESObgAKRC4ABfQuAAXL7kAGgAD9LgAIxC4ACrcALgAGS+4AAUvuAAARVi4ABIvG7kAEgAFPlm6AAAABQAZERI5uQAdAAH0QRkABwAdABcAHQAnAB0ANwAdAEcAHQBXAB0AZwAdAHcAHQCHAB0AlwAdAKcAHQC3AB0ADF1BBQDGAB0A1gAdAAJdugAPABIAHRESOTAxBQ4DByc+Azc2NjU3BgYjIi4CNRE3ERQWNzY2NxEzERQOAgcBlg80P0QfEBQxMCgLCgMBI0UoGjQsG143LBk0El4CBQoJehwnGQwBQQMHDhgUE0EZAg4NEiMzIQE1IP7CLS0BARYLAWb+bBMuLywQAAAAAAEAHgAAAZgBxQAHACgAuAAARVi4AAAvG7kAAAAFPlm7AAQAAQABAAQruAAAELkABQAB9DAxMxMjNyEDMxUe39YjAUTf6QF+R/6CRwABAB7/UAFXAyIAKQA5uwAlAAMABgAEK7gABhC4AA7QuAAlELgAGdC6AB8ABgAlERI5ALgAAC+4ABUvugAfAAAAFRESOTAxBSYmJyYmNTU0Jic1NjY1NTQ2NzY2NxcGBhUXFA4CBx4DFRUGFhcHATYmThwPFjEyMjEXDx1MJiE8PgEOGB4QEB4XDgRCPCGwDDEkEzshfzEzDVMNMzF+ITwTIzEMQxdKKY8aLCIbCgkbIiwakClKF0IAAQBQ/9YAqAL7AAMAFbsAAwADAAAABCsAuAACL7gAAC8wMRcRNxFQWCoDBCH8+gAAAQAe/1EBWAMiACYAPbsAIAADAAMABCu6AAcAAwAgERI5uAADELgADNC4ACAQuAAX0LgAFy8AuAARL7gAJi+6AAcAJgARERI5MDEXNjYnNTQ2Ny4DNTc0Jic3FhYXFhYVBwYWFxcGBgcHFAYHBgYHHjxCBDMgEB4XDgE+PCAmTh0PFgEBMjIBMjABARYPHE4mbBdKKJA0RRMJGyIsGpApSxdCDDEjEzsifzEzDVINMzF/ITsUIzELAAEAMgDfAYMBSgAYACcAuAAML7gAFC+4AAAvuAAIL7gADBC5AAUAAfS4AAAQuQARAAH0MDElIi4CIyIGByc2NjMyHgIzMjY3FwYGIwEIERsZGQ4TGRcnHzcmERsZGQ4TGRYnHzYm4AoMCg8SMx0aCgsKDxEyHRoAAAQACv/+AiQDIwAMABkAIQAkAOu4ACUvuAADL0EFAEoAAwBaAAMAAl1BCQAJAAMAGQADACkAAwA5AAMABF25AAkABPS4ACUQuAAQ0LgAEC+5ABYABPRBCQAGABYAFgAWACYAFgA2ABYABF1BBQBFABYAVQAWAAJduAAJELgAGtC4ABovuAADELgAINC4ACAvugAiABAAGhESOboAIwAQABYREjm6ACQAAwAJERI5uAAJELgAJtwAuAAGL7gAEy+4AABFWLgAGi8buQAaAAU+WbgAAEVYuAAdLxu5AB0ABT5ZuwAkAAEAGwAEK7gAExC5AA0AAfS4AADQuAAALzAxASImNTQ2MzIWFRQGIwciJjU0NjMyFhUUBiMBJyMHIxM3EwEHMwGDGiMiGhojIxnCGSQjGRokIxoBAELhR03oVd3+8FyxAqYkGholJRoZJAIkGholJRkaJP1YwsICehv9awIE/QAABAAKAAACJANtABMAGwAoACsA5bgALC+4ACUvuAAsELgABdC4AAUvQQUASgAlAFoAJQACXUEJAAkAJQAZACUAKQAlADkAJQAEXbgAJRC5AA8AA/S4ABXQuAAVL7gABRC5AB8AA/RBCQAGAB8AFgAfACYAHwA2AB8ABF1BBQBFAB8AVQAfAAJduAAZ0LgAGS+4ACUQuAAa0LgAGi+6ACkABQAPERI5uAAFELgAKtC4ACovugArACUADxESOQC4AAovuAAARVi4ABQvG7kAFAAFPlm4AABFWLgAFy8buQAXAAU+WbsAKwABABUABCu7ACIAAgAAAAQrMDEBIi4CNTQ+AjMyHgIVFA4CEycjByMTNxMBIgYVFhYzMjY1NCYjAwczARwVJhsQER0lFRUmHBARHCaPQuFHTehV3f77FBoBGRESGxkRC1yxApoRHCcVFiYdEREcJxUWJh0R/WbCwgJ7G/1qAzAbERIbGxISG/7S/QABACb/RgIVApIAOwDCuwAzAAMABgAEK0EFAEoABgBaAAYAAl1BCQAJAAYAGQAGACkABgA5AAYABF0AuAAARVi4AAsvG7kACwAFPlm4AABFWLgALS8buQAtAAU+WbgAAEVYuAAwLxu5ADAABT5ZuwADAAIAOAAEK7sAFQABABwABCu4AC0QuQAjAAH0QRkABwAjABcAIwAnACMANwAjAEcAIwBXACMAZwAjAHcAIwCHACMAlwAjAKcAIwC3ACMADF1BBQDGACMA1gAjAAJdMDEXFhYzMjY1NCYjIzUuAzc+AxcWFhcHJiYjIgYGHgIzMjY3NjY3FwYGBxUWFxYWBxQOAiMiJifqGRoPDhYZDik2UjcbAgEiQGJCN2EtJShGJjhIIwIlRjMmNyALGxUlN2Q2CQMpHwEOGycaFy0XaQsHEQ4ODD8KR19tMjh1XjsBAhogPhoUS3KDcksSEgYPDDwrKAQCAgEGMB0QIBsREAsAAAIAPAAAAbADWgADAA8AWbsADQADAAQABCu4AA0QuAAI0AC4AAIvuAAARVi4AAkvG7kACQAHPlm4AABFWLgABC8buQAEAAU+WbsABgABAAcABCu4AAkQuQALAAH0uAAEELkADQAB9DAxEyc3FwERIQcjFTMHIxUhFaoy2Cb+xgF0JPPUJLABCgKlM4JP/PUCh0jASPBHAAAAAgA8AAACJgMXABcAIQCXuAAiL7gAHi+4AADQuAAAL7gAIhC4ABvQuAAbL7kAGgAD9LgADNC4AAwvuAAaELgAHdC4AB4QuQAhAAP0uAAj3AC4AA8vuAAXL7gAAEVYuAAYLxu5ABgABT5ZuAAARVi4ABovG7kAGgAFPlm4AA8QuQAIAAH0uQAUAAL0uQADAAH0ugAZABgAFxESOboAHgAYABcREjkwMQEGBiMiLgIjIgYHJzY2MzIeAjMyNjcTAREjETcBETMRAdoeNiYRHBkZDxMZFyUeNiYRHBkZDhMZFxv+tUhIAVtHAuEfGwoMCg8TNh8bCgwKDxP86QHn/hkCfBj+AQHx/XoABAAe//UCSwMjAAwAGQAuAEMBRrsANAADAB8ABCu7ABYABAAQAAQruwAJAAQAAwAEK7sAKQADAD4ABCtBBQBKAAMAWgADAAJdQQkACQADABkAAwApAAMAOQADAARdQQkABgAWABYAFgAmABYANgAWAARdQQUARQAWAFUAFgACXboALwAfACkREjlBCQAGADQAFgA0ACYANAA2ADQABF1BBQBFADQAVQA0AAJdQQUASgA+AFoAPgACXUEJAAkAPgAZAD4AKQA+ADkAPgAEXbgAKRC4AEXcALgABi+4ABMvuAAARVi4AC4vG7kALgAFPlm7ACQAAQBDAAQruAATELkADQAB9LgAANC4AAAvuAAuELkAOQAB9EEZAAcAOQAXADkAJwA5ADcAOQBHADkAVwA5AGcAOQB3ADkAhwA5AJcAOQCnADkAtwA5AAxdQQUAxgA5ANYAOQACXTAxASImNzQ2MzIWFxQGIwciJjU0NjMyFhUUBiMTIi4CNTQ+AjMyHgIVFA4CIxMiDgIVFB4CMzI+AjU0LgIjAZQaIwEhGhojASMawhkkIxoaJCQaYkVoRiMlR2dDQ2hHJSNHaEUBK0IsFhctQSopQS0XFixCKwKmJBoaJSUaGSQCJBoaJSUZGiT9UD9jeTs8dVw5OV11PTt5Yj8CUSxIWS0yX0otLUpfMi1ZSCwAAwA8//UCEQMjAAwAGQAvAOy7ACgAAwAnAAQruwAJAAQAAwAEK0EFAEoAAwBaAAMAAl1BCQAJAAMAGQADACkAAwA5AAMABF26ABAAJwAoERI5uAAQL7kAFgAE9LgACRC4ABrQuAAaL7gACRC5ABsAA/S4AAkQuAAx3AC4AAYvuAATL7gAAEVYuAAhLxu5ACEABT5ZuAATELkADQAB9LgAANC4AAAvugAoACEABhESObgAIRC5ACwAAfRBGQAHACwAFwAsACcALAA3ACwARwAsAFcALABnACwAdwAsAIcALACXACwApwAsALcALAAMXUEFAMYALADWACwAAl0wMQEiJjc0NjMyFhUUBiMHIiY1NDYzMhYVFAYjFzMRFA4CIyIuAjURNxMUFjc2NjUBjBojASEaGiMjGcEZJCIaGiQjGvlNJEBWMzFVPiReAUZKSFECpiQaGiUlGhkkAiQaGiUlGRokIv5YM1Y9ISI9VTMBmSD+U05VAQFYSwAAAAADACj/9wGMAqgAAwAlADAA6LgAMS+4ACYvuAAC0LgAAi+4ADEQuAAJ0LgACS+4ACYQuQAhAAP0ugAEAAkAIRESObgAJhC4AA/QuAAPL7gACRC5ACoAA/RBCQAGACoAFgAqACYAKgA2ACoABF1BBQBFACoAVQAqAAJduAAhELgAMtwAuAACL7gAAEVYuAAELxu5AAQABT5ZuwAOAAEAJwAEK7sAHAABABMABCu4AAQQuQAtAAH0QRkABwAtABcALQAnAC0ANwAtAEcALQBXAC0AZwAtAHcALQCHAC0AlwAtAKcALQC3AC0ADF1BBQDGAC0A1gAtAAJdMDETJzcXAy4DNTQ+AjMzNTQmIyIGByc+AzMyHgIVFwYGJzcnJgYVFBYXMjY3kjHXJp4fOCkYGis6IWoxIB80JBoXJycnFxw3KxoBI2dDclMmLzEmGi0KAfMzgk/9nwEYKjcgIjYmFB8gKRASPA0RCgQSJDMh/yMvAuYBASokITUBFQkAAAMAKP/3AYwCqAADACUAMADouAAxL7gAJi+4AAPQuAADL7gAMRC4AAnQuAAJL7gAJhC5ACEAA/S6AAQACQAhERI5uAAmELgAD9C4AA8vuAAJELkAKgAD9EEJAAYAKgAWACoAJgAqADYAKgAEXUEFAEUAKgBVACoAAl24ACEQuAAy3AC4AAEvuAAARVi4AAQvG7kABAAFPlm7AA4AAQAnAAQruwAcAAEAEwAEK7gABBC5AC0AAfRBGQAHAC0AFwAtACcALQA3AC0ARwAtAFcALQBnAC0AdwAtAIcALQCXAC0ApwAtALcALQAMXUEFAMYALQDWAC0AAl0wMRM3FwcDLgM1ND4CMzM1NCYjIgYHJz4DMzIeAhUXBgYnNycmBhUUFhcyNjdrJtgydx84KRgaKzohajEgHzQkGhcnJycXHDcrGgEjZ0NyUyYvMSYaLQoCWU+CM/4FARgqNyAiNiYUHyApEBI8DREKBBIkMyH/Iy8C5gEBKiQhNQEVCQAAAwAo//cBogKyAAUAJwAyANa4ADMvuAAoL7gAMxC4AAvQuAALL7gAKBC4ABHQuAARL7gAKBC5ACMAA/S4AAsQuQAsAAP0QQkABgAsABYALAAmACwANgAsAARdQQUARQAsAFUALAACXbgAIxC4ADTcALgAAy+4AABFWLgABi8buQAGAAU+WbsAEAABACkABCu7AB4AAQAVAAQruAAGELkALwAC9EEZAAcALwAXAC8AJwAvADcALwBHAC8AVwAvAGcALwB3AC8AhwAvAJcALwCnAC8AtwAvAAxdQQUAxgAvANYALwACXTAxEwcnNxcHAy4DNT4DMzMnJiYjIgYHJz4DMzIeAhUXBgYnNycmBhUUFhcyNjfoiSiwuy61HzcqFwEZLDkgawEBMCAfNCQaFycnJxccNysaASNnQnBTJi8xJhotCgJITzmAgDn9/wEYKjcgIjYmFB8gKRASPA0RCgQSJDMh/yMvAuYBASokITUBFQkAAAAABAAo//UBjAJ0AAwAGQA7AEYBBrsAQAADAB8ABCu7ADcABAADAAQrQQkABgBAABYAQAAmAEAANgBAAARdQQUARQBAAFUAQAACXboADQAfAEAREjm6ABAAHwBAERI5uAAQL7kAFgAE9LoAGgAQABYREjm4ADcQuQA8AAP0uAAl0LgAJS+4ADcQuABI3AC4AAYvuAATL7gAAEVYuAAaLxu5ABoABT5ZuwAlAAEAPAAEK7sAMgABACkABCu4ABMQuQANAAH0uAAA0LgAAC+4ABoQuQBDAAH0QRkABwBDABcAQwAnAEMANwBDAEcAQwBXAEMAZwBDAHcAQwCHAEMAlwBDAKcAQwC3AEMADF1BBQDGAEMA1gBDAAJdMDEBIiY1NDYzMhYVFgYjByImNTQ2MzIWFRQGIxMuAzU0PgIzMzU0JiMiBgcnPgMzMh4CFRcGBic3IyIGFRQWFzI2NwFHGiMiGhojASQZwBkkIhkaJCMaOh84KRgaKzohajEgHzQkGhcnJycXHDcrGgEjZ0NyUyYvMSYaLQoB9yQaGiUlGhkkAiQaGiUlGhkk/f8BGCo3ICI2JhQfICkQEzwNEQoEEiQzIf4jLwLmKSMhNQEVCQAAAAADACj/9wGMAmUAFwA5AEQA/rgARS+4ADovuQA1AAP0uAAA0LgAAC+4AEUQuAAd0LgAHS+6ABgAHQAAERI5uAA6ELgAI9C4ACMvuAAdELkAPgAD9EEJAAYAPgAWAD4AJgA+ADYAPgAEXUEFAEUAPgBVAD4AAl24ADUQuABG3AC4AA8vuAAXL7gAAEVYuAAYLxu5ABgABT5ZuwAwAAEAJwAEK7sAIwABADoABCu4AA8QuQAIAAH0uQAUAAL0uQADAAH0uAAYELkAQQAB9EEZAAcAQQAXAEEAJwBBADcAQQBHAEEAVwBBAGcAQQB3AEEAhwBBAJcAQQCnAEEAtwBBAAxdQQUAxgBBANYAQQACXTAxAQYGIyIuAiMiBgcnNjY3Mh4CMzI2NwMuAzU0PgIzMzU0JgciBgcnPgMzMh4CFRcGBic3IyIGFRQWFzI2NwGMHjYmERwZGQ4TGRYmHjYlERwZGQ4TGRemHzgpGBorOiFqMSAfNCQaFycnJxccNysaASNnQ3JTJi8xJhotCgIvHxsKDQoPEzUfGwEKDQoPE/2TARgqNyAiNiYUHyApARASPA0RCgQSJDMh/iMvAuYpIyE1ARUJAAQAKP/3AYwCywATADUAQQBMASq7AEYAAwAZAAQruwAAAAMAOQAEK0EJAAYARgAWAEYAJgBGADYARgAEXUEFAEUARgBVAEYAAl26AAoAGQBGERI5uAAKL0EFAEoAOQBaADkAAl1BCQAJADkAGQA5ACkAOQA5ADkABF26AEIAOQAAERI5uABCL7kAMQAD9LoAFAAZADEREjm4AEIQuAAf0LgAHy+4AAoQuQA/AAP0uAAxELgATtwAuAAARVi4ABQvG7kAFAAFPlm7AA8AAgA8AAQruwA2AAIABQAEK7sAHgABAEMABCu7ACwAAQAjAAQruAAUELkASQAB9EEZAAcASQAXAEkAJwBJADcASQBHAEkAVwBJAGcASQB3AEkAhwBJAJcASQCnAEkAtwBJAAxdQQUAxgBJANYASQACXTAxARQOAiMiLgI1ND4CMzIeAgMuAzU0PgIzMzU0JiMiBgcnPgMzMh4CFRcGBicTMjY1NCYjIgYVFBYTJyYGFRQWFzI2NwFPEB0mFRUlHBARHCcVFSUcD48fOCkYGis6IWoxIB80JBoXJycnFxw3KxoBI2dDKhEbGRETGxtZUyYvMSYaLQoCYhYmHRERHCcVFiYdEREcJ/2BARgqNyAiNiYUHyApEBI8DREKBBIkMyH/Iy8CAjobEhIbGxISG/6sAQEqJCE1ARUJAAEAHv9GAYIB0AA7ADm7ACEAAwAQAAQrQQkABgAhABYAIQAmACEANgAhAARdQQUARQAhAFUAIQACXQC7AAMAAgA4AAQrMDEXFhYzMjY3NCYjIzUuAzU0Njc2NhYWFwcmJgcOAxUUHgIzFjY3FwYGBzUWFxYWFRQOAiMiJiedGBoPDhYBGQ4pJDglFDEwGDo/QB4eHTcYGScbDQ8cKhsjOR8bIEImBgMpHQ4bJxoWLRdpCwcRDg4MOwgtP0olP3QhEQ8CFRM4DhACASAxPR8dOS4dARgPOBUZBAECAQYwHRAgGxEQCwAAAAADAB7/9gGNAqgAAwAiAC0AgLgALi+4ACMvuAAuELgAD9C4AA8vuQAaAAP0uAAA0LgAAC+4ACMQuAAC0LgAAi+4ACMQuQAZAAP0uAAaELgALdC4AC0vuAAZELgAL9wAuAACL7gAAEVYuAAoLxu5ACgABz5ZugAZAB8AAyu4ACgQuQAUAAL0uAAoELkAIwAB9DAxEyc3FxMGBgcGBiYmJyYmNTQ+AjMyHgIXJQYeAjc2NjcnLgMjIg4CB4Ux2CU8FycXGDY2MxUlKRMrRjMwQykTAf75AhIgLRojNyRMAQoUHRMVHhQMAwHzM4JP/dQPFAYHBwUSEiBkOStXRSwhPlg3ASc+KxcBARURvRYnHhIRHigWAAADAB7/9gGNAqgAAwAiAC0AgLgALi+4ACMvuAAuELgAD9C4AA8vuQAaAAP0uAAB0LgAAS+4ACMQuAAD0LgAAy+4ACMQuQAZAAP0uAAaELgALdC4AC0vuAAZELgAL9wAuAABL7gAAEVYuAAoLxu5ACgABz5ZugAZAB8AAyu4ACgQuQAUAAL0uAAoELkAIwAB9DAxEzcXBxMGBgcGBiYmJyYmNTQ+AjMyHgIXJQYeAjc2NjcnLgMjIg4CB1Qm1zFtFycXGDY2MxUlKRMrRjMwQykTAf75AhIgLRojNyRMAQoUHRMVHhQMAwJZT4Iz/joPFAYHBwUSEiBkOStXRSwhPlg3ASc+KxcBARURvRYnHhIRHigWAAADAB7/9wGOArIABQAkAC8AdLgAMC+4ACUvuAAwELgAEdC4ABEvuAAC0LgAAi+4ACUQuQAbAAP0uAARELkAHAAD9LgAL9C4AC8vuAAbELgAMdwAuAADL7gAAEVYuAAqLxu5ACoABz5ZugAbACEAAyu4ACoQuQAWAAL0uAAqELkAJQAB9DAxEwcnNxcHEwYGBwYGJiYnJiY1ND4CMzIeAhclBh4CNzY2NycuAyMiDgIH1IkosbouLRcnFxg2NjIVJSoTK0YzMEMpEwH++QISIC0aIzckTAEKFB0TFR4UDAMCSE85gIA5/jQPFAYHBgQSEiBkOStXRSwhPlg3ASc+KxcBARURvRYnHhIRHigWAAAAAAQAHv/2AY0CdAAMABkAOABEANi7ADAAAwAlAAQruwAJAAQAAwAEK0EFAEoAAwBaAAMAAl1BCQAJAAMAGQADACkAAwA5AAMABF26AA0AJQAwERI5ugAQACUAMBESObgAEC+5ABYABPS6ADkAAwAJERI5uAA5L7kALwAD9LgAMBC4AETQuABEL7gALxC4AEbcALgABi+4ABMvuAAARVi4AD4vG7kAPgAHPlm6AC8ANQADK7sADQACACoABCu4ABMQuQAZAAH0uAAA0LgADRC4AAzQuAAML7gAPhC5ADkAAfS4ACoQuQA/AAL0MDEBIiY1NDYzMhYVFAYjByImNTQ2MzIWFRQGIwEGBgcGBiYmJyYmNTQ+AjMyHgIXJQYeAjc2NjcnLgMjFSIOAgcBOhojIhsaIiMZwBkkIhkaJCMaARQXJxcYNjYyFSUqEytGMzBDKRMB/vkCEiAtGiM3JEwBChQdExUeFAwDAfckGholJRoZJAEjGholJRoZJP41DxQGBwYEEhIgZDgrV0UsIT5YNwEnPisWAQEVEb0WJx4SAREeJxYAAAIAEgAAAQ0CqAADAAcALLsABwADAAQABCsAuAACL7gAAEVYuAAELxu5AAQABT5ZugAGAAQAAhESOTAxEyc3FwMRNxFDMdYlvFsB8zOCT/2nAbcf/ioAAAAC//QAAADvAqgAAwAHACy7AAcAAwAEAAQrALgAAS+4AABFWLgABC8buQAEAAU+WboABgAEAAEREjkwMQM3FwcDETcRDCXWMW5bAllPgjP+DQG3H/4qAAAAAv/LAAABNgKuAAUACQAsuwAJAAMABgAEKwC4AAMvuAAARVi4AAYvG7kABgAFPlm6AAgABgADERI5MDETByc3FwcDETcRfIkosboutlwCRE85gIA5/gsBtx/+KgAD/9n//gESAnQADAAZAB0ArrsAFgAEABAABCu7AAkABAADAAQrQQUASgADAFoAAwACXUEJAAkAAwAZAAMAKQADADkAAwAEXUEJAAYAFgAWABYAJgAWADYAFgAEXUEFAEUAFgBVABYAAl24ABYQuAAa0LgAGi+4ABYQuQAdAAP0uAAJELgAH9wAuAAGL7gAEy+4AABFWLgAGi8buQAaAAU+WbgAExC5AA0AAfS4AADQuAAAL7oAHAAaAAYREjkwMRMiJjU0NjMyFhcUBiMHIiY1NDYzMhYXFAYjExE3EdYaIyIaGiIBIxnAGSQiGRokASMaN1wB9yQaGiUlGhkkAiQaGiUlGhkk/gcBtx/+KgAAAAIAMgAAAaECZQAYAC8AfbgAMC+4ABkvuAAwELgAItC4ACIvuAAZELkALwAD9LoAAAAiAC8REjm4ACIQuQAhAAP0uAAvELgAMdwAuAAML7gAFC+4AABFWLgAGS8buQAZAAU+WbgAAEVYuAAhLxu5ACEABT5ZuAAMELkABQAB9LkAEQAC9LkAAAAB9DAxASIuAiMiBgcnNjY3Mh4CMzI2NxcGBiMTETQmBwYGBxEjETY2NzY2Fx4DFREBGhEcGRkOExkXJh42JhEcGRkOExkXJh43JiszLBktEF0fNyMbSCkVJh0SAfUKDQoPEzUfGwEKDQoPEzYfG/4LATEtLwEBEQr+kAGEFyAKCAgJBRQdKBj+qgAAAAMAHv/3Ab0CqAADABgALQDsuAAuL7gAKC+4AC4QuAAJ0LgACS9BBQBKACgAWgAoAAJdQQkACQAoABkAKAApACgAOQAoAARduAAoELkAEwAD9LoAGQAJABMREjm4AAkQuQAeAAP0QQkABgAeABYAHgAmAB4ANgAeAARdQQUARQAeAFUAHgACXbgAExC4AC/cALgAAi+4AABFWLgAGC8buQAYAAU+WbsADgABABkABCu4ABgQuQAjAAL0QRkABwAjABcAIwAnACMANwAjAEcAIwBXACMAZwAjAHcAIwCHACMAlwAjAKcAIwC3ACMADF1BBQDGACMA1gAjAAJdMDETJzcXAyIuAjU0PgIXMh4CFRQOAiMTDgMVFB4CMzI+AjU0LgInoTHYJoI1TTMZHDZNMTFNNRwZNE81ASEqGQkLGiofISoYCQsaKh8B8zOCT/2eKkVYLi1UPyYBJj9SLS5ZRSkBkwIdLDgdIEAzHyAyQCAdNy0cAgAAAAADAB7/9wG9AqgAAwAYAC0A7LgALi+4ACgvuAAuELgACdC4AAkvuQAeAAP0QQkABgAeABYAHgAmAB4ANgAeAARdQQUARQAeAFUAHgACXbgAANC4AAAvQQUASgAoAFoAKAACXUEJAAkAKAAZACgAKQAoADkAKAAEXbgAKBC5ABMAA/S6ABkACQATERI5uAAv3AC4AAEvuAAARVi4ABgvG7kAGAAFPlm7AA4AAQAZAAQruAAYELkAIwAC9EEZAAcAIwAXACMAJwAjADcAIwBHACMAVwAjAGcAIwB3ACMAhwAjAJcAIwCnACMAtwAjAAxdQQUAxgAjANYAIwACXTAxEzcXBwMiLgI1ND4CFzIeAhUUDgIjEw4DFRQeAjMyPgI1NC4CJ3km2DFaNU0zGRw2TTExTTUcGTRPNQEhKhkJCxoqHyEqGAkLGiofAllPgjP+BCpFWC4tVD8mASY/Ui0uWUUpAZMCHSw4HSBAMx8gMkAgHTctHAIAAAAAAwAe//cBvQKuAAUAGgAvAOy4ADAvuAAqL7gAMBC4AAvQuAALL0EFAEoAKgBaACoAAl1BCQAJACoAGQAqACkAKgA5ACoABF24ACoQuQAVAAP0ugAbAAsAFRESObgACxC5ACAAA/RBCQAGACAAFgAgACYAIAA2ACAABF1BBQBFACAAVQAgAAJduAAVELgAMdwAuAADL7gAAEVYuAAaLxu5ABoABT5ZuwAQAAEAGwAEK7gAGhC5ACUAAvRBGQAHACUAFwAlACcAJQA3ACUARwAlAFcAJQBnACUAdwAlAIcAJQCXACUApwAlALcAJQAMXUEFAMYAJQDWACUAAl0wMRMHJzcXBwMiLgI1ND4CMzIeAhUUDgIjEw4DFRQeAjMyPgI1NC4CJ/CJKLG6LZE1TTMZHDZNMTFNNRwZNE81ASEqGQkLGiofISoYCQsaKh8CRE85gIA5/gIqRVguLVRAJSY/Uy0uWUUpAZMCHSw4HSBAMx8gMkAgHTctHAIAAAAEAB7/9wG9AnQADAAYACwAQQEwuwAyAAMAHgAEK7sACQAEAAMABCtBBQBKAAMAWgADAAJdQQkACQADABkAAwApAAMAOQADAARdQQkABgAyABYAMgAmADIANgAyAARdQQUARQAyAFUAMgACXboAEwAeADIREjm4ABMvuQANAAT0ugA8AAMACRESObgAPC9BBQBKADwAWgA8AAJdQQkACQA8ABkAPAApADwAOQA8AARduQAoAAP0ugAtAB4AKBESObgAQ9wAuAAGL7gAFi+4AABFWLgAGS8buQAZAAU+WbsAIwABAC0ABCu4ABYQuQAQAAH0uAAA0LgAGRC5ADcAAvRBGQAHADcAFwA3ACcANwA3ADcARwA3AFcANwBnADcAdwA3AIcANwCXADcApwA3ALcANwAMXUEFAMYANwDWADcAAl0wMQEiJjU0NjMyFhUUBiMnFAYjIiY3NDYzMhYTIi4CNTQ+AjMyHgIVFA4CAw4DFRQeAjMyPgI1NC4CJwFOGiMiGhojIxmEIxoZJAEiGRokIjVNMxkcNk0xMU01HBk0TzQhKhkJCxoqHyEqGAkLGiofAfckGholJRoZJDwZJCMaGiUl/akqRFcuLVRAJSY/Uy0uWEUpAZICHSs3HSBAMx8gMkAgHTctHAIAAAADAB7/+AG9AmUAFwArAEABBLgAQS+4ADsvuABBELgAHdC4AB0vQQUASgA7AFoAOwACXUEJAAkAOwAZADsAKQA7ADkAOwAEXbgAOxC5ACcAA/S6ACwAHQAnERI5uAAdELkAMQAD9EEJAAYAMQAWADEAJgAxADYAMQAEXUEFAEUAMQBVADEAAl24ACcQuABC3AC4AA8vuAAXL7gAAEVYuAAYLxu5ABgABT5ZuwAUAAIACAAEK7sAIgABACwABCu4ABQQuQADAAH0uAAYELkANgAC9EEZAAcANgAXADYAJwA2ADcANgBHADYAVwA2AGcANgB3ADYAhwA2AJcANgCnADYAtwA2AAxdQQUAxgA2ANYANgACXTAxAQYGIyIuAiMiBgcnNjY3Mh4CMzI2NwMiLgI1ND4CMzIeAhUUDgIDDgMVFB4CMzI+AjU0LgInAZoeNiYRHBkZDhMZFyYeNiYRHBkZDhMZF4g1TTMZHDZNMTFNNRwZNE80ISoZCQsaKh8hKhgJCxoqHwIvHxsKDQoPEzUfGwEKDQoPE/2TKkRXLi1UQCUmQFMtLldFKQGSAh0rNx0gQDMfIDJAIB03LRwCAAAAAgAy//gBqAKoAAMAFwCauAAYL7gABC+4ABgQuAAO0LgADi+5ABEAA/S4AADQuAAAL7gABBC5AAUAA/S4ABncALgAAi+4AABFWLgACS8buQAJAAU+WboAEAAJAAIREjm5ABQAAfRBGQAHABQAFwAUACcAFAA3ABQARwAUAFcAFABnABQAdwAUAIcAFACXABQApwAUALcAFAAMXUEFAMYAFADWABQAAl0wMRMnNxcHMxEGBiMiLgI1ETcRFBY3NjY3ljHYJhhdMW1CGjUrHF84LBksEQHzM4JPj/57JCkQITMkATcf/sItMAEBEgsAAAAAAgAy//gBqAKoAAMAFwCauAAYL7gABC+4ABgQuAAO0LgADi+5ABEAA/S4AAHQuAABL7gABBC5AAUAA/S4ABncALgAAS+4AABFWLgACS8buQAJAAU+WboAEAAJAAEREjm5ABQAAfRBGQAHABQAFwAUACcAFAA3ABQARwAUAFcAFABnABQAdwAUAIcAFACXABQApwAUALcAFAAMXUEFAMYAFADWABQAAl0wMRM3FwcXMxEGBiMiLgI1ETcRFBY3NjY3ZybYMRddMW1CGjUrHF84LBksEQJZT4IzKf57JCkQITMkATcf/sItMAEBEgsAAAAAAgAy//gBqAKuAAUAGQCWuAAaL7gABi+5AAcAA/S4AATQuAAaELgAENC4ABAvuQATAAP0uAAHELgAG9wAuAADL7gAAEVYuAALLxu5AAsABT5ZugASAAsAAxESObkAFgAB9EEZAAcAFgAXABYAJwAWADcAFgBHABYAVwAWAGcAFgB3ABYAhwAWAJcAFgCnABYAtwAWAAxdQQUAxgAWANYAFgACXTAxEwcnNxcHBzMRBgYjIi4CNRE3ERQWNzY2N+6JJ7C6LTBdMW1CGjUrHF84LBksEQJETzmAgDkr/nskKRAhMyQBNx/+wi0wAQESCwAAAwAy//cBqAJ0AAwAGAAsAOK7ACYAAwAjAAQruwAJAAQAAwAEK0EFAEoAAwBaAAMAAl1BCQAJAAMAGQADACkAAwA5AAMABF26ABMAIwAmERI5uAATL7kADQAE9LoAGQADAAkREjm4ABkvuQAaAAP0uAAu3AC4AAYvuAAWL7gAAEVYuAAeLxu5AB4ABT5ZuAAWELkAEAAB9LgAANC6ACUAHgAGERI5uAAeELkAKQAB9EEZAAcAKQAXACkAJwApADcAKQBHACkAVwApAGcAKQB3ACkAhwApAJcAKQCnACkAtwApAAxdQQUAxgApANYAKQACXTAxASImNzQ2MzIWFRQGIycUBiMiJjU0NjMyFhczEQYGIyIuAjURNxEUFjc2NjcBURojASIaGiIjGYMjGhkkIhkaJH5dMW1CGjUrHF84LBksEQH3JBoaJSUaGSQ8GSQjGholJYb+fCQpECEzJAE2H/7DLTABARELAAAAAAEALf9yAf4CugALAEm7AAsAAwAAAAQruAAAELgABNC4AAsQuAAG0AC4AAUvuAAAL7sABAABAAEABCu4AAQQuAAH0LoACAAAAAUREjm4AAEQuAAJ0DAxFxEjNTM1MxUzByMR2q2tXMgkpI4CLUnS0kn98wAAAgAyAf0A/QLLABMAIACLuAAhL7gAHS+4ACEQuAAF0LgABS9BBQBKAB0AWgAdAAJdQQkACQAdABkAHQApAB0AOQAdAARduAAdELkADwAD9LgABRC5ABcAA/RBCQAGABcAFgAXACYAFwA2ABcABF1BBQBFABcAVQAXAAJduAAPELgAItwAuwAaAAIAAAAEK7sACgACABQABCswMRMiLgI1ND4CMzIeAhUUDgInIgYVFBYzNjY1NCYjlxUlGxAQHCUVFSUbEBAcJRMTGhoRERoYEQH9EB0mFRUlHBAQHSUVFSUdEJMbEhEZARgREhoAAAAAAQAe/54BggIxACcAZbgAKC+4AAsvuAAA0LgAKBC4AAbQuAAGL7gACxC5AA4AA/S4AAYQuQAaAAP0QQkABgAaABYAGgAmABoANgAaAARdQQUARQAaAFUAGgACXbgADhC4ACbQuAAmLwC4AA0vuAAALzAxFzUuAzU0PgI3NTcHFhYXByYmBw4DFRQeAjMWNjcXBgYHFbsmOigVEyc7KFIBFzAbHh03GBknGw0PHCobIzkfGx04IGJaByxATCYmTUIwCkkcYwQSETgOEAIBIDE9Hx05Lh0BGA84ExgFPwAAAAABACj//wIeAuEAHQB8uwAbAAMAAgAEK7gAAhC4AAbQuAAbELgAFtAAuAAKL7gAAEVYuAAFLxu5AAUABz5ZuAAARVi4ABcvG7kAFwAHPlm4AABFWLgAAC8buQAAAAU+WbkAAQAB9LgAFxC5AAMAAfS4AATQuAAZ0LgAGtC4AAEQuAAb0LgAHNAwMRc1MzUjNTM1NDYzMhYXByYmJyYOAhUVMwcjFTMXKKSNjWxcGSYcFg8WByw0Gwi9HaDVHwFc2ltxc20LDEIFCAIGFiw5HXVb2lwAAAIAMv/1Aa0CogBGAF4A3rsATQADACEABCu7AAMAAwAUAAQrQQUASgAUAFoAFAACXUEJAAkAFAAZABQAKQAUADkAFAAEXbgAFBC5AEEABPRBCQAGAE0AFgBNACYATQA2AE0ABF1BBQBFAE0AVQBNAAJdugBeABQAAxESObgAAxC4AGDcALgAAEVYuAAILxu5AAgABT5ZuwAtAAEANAAEK7gACBC5AA8AAfRBGQAHAA8AFwAPACcADwA3AA8ARwAPAFcADwBnAA8AdwAPAIcADwCXAA8ApwAPALcADwAMXUEFAMYADwDWAA8AAl0wMSUWFhUUDgIjIiYnNxYWMzI+AjU0LgInJiYnLgM1ND4CNyY1ND4CMzIWFwcmJiMiBgcUFxYWFx4DFRQOAgcnJiYnBgYVFBYXFhYXFhYXNjY1JiYnJicBaQoNIjRBHyhNIyYbOxsRIRkODRIWCgoUCxcsIxYLExcMExwuOR4jQyUkHy4XHSwBHhApFBctIxUNExkMLh03IBYXDw4RLBILDQgZEwIGAwQE0g8nFSY4JBAeGz4XFQgPGBANEg0IBAQIBAkTHSofFiokHQkbKCI1IxIXFj8SDx0aGQ0IEQgJFR4pHhYpIhsJoxESCg0uEg4RBwgRBwUEAg4uFAgPBQYFAAEAPACgAXIB1QATAAsAuAAPL7gABS8wMQEUDgIjIi4CNTQ+AjMyHgIBchgqOSAgOSoYGCo5ICA5KhgBOyA5KhgYKjkgIDgqGBgqOAABAB7/igG3AoUAGABLuAAZL7gAAC+4ABkQuAAE0LgABC+5AAMAA/S4AAQQuAAP0LgADy+4AAAQuQAYAAP0uAAa3AC4AA8vuAAVL7gAFy+4AAMvuAAYLzAxBREjEScRLgM1ND4CNwc+AzM2MxEBWzZcJD4uGxsxQSUHARYiKxY0QFYCmf1HIAFtAh4yQCUlQjEdAQcBAwECAf0FAAABABT/ewIRAokARQBjuABGL7gACS9BBQBKAAkAWgAJAAJdQQkACQAJABkACQApAAkAOQAJAARduABGELgAI9C4ACMvuQAiAAP0uAAjELgAJ9C4AAkQuQBAAAP0uABH3AC4ACMvuwAnAAEAJAAEKzAxBQYmJzcWNzY2NTQuAicmJicmNjc+AiYnJiYGBgcGBhURBxEjNTM1NDY3PgIWMx4DFQYHBgYHBhYXFhYXFA4CBwFLIj8iIDAgNjwEDhwYJicDAxgXEhUCERQJGxsYBhcRXE9PHiIZMikcAhw1KRgCCAcdGxQDGz9JASA3SCcGBAoMQhIECEMxDRwaFwgMJB0XLQ4LIiMfCQQCAwQCCCkb/bQfAfhFLipFFA8NBAICECA0JhYUESYNChMIEU5KK0UzHwQAAAQAMv/kAxQC7wATACcANwBCANi7ACMAAwAFAAQruwArAAMALAAEK7sAMwADADsABCu7AA8AAwAZAAQrQQUASgAZAFoAGQACXUEHABkAGQApABkAOQAZAANdQQMACQAZAAFdQQkABgAjABYAIwAmACMANgAjAARdQQUARQAjAFUAIwACXboANgAFAA8REjm6ADcABQAPERI5QQUASgA7AFoAOwACXUEJAAkAOwAZADsAKQA7ADkAOwAEXbgAKxC4AEHQuAAPELgARNwAuwAUAAIAAAAEK7sACgACAB4ABCu7AC4AAgBAAAQrMDEFIi4CNTQ+AjMyHgIVFA4CJzI+AjU0LgIjIg4CFRQeAjcnIxUjETcyHgIVFAYHFwMWNjU0LgIjIxUBo06GZDk5ZIZOTYdkOTlkh00/ak0sLE1qPz9qTisrTmqTfhVPoR81JxdCM4GlIikMFBsPTBw9aY9RUY5pPT1pj1FRjmk9QjNYdkJCdlgzM1h1QkJ2WDRV3t4B8wEVJzMeNksH3wEbAS4hDhsVDZgAAwAy//EDFAL7ABQAKABLAQS7ACQAAwAFAAQruwAPAAMAGgAEK7sAQwADADIABCtBBQBKABoAWgAaAAJdQQkACQAaABkAGgApABoAOQAaAARdQQkABgAkABYAJAAmACQANgAkAARdQQUARQAkAFUAJAACXUEJAAYAQwAWAEMAJgBDADYAQwAEXUEFAEUAQwBVAEMAAl24AA8QuABN3AC4ABQvuAAARVi4AAAvG7kAAAAFPlm7AAoAAQAfAAQruwBIAAEALQAEK7gAABC5ABUAAfRBGQAHABUAFwAVACcAFQA3ABUARwAVAFcAFQBnABUAdwAVAIcAFQCXABUApwAVALcAFQAMXUEFAMYAFQDWABUAAl0wMQUiLgI1ND4CMzIeAhUUDgIjNTI+AjU0LgIjIg4CFRQeAjcGBiMnIi4CNTQ2NzY2FhYXByYmBw4DFRQeAjMyNjcBo06GZDk5ZIZOTYdkOTlkh008ZksqKktmPDxnSioqSmfcJ1QyAS1FLxkzMBg7P0EeHx03GBonGw8PHSsbIzogDj1pjlFRjmk8PWmOUVGOaT1PMVVxQEByVTExVXFAQXFVMX8ZGwEpQlIqP3QhEQ8CFRM4DhACASAxPR8dOS4dFw8AAAIAHgG+Ag0C4QAMABQAf7sAFAADAA0ABCu7AAUAAwAGAAQruwAMAAMAAAAEK7oACQANAAwREjm4AAwQuAAW3AC4AAgvuAAAL7gAAy+4AAUvuAANL7sAEAACAA8ABCu6AAEAAwAIERI5ugAEAAMACBESOboACQADAAgREjm4ABAQuAAK0LgADxC4ABLQMDEBNQcHJxUjETcXNzMRITUjNzMVIxUB1joqQC4xVUs4/mVUFsBLAcWZkg6blAEMEMW9/uznLS3nAAAAAQA8AfkBNwKoAAMAFQC4AAIvuAAAL7oAAQAAAAIREjkwMRMnNxdtMdYlAfkxfk0AAgA8Af0BdQJ0AAwAGQCNuAAaL7gAAy9BBQBKAAMAWgADAAJdQQkACQADABkAAwApAAMAOQADAARduQAJAAT0uAAaELgAENC4ABAvuQAWAAT0QQkABgAWABYAFgAmABYANgAWAARdQQUARQAWAFUAFgACXbgACRC4ABvcALgAAC+4AA0vuQATAAH0uAAG0LgADRC4AAzQuAAMLzAxASImNTQ2MzIWFRQGIwciJjU0NjMyFgcUBiMBORkjIhkaIyMYwhgkIxkaJAEjGQH+IhcZJCMZGCIBIhkZIyMZGCIAAAABADz//wJ6AlYAEwBMALgACy+4AABFWLgAAS8buQABAAU+WbsAEQABAAAABCu7AAoAAQAHAAQruAAAELgAA9C4ABEQuAAF0LgAChC4AA3QuAAHELgAD9AwMSUHJzcjNTM3IychNxcHMxUjBzMXAVlZSU2qzS/1JQE9UUpFjbEv2SW4uRmgSWNKqBiQSmNJAAACAAoAAAMHAoUADwASAHi7AA0AAwAAAAQruAANELgACNC4AAAQuAAQ0AC4AABFWLgACS8buQAJAAc+WbgAAEVYuAAALxu5AAAABT5ZuAAARVi4AAMvG7kAAwAFPlm7AAYAAQAHAAQruwASAAEAAQAEK7gACRC5AAsAAfS4AAAQuQANAAH0MDEhNSMHIwEhByMVMwcjFSEVAQczAZC1d1oBigFzJPbWJLIBDf6WjIzCwgKFR8BH8EcB7ecAAAMAHv9jAksDEgAfACsANwEruAA4L7gAKC+4ADgQuAAG0LgABi+5ADQAA/RBCQAGADQAFgA0ACYANAA2ADQABF1BBQBFADQAVQA0AAJduAAA0LgAAC9BBQBKACgAWgAoAAJdQQkACQAoABkAKAApACgAOQAoAARduAAoELkAFQAD9LoAKwAGABUREjm6ADcABgAVERI5uAA53AC4AA4vuAAfL7gAAEVYuAAbLxu5ABsABT5ZuAAARVi4AB4vG7kAHgAFPlm7AAsAAQAuAAQruAALELgADdC4AA0vuAAbELkAIwAB9EEZAAcAIwAXACMAJwAjADcAIwBHACMAVwAjAGcAIwB3ACMAhwAjAJcAIwCnACMAtwAjAAxdQQUAxgAjANYAIwACXboAKwAfAA4REjm6ADcAHwAOERI5MDEXNy4DNTQ+AjMyFzcXBx4DFRQOAiM1IiYnBzcWFjMyPgI1NCYnJyYjMyIOAhUUFheFLyU4JhMlR2dDHx0nVCoiMyMSI0doRQwYCy1EBgwHKUEtFx8eTRITAStCLBYlI4CaF0VSWSw8dlw4BoUdixY/S1QqO3ljPwECApjkAQEtSmAyNWglMwUsSFotP3QmAAABAB4AAAJVApQAHACmuwABAAMAAgAEK7gAAhC4AAbQugAOAAIAARESObgAARC4ABnQALgADS+4ABMvuAAARVi4AAovG7kACgAHPlm4AABFWLgAFS8buQAVAAc+WbgAAEVYuAABLxu5AAEABT5ZuwAaAAEAAAAEK7gAABC4AAPQuAAaELgABdC4ABUQuQAIAAH0uAAJ0LoACwABABMREjm6AA4AFQAIERI5uAAX0LgAGNAwMSUVIzUjNTM1JyMnMyc3EzY2NzY3FwczByMHFTMXAWBex8cMtSOyiFqcFDYYHB5Dh6MByBDSI7KyskUzFUXvIP7oJWAsMzUb9UUdK0UAAQAy/x0BqAHUABMAXrgAFC+4AAkvuAAUELgAAdC4AAEvuQADAAP0uAAJELkADAAD9LgAAxC4ABLQuAASL7gADBC4ABXcALgAAi+4AAAvuAAARVi4AA8vG7kADwAFPlm6ABIAAAACERI5MDEXETcRFBY3NjY3ETMRBgYjMyInFTJfOCwZLBFdMW1CAR4c4wKXIP7BLTACARELAXD+fCQpCeIAAAADACgA8gGMArkAHQAhACwA7bgALS+4ACIvuAAtELgABdC4AAUvuAAiELgACdC4AAkvuAAiELkAGQAD9LgABRC5ACYAA/RBCQAGACYAFgAmACYAJgA2ACYABF1BBQBFACYAVQAmAAJduAAZELgALtwAuAAARVi4ABovG7kAGgAHPlm4AABFWLgAKS8buQApAAc+WbsAHwABAB4ABCu7ABQAAgANAAQruwAJAAIAIgAEK7gAKRC5AAAAAvRBBQDJAAAA2QAAAAJdQRkACAAAABgAAAAoAAAAOAAAAEgAAABYAAAAaAAAAHgAAACIAAAAmAAAAKgAAAC4AAAADF0wMRMiLgI1NjYzMzU0JgciBgcnNjYzMh4CFRUGBiMHNSEXAyMiBhUUFhcyNje6GCofEgFHMk0kFxcmHRYlNiMVKiEVG04ykwE/JYE7HCEjGxMfCAFTEiArGDU7FBcdAQwOMhQODhsoGb8bImFISAEOHRkYJgEPBgADACgA8QGMArgAFAAYACwA8LgALS+4ACgvuAAtELgABdC4AAUvQQUASgAoAFoAKAACXUEJAAkAKAAZACgAKQAoADkAKAAEXbgAKBC5AA8AA/S4ABfQuAAXL7gABRC5AB4AA/RBCQAGAB4AFgAeACYAHgA2AB4ABF1BBQBFAB4AVQAeAAJduAAPELgALtwAuAAARVi4ACMvG7kAIwAHPlm7ABYAAQAVAAQruwAKAAIAGQAEK7gAIxC5AAAAAvRBBQDJAAAA2QAAAAJdQRkACAAAABgAAAAoAAAAOAAAAEgAAABYAAAAaAAAAHgAAACIAAAAmAAAAKgAAAC4AAAADF0wMRMiLgI1ND4CMzIeAhUUDgIjBzUhFwMOAxUUHgIzMj4CNTQuAs8pOycTFig7JiU7KBUTJzwopwFAJL0YHhEHCBMeFhgeEgYIEx4BUCA1QiMiPzEcHTBAIiNCNB9gSEgBjAIUICkWGC8lFhclLhgWKSAUAAADACj/9gKoAdAANwBCAE8BELsARwADABAABCu7AC8AAwBDAAQruwAuAAMAOAAEK7gAQxC4ABbQuAAWL7gALxC4AELQuABCL0EJAAYARwAWAEcAJgBHADYARwAEXUEFAEUARwBVAEcAAl24AC4QuABR3AC4ACMvuAApL7gAAEVYuAAaLxu5ABoABz5ZuAAARVi4AD0vG7kAPQAHPlm4AABFWLgACy8buQALAAU+WbsAOAACAC4ABCu4ADgQuAAV0LgAFS+4AAsQuQA0AAH0QRkABwA0ABcANAAnADQANwA0AEcANABXADQAZwA0AHcANACHADQAlwA0AKcANAC3ADQADF1BBQDGADQA1gA0AAJduAAuELgAQ9C4ADQQuABM0DAxJQYGBwYGJiYnBgYnLgM1PgMzMzU0JiMiBgcnPgMzMhYXNjYzMh4CFyEGHgI3NjY3Jy4DIyIOAgcHIyIGBxQeAjMyNjcCqBcoFx08OzUVIFs5HzgpGAEZLDohazIhHzQkGhcoJicXJEQXFj0pMUMqFAH+9gISIS0aIzclSwELFR0TFR8VDAJpVCYwAQ0YIBMbLQstDxQGCAYJGhcZIAEBGCk3ICI2JhQeICkQEjwMEQoFHR0ZHSE+VzcnPSsWAQEVEbwWJx4SER4nFkAoIxEfGA8VCQAAAAADAB7/vgG9AggAHQAnADIA6bgAMy+4ACQvuAAzELgABtC4AAYvuQAvAAP0QQkABgAvABYALwAmAC8ANgAvAARdQQUARQAvAFUALwACXbgAAdC4AAEvQQUASgAkAFoAJAACXUEJAAkAJAAZACQAKQAkADkAJAAEXbgAJBC4ABDQuAAQL7gAJBC5ABMAA/S6AB4ABgATERI5ugAnAAYAExESOboAMgAGABMREjm4ADTcALgADi+4AB0vuAAARVi4ABgvG7kAGAAFPlm4AABFWLgAHC8buQAcAAU+WbsACwABACoABCu4ABgQuQAeAAL0ugAyAB0ADhESOTAxFzcuAzU0PgIzMhc3FwcWFhUUDgIjMyImJwc3MzI+AjU0JicnJiMiDgIVFBYXdBIcKBkLHDZNMQ8OEUoRNjIaNE80AQgOCBImDCEqGAgNEUQEBx8pGQoNEio8ETE6Ph4tVD8nAzoZOiBvPC5YRCkBATt7ITM/Hh8/GCkBHC05HSFIHAAAAAACACj/8gG3AtQACwAtAHm7AAAABAAGAAQrQQUASgAGAFoABgACXUEJAAkABgAZAAYAKQAGADkABgAEXboAHwAGAAAREjm4AB8vugAhAAYAABESObkAIgAD9AC4AABFWLgAGS8buQAZAAc+WbgAAEVYuAAcLxu5ABwABz5ZuwAJAAEAAwAEKzAxARQGIyImNTQ2MzIWEwYGJy4DJzQ+AjcjNjc2Njc1NxUjIg4CFhYXFjY3AVsjGhojIxoaI1wsZDsnRjYgARYmMRsBBgkIGBFdOCY3IAYVMSgmSR8ClxojIxoaIyP9iCAnBgQeM0gvKkAvIAsBAwIFAmwg2CQ3QjsrBgUcGAAAAAACAEb//wDAAtYADAAQAGi7AAwABAAGAAQrQQkABgAMABYADAAmAAwANgAMAARdQQUARQAMAFUADAACXboADQAGAAwREjm4AA0vugAOAAYADBESObkAEAAD9AC4AABFWLgADS8buQANAAU+WbsACQABAAMABCswMRMUBiciJjU0NhcyFhUDERcRwCMaGiMjGhojaFQCmBojASMaGiMBIxn9ZgIjH/38AAABAAr/cAG4As4AFQAlALgAAC+4AAgvuwAEAAEAAQAEK7gABBC4ABHQuAABELgAE9AwMRcTIzUzNzY2FzIWFwcmDgIHMwcjAwplLDoIF39bERwVIjZDJxQHYQFuX5ACDkgpdGsBBgg+Dxs7TyVI/hIAAQAUAAACSwLOAC4Ap7gALy+4ABovuAAA0LgAAC+4AC8QuAAE0LgABC+5AAMAA/S4AAQQuAAI0LgAAxC4ABXQuAAVL7gAAxC4ABjQuAAYL7gAGhC5ACkAA/S4AC3QALgADC+4AB8vuAAARVi4AAAvG7kAAAAFPlm4AABFWLgAAy8buQADAAU+WbsAGQABAAEABCu4AAEQuAAF0LgAGRC4AAfQuAAZELgAKtC4AAEQuAAs0DAxIREjESMRIzUzNTQ2FzIWFwcmDgIHBhQHMycmPgIzMhYXBwcmDgIVFTMVIxEBQKBeLi5tXBEdFBYqNyEQAwIBoQECHTVLLhEdFRYBMDshC2VlAX7+ggF+SCd0bQEGBz8KBx81IhIlESc6VTcaBgc/AQwOKj8kK0j+ggAAAAIAMgAwAdQCIgAFAAsALQC4AAAvuAAGL7gAAEVYuAACLxu5AAIACT5ZuAAARVi4AAgvG7kACAAJPlkwMSUnNxcHFwcnNxcHFwGLrq5Ji4vzr69JjIww+fkvysov+fkvysoAAAACADIAMAHUAiIABQALAC0AuAAFL7gACy+4AABFWLgAAy8buQADAAk+WbgAAEVYuAAJLxu5AAkACT5ZMDE3Nyc3FwcnNyc3Fwfdi4tJrq70jIxKrq5fysov+fkvysov+fkAAAAAAwA7//cCcgBtAAsAFwAjAPa4ACQvuAAGL0EFAEoABgBaAAYAAl1BCQAJAAYAGQAGACkABgA5AAYABF25AAAABPS4ACQQuAAS0LgAEi+5AAwABPRBCQAGAAwAFgAMACYADAA2AAwABF1BBQBFAAwAVQAMAAJduAAAELgAJdwAuAAARVi4AAMvG7kAAwAFPlm4AABFWLgADy8buQAPAAU+WbgAAEVYuAAbLxu5ABsABT5ZuAADELkACQAB9EEZAAcACQAXAAkAJwAJADcACQBHAAkAVwAJAGcACQB3AAkAhwAJAJcACQCnAAkAtwAJAAxdQQUAxgAJANYACQACXbgAFdC4ACHQMDElFAYjIiY1NDYzMhYHFAYjIiY1NDYzMhYHFAYjIiY1JjYzMhYCciMZGiMiGhoj3iMZGiMiGhoj3iMZGiQBJBoaIzEYIiIYGSMjGRgiIhgZIyMZGCIiGBkjIwAAAAADAAoAAAIkA1oAAwALAA4AMwC4AAEvuAAARVi4AAQvG7kABAAFPlm4AABFWLgABy8buQAHAAU+WbsADgABAAUABCswMRM3FwcTJyMHIxM3EwEHM5Im2TJiQuFHTehV3f7wXLEDC0+CM/1bwsICexr9awIE/QAAAAADAAoAAAIkAxcAGAAgACMAUQC4AAwvuAAUL7gAAEVYuAAZLxu5ABkABT5ZuAAARVi4ABwvG7kAHAAFPlm7ACMAAQAaAAQrugAAABkAFBESObgADBC5AAUAAfS5ABEAAvQwMQEiLgIjIgYHJzY2MzIeAjMyNjcXBgYjEycjByMTNxMBBzMBWREcGRkPExkXJx82JhEcGRkPExkXJx83JmlC4UdN6FXd/vBcsQKnCgwKDxM2HxsKDAoPEzYfG/1ZwsICehv9awIE/QAAAAADAB7/9wJLAxcAFwAsAEEBDrgAQi+4ADwvQQUASgA8AFoAPAACXUEJAAkAPAAZADwAKQA8ADkAPAAEXbgAANC4AAAvuABCELgAHdC4AB0vuQAyAAP0QQkABgAyABYAMgAmADIANgAyAARdQQUARQAyAFUAMgACXbgADNC4AAwvuAA8ELkAJwAD9LoALQAdACcREjm4AEPcALgADy+4ABcvuAAARVi4ACwvG7kALAAFPlm7ACIAAQBBAAQruAAPELkACAAB9LkAFAAC9LkAAwAB9LgALBC5ADcAAfRBGQAHADcAFwA3ACcANwA3ADcARwA3AFcANwBnADcAdwA3AIcANwCXADcApwA3ALcANwAMXUEFAMYANwDWADcAAl0wMQEGBiMiLgIjIgYHJzY2MzIeAjMyNjcDIi4CNTQ+AjMyHgIVFA4CIxMiDgIVFB4CMzI+AjU0LgIjAd8fNiYRHBkZDxMZFyYfNiYRHBkZDxMZFoRFaEYjJUdnQ0NoRyUjR2hFAStCLBYXLUEqKUEtFxYsQisC4R8bCgwKDxM2HxsKDAoPE/zhP2J5Ozx2XDk4XXY9O3liPwJRLEhZLTJfSi0tSl8yLVlILAACABwAAAMBAoUAHgAoALK7ABcAAwAfAAQrugAMAB8AFxESOboADgAfABcREjm4ABcQuAAb0AC4AAsvuAANL7gAEy+4ABUvuAAARVi4ABgvG7kAGAAHPlm4AABFWLgAAS8buQABAAU+WbgAAEVYuAAeLxu5AB4ABT5ZuwAMAAEAHwAEK7gADBC4AA7QuAAOL7gAHxC4ABbQuAAWL7gAGBC5ABoAAfS4AAEQuQAcAAH0uAAd0LgAHS+4ACfQuAAo0DAxJSMiLgI3PgMzMwcXMj4CMzYzByMVMwcjFSEVASMiBgYeAjMzAaaGQGJBIQIBIkFjQn8FAQ8uNzwdRU0k9tclsgEN/pdXOUkjAyVGM1sBP2J1NThwWTgEAQECAQFHwEfwRwI5SW1/bUkAAAADAB7/9wLVAdAALAA3AEsBXbsAPQADAA8ABCu7ACMAAwBHAAQruwAfAAMALQAEK7oAAAAtAB8REjlBBQBKAEcAWgBHAAJdQQkACQBHABkARwApAEcAOQBHAARdugAHAEcAIxESOboAFwBHACMREjm4ACMQuAAg0LgAIC+4ACMQuAA30LgANy9BCQAGAD0AFgA9ACYAPQA2AD0ABF1BBQBFAD0AVQA9AAJduAAfELgATdwAuAAUL7gAGi+4AABFWLgAFy8buQAXAAc+WbgAAEVYuAAyLxu5ADIABz5ZuAAARVi4ADgvG7kAOAAHPlm4AABFWLgACi8buQAKAAU+WbsALQACAB8ABCu4AAoQuQAmAAL0QRkABwAmABcAJgAnACYANwAmAEcAJgBXACYAZwAmAHcAJgCHACYAlwAmAKcAJgC3ACYADF1BBQDGACYA1gAmAAJdugAAAAoAJhESOboABwAKABQREjm4AELQMDElBgYmJicmJwYGIyIuAjU0PgIzMhYXNjYzMh4CFyEUBgcWFjc2NjcXBgcDLgMjIg4CBycOAxUUHgIzPgM1NC4CAnkYNzYzFRIOGk81NU8zGRw2TjIzThsWQy8xQyoUAf74AQEFQjAkPCYbMSwOAQsVHRMVHxUMAtMhKhkJCxorHyIqGAgLGioEBwYEEhIPFCIoKkRXLi1TPyYoIiAmIT5XNwcNBkJJAgEUEjQgCwEaFiceEhEeJxZqAh0rNx0gPzMfAR8yPiAdNy0cAAAAAAEAPADsAl0BLwADAA0AuwABAAIAAAAEKzAxNzUhFzwB+ybsQ0MAAAABADwA7AMRATAAAwANALsAAQABAAAABCswMTc1IRc8Aq8m7EREAAAAAgA7AbQBRwKMABYALgA1ALgACC+4AB0vuAAWL7gAKy+4AABFWLgAAi8buQACAAk+WbgAAEVYuAAXLxu5ABcACT5ZMDEBBgcWFhUUBiMiJicmNTQ2NzY2NzY2NwcWFhUUBiMiJicmNTQ2NzY2NzY2NxcGBwFHJgoUGyEaGCICAQECBhgPCRISphQbIRoYIgMBAQIGGA8JEhIdJQwCZRofBSAVGSUgFwgKCBIIFyQRCQ0LYAUgFRklIBcICggSCBckEQkNCycZIAACADwBsAFHAogAFQAsABMAuAAIL7gAHy+4ABUvuAAsLzAxEzY3JiY1NDYzMhYXFhUUBwYGBwYGByc2NyMmJjU2NjMyFhcWFRQHBgYHBgYHziULFBshGhgiAgEDBhgPCRISriULARQaASAaGCICAQMGGA8JEhIB1xkgBSAVGSUgFwoJEg8XJBEJDQsnGSAFIBUZJSAXCgkSDxckEQkNCwAAAQA7AbQAsAKMABcAHAC4AAYvuAAUL7gAAEVYuAAALxu5AAAACT5ZMDETFhYVFAYjIiYnJjU0Njc2Njc2NjcXBgeDFBkgGhchAgEBAgYXEAgRERsjCwIsBSAVGSUgFwgKCBIIFyQRCQ0LJxkgAAAAAAEAPAGwALECiAAWAAsAuAAJL7gAFi8wMRM2NyMmJjU0NjMyFhcWFRQHBgYHBgYHPCMLARQZIBoXIQIBAwYXEAgREQHXGSAFIBUZJSAXCgkSDxckEQkNCwACABQAAAK1As4ACwA8ANK7ACoAAwAZAAQruwAPAAMAEAAEK7sAOwADAAYABCu4ADsQuQAMAAP0uAAqELgAEtC4ABkQuAAU0LgAFC+4ACoQuAAn0LgAJy+4ABAQuAAr0LgADxC4ADjQuAA7ELgAPtwAuAAeL7gALy+4AABFWLgADC8buQAMAAU+WbgAAEVYuAAPLxu5AA8ABT5ZuAAARVi4ABMvG7kAEwAFPlm7AAkAAQADAAQruwA6AAEADQAEK7gADRC4ABHQuAANELgAFdC4ADoQuAAX0LgAOhC4ACrQMDEBFAYjIiY1NDYzMhYDESMRIxEjESMRIzUzJyY+AjMyFhcHJg4CBwYUFTM1NDYXMhYXByYOAhUVMzcRArUiGBgiIhgYImewXqBdLy8BAh01Sy4RHRUWKjciEAMCoG1cER0VFzA7IQu5UwJTGCIiGBgiIv2VAX7+ggF+/oIBfkgnOlU3GgYHPwoHHzUiEiURJ3RtAQYHQAwOKj8kKw7+LAACABT/8gMTAs4ACQA4AMa7AAwAAwATAAQruwA4AAMACgAEK7sABgADAAMABCu4ABMQuAAO0LgADi+4AAwQuAAh0LgAIS+4AAwQuAAk0LgAJC+4AAoQuAAl0LgAOBC4ADPQuAAGELgAOtwAuAAFL7gAGC+4ACkvuAAARVi4AAAvG7kAAAAFPlm4AABFWLgACi8buQAKAAU+WbgAAEVYuAANLxu5AA0ABT5ZuwAlAAEACwAEK7gACxC4AA/QuAAlELgAEdC4ACUQuAA00LgACxC4ADbQMDEFBiY1ETcRFBYXBREjESMRIzUzJyY+AjMyFhcHJg4CBwYUFTM1NDYXMhYXBwcmDgIVFTMVIxEDE1NbXCUs/i+gXi8vAQIdNUwuER0UFio3IhADAqFtXBEdFRYBMDshC2RkBghAPwI9Hf2nJRgBNAF+/oIBfkgoOlU2GgYHPwoHHzUiEiURJ3RtAQYHPwEMDio/JCtI/oIAAwA8/x0BugJ0AAsAFwA/AQC7ACwAAwApAAQruwAJAAQAAwAEK0EFAEoAAwBaAAMAAl1BCQAJAAMAGQADACkAAwA5AAMABF26AA8AKQAsERI5uAAPL7kAFQAE9LoAMgADAAkREjm4ADIvuAAg0LgAIC+6ACEAAwAJERI5uAAyELkANQAD9LgAQdwAuAA/L7gAAEVYuAAkLxu5ACQABT5ZuwAGAAEAAAAEK7gAABC4AAzQuAAGELgAEtC4ACQQuQAvAAH0QRkABwAvABcALwAnAC8ANwAvAEcALwBXAC8AZwAvAHcALwCHAC8AlwAvAKcALwC3AC8ADF1BBQDGAC8A1gAvAAJdugAhACQALxESOTAxASImNzQ2MzIWFRQGIyImNTQ2MzIWFxQGAz4DNzY2NTcGBiMiLgI1ETcRFBY3MjY3ETMRFA4CBw4DBwFaGiMBIhoaIiPZGSQiGRokASMJFDEwKAsKAwEjRSgaNCwbXjcsGTQSXgIFCgkPND9EHwH3JBoaJSYaGSQkGholJRoaJP1nAwcOGBUTQRkBDg0SJDMhATUg/sItLgEXCwFn/m0TLjAsEBwnGQwBAAAAAwAU//4B6AMjAAwAGQAmAKC7ABYABAAQAAQrQQkABgAWABYAFgAmABYANgAWAARdQQUARQAWAFUAFgACXboAGgAQABYREjm4ABovuQAmAAP0uAAD0LgAAy+4ACYQuQAJAAT0ugAeABoAJhESObgAAxC4ACXQuAAlLwC4AAYvuAATL7gAAEVYuAAaLxu5ABoABT5ZuAATELkADQAB9LgAANC4AAAvugAeABoABhESOTAxASImNTQ2MzIWFRQGIwciJjU0NjMyFhUUBiMTEQM3EzY2NzY3FwMRAWIaIyIaGiMjGcEZJCIaGiQjGi26WpwUNRgcHkO9AqYkGholJRoZJAIkGholJRkaJP1YASoBSyD+5yVgLDM1G/6o/t4AAAAAAf/s/2UCFwMPAAMACwC4AAEvuAADLzAxBwEXARQB2lH+JX4DjRz8cgAAAAABADIAMAEmAiIABQAYALgAAC+4AABFWLgAAi8buQACAAk+WTAxNyc3FwcX3aurSYqKMPn5L8rKAAEAMgAwASYCIgAFABgAuAAFL7gAAEVYuAADLxu5AAMACT5ZMDE3Nyc3FwcyiYlIrKxfysov+fkAAgAUAAABtQLOAAsAJQDNuwAPAAMAEAAEK7sAAAAEAAYABCtBBQBKAAYAWgAGAAJdQQkACQAGABkABgApAAYAOQAGAARdugAMAAYAABESObgADC+4ABAQuAAU0LgADxC4ACHQuAAMELkAJQAD9AC4ABgvuAAARVi4AA0vG7kADQAHPlm4AABFWLgAES8buQARAAc+WbgAAEVYuAAMLxu5AAwABT5ZuAAARVi4AA8vG7kADwAFPlm7AAkAAQADAAQruAANELgAEtC4ABIvuAANELkAIwAB9LgAE9AwMQEUBiMiJjU0NjMyFgMRIxEjESM1MzU0NhcyFhcHJg4CFRUzNxEBtSIYGCIiFxgiZ65dLi5sWxEdFRcvOyELuFICUxgiIhgYIiL9lQF+/oIBf0cndG0BBgdADA4qPyQrDv4sAAACABT/8gISAs4ACQAhAHu4ACIvuAADL7kABgAD9LgAIhC4AArQuAAKL7gADtC4AAoQuQAhAAP0uAAc0LgABhC4ACPcALgABS+4ABIvuAAARVi4AAAvG7kAAAAFPlm4AABFWLgACi8buQAKAAU+WbsADgABAAsABCu4AA4QuAAd0LgACxC4AB/QMDEFBiY1ETcRFBYXBREjNTM3NjYXMhYXBxUmDgIVFTMVIxECEVJaXCUs/jAuLgEDaVsRHRUWMDshC2NjBghAPwI9Hf2nJRgBNAF+SCh0bAEGBz8BDA4qPyQrSP6CAAAAAQAo/3IB+QK6ABMAfbsAEwADAAAABCu4AAAQuAAE0LgAABC4AAjQuAATELgACtC4ABMQuAAO0AC4AAAvuAAJL7sACAABAAUABCu7AAQAAQABAAQruAAIELgAC9C6AAwAAAAJERI5uAAFELgADdC4AAQQuAAP0LoAEAAAAAkREjm4AAEQuAAR0DAxFxEjNTM1IzUzNTMVMwcjFTMHIxHVra2trVzIJKTIJKSOAVFJk0nS0kmTSf7PAAEAPADWALABTQAMAEG7AAkABAADAAQrQQkABgAJABYACQAmAAkANgAJAARdQQUARQAJAFUACQACXboAAAADAAkREjkAuAAGL7gAAC8wMTciJjU0NjcyFhcUBiN3GSIgGRkhASIY1iIYGCQBJBkYIgABADz/mwCxAHMAFgAcALgACS+4ABYvuAAARVi4AAIvG7kAAgAFPlkwMRc2NyMmJjU2NjMyFhcWFRQHBgYHBgYHPCMLARQYAR8ZFyECAQMGFxAIERE+GSAFIBUZJSAXCgkSDxckEQkNCwAAAAACADz/nAF0AHMAFgAtADUAuAAJL7gAIC+4ABYvuAAtL7gAAEVYuAACLxu5AAIABT5ZuAAARVi4ABkvG7kAGQAFPlkwMRc2NyMmJjU2NjMyFhcWFRQHBgYHBgYHJzY3IyYmNTY2MzIWFxYVFAcGBgcGBgf7JQsBFBoBIBoYIgIBAwYYDwkSEtslCwEUGgEgGhgiAgEDBhgPCRISPhkgBSAWGSQgFwoJEg8XJBEJDAsmGSAFIBYZJCAXCgkSDxckEQkMCwAABwAo//QECgK+ABMAKAAsAEEATwBfAG4B37sAYwADADIABCu7AFMAAwAZAAQruwAjAAMAXQAEK7sADwADAE0ABCu7ADwAAwBrAAQruwBFAAMABQAEK0EFAEoABQBaAAUAAl1BCQAJAAUAGQAFACkABQA5AAUABF26ABQAMgAPERI5ugApADIADxESOboAKwAyAA8REjm6AC0AMgAPERI5QQkABgA8ABYAPAAmADwANgA8AARdQQUARQA8AFUAPAACXUEFAEoATQBaAE0AAl1BCQAJAE0AGQBNACkATQA5AE0ABF1BBQAmAFMANgBTAAJdQQUABgBTABYAUwACXUEFAEUAUwBVAFMAAl1BBQBKAF0AWgBdAAJdQQkACQBdABkAXQApAF0AOQBdAARdQQkABgBjABYAYwAmAGMANgBjAARdQQUARQBjAFUAYwACXbgADxC4AHDcALgAKi+4ADcvuAAARVi4ACkvG7kAKQAFPlm4AABFWLgAAC8buQAAAAU+WbgAAEVYuAAULxu5ABQABT5ZuwBoAAIALQAEK7oAKwAAADcREjm4AAAQuQBKAAL0QRkABwBKABcASgAnAEoANwBKAEcASgBXAEoAZwBKAHcASgCHAEoAlwBKAKcASgC3AEoADF1BBQDGAEoA1gBKAAJduABY0DAxBSIuAjU0PgIzMh4CFRQOAiEiLgI1ND4CMzIeAhUUDgIjJQEzAQMiLgI1ND4CMzIeAhUUDgIjBQYGFRQeAjM2NjU0JiUGBhUUHgIzMj4CNTQmAQYGFRQeAjM2NjU0JicDdCc4JBEUJjckJDglFBIkOf6YJzglERQmOCQkNyYTEiQ5J/5pAVdf/qo+JzglERQmOCQkNyYTEiU4JwK6JRoHEBgRJRod/pslGgcQGBETGA8GHv5mJRoHEBgRJRoeIgwgM0EhIT4wHR0wPiEhQTQfIDNBISE+MB0dMD4hIUE0HwwCuP1IAV4gM0EhIT4wHB0wPSEhQTQfTgM6KhcqHxIBQi8pOwMDOioXKh8SEx8pFyk7AW0DOioXKh8SAUIvKDwCAAAAAAMACgAAAiQDWwAFAA0AEAAzALgAAy+4AABFWLgABi8buQAGAAU+WbgAAEVYuAAJLxu5AAkABT5ZuwAQAAEABwAEKzAxAQcnNxcHEycjByMTNxMBBzMBHIoosrsuGELhR03oVd3+8FyxAvBPOoCBOf1fwsICexr9awIE/QACADwAAAGwA1sABQARAFm7AA8AAwAGAAQruAAPELgACtAAuAADL7gAAEVYuAALLxu5AAsABz5ZuAAARVi4AAYvG7kABgAFPlm7AAgAAQAJAAQruAALELkADQAB9LgABhC5AA8AAfQwMRMHJzcXBwERIQcjFTMHIxUhFfKJKLG6Lv6+AXQk89QksAEKAvBPOoCBOf1fAodIwEjwRwADAAoAAAIkA1oAAwALAA4AMwC4AAIvuAAARVi4AAQvG7kABAAFPlm4AABFWLgABy8buQAHAAU+WbsADgABAAUABCswMRMnNxcTJyMHIxM3EwEHM8Ax2SYzQuFHTehV3f7xXbECpTOCT/z1wsICexr9awIE/QAAAAADADz//gGwAyMADAAZACUAvbsAIwADABoABCu7AAkABAADAAQrQQUASgADAFoAAwACXUEJAAkAAwAZAAMAKQADADkAAwAEXboAEAAaACMREjm4ABAvuQAWAAT0uAAjELgAHtC6ACAAAwAJERI5uAAJELgAJ9wAuAAGL7gAEy+4AABFWLgAHy8buQAfAAc+WbgAAEVYuAAaLxu5ABoABT5ZuwAcAAEAHQAEK7gAExC5ABkAAfS4AADQuAAfELkAIQAB9LgAGhC5ACMAAfQwMQEiJjU0NjMyFhcUBiMHIiY3NDYzMhYVFAYjAxEhByMVMwcjFSEVAVMaIyIaGiIBIxnBGSQBIhkaJCMaVgF0JPPUJLABCgKmJBoaJSUaGSQCJBoaJSUZGiT9WAKGR8BI8EcAAgA8AAABsANaAAMADwBZuwANAAMABAAEK7gADRC4AAjQALgAAS+4AABFWLgACS8buQAJAAc+WbgAAEVYuAAELxu5AAQABT5ZuwAGAAEABwAEK7gACRC5AAsAAfS4AAQQuQANAAH0MDETNxcHAREhByMVMwcjFSEVcCbXMf8AAXQk89QksAEKAwtPgjP9WwKHSMBI8EcAAAACACUAAAEgA1oAAwAHACy7AAcAAwAEAAQrALgAAi+4AABFWLgABC8buQAEAAU+WboABgAEAAIREjkwMRMnNxcDETcRVjHWJcxcAqUzgk/89QJ3IP1pAAAAAv/LAAABNgNbAAUACQAsuwAJAAMABgAEKwC4AAMvuAAARVi4AAYvG7kABgAFPlm6AAgABgADERI5MDETByc3FwcDETcRfIkosbouuF0C8E86gIE5/V8CdyD9aQAD/+T//gEbAyMADAAZAB0AnLsAFgAEABAABCtBCQAGABYAFgAWACYAFgA2ABYABF1BBQBFABYAVQAWAAJdugAaABAAFhESObgAGi+5AB0AA/S5AAkABPS6AAAAHQAJERI5uAAdELgAA9C4AAMvuAAc0LgAHC8AuAAGL7gAEy+4AABFWLgAGi8buQAaAAU+WbgAExC5AA0AAfS4AADQuAAAL7oAHAAaAAYREjkwMRMiJjU0NjMyFhUUBiMHIiY1NDYzMhYVFAYjExE3EeAaIyIaGiIjGb4ZJCIZGiQjGSpdAqYkGholJRoZJAIkGholJRoZJP1YAncg/WkAAAAC//EAAADsA1oAAwAHACy7AAcAAwAEAAQrALgAAS+4AABFWLgABC8buQAEAAU+WboABgAEAAEREjkwMQM3FwcDETcRDybVMWxcAwtPgjP9WwJ3IP1pAAAAAwAe//cCSwNaAAMAFwAsAOy4AC0vuAAnL7gALRC4AAnQuAAJL0EFAEoAJwBaACcAAl1BCQAJACcAGQAnACkAJwA5ACcABF24ACcQuQATAAP0ugAYAAkAExESObgACRC5AB0AA/RBCQAGAB0AFgAdACYAHQA2AB0ABF1BBQBFAB0AVQAdAAJduAATELgALtwAuAACL7gAAEVYuAAELxu5AAQABT5ZuwAOAAEALAAEK7gABBC5ACIAAfRBGQAHACIAFwAiACcAIgA3ACIARwAiAFcAIgBnACIAdwAiAIcAIgCXACIApwAiALcAIgAMXUEFAMYAIgDWACIAAl0wMRMnNxcDIi4CNTQ+AjMyHgIVFA4CAyIOAhUUHgIzMj4CNTQuAiPiMtkme0VoRiMlR2dDQ2hHJSNHaEQrQiwWFy1BKilBLRcWLEIrAqUzgk/87D9jeTs8dlw5OV11PTt5Yj8CUSxIWi0yX0otLUpgMi1ZSCwAAAAAAwAe//cCSwNbAAUAGQAuAOy4AC8vuAApL7gALxC4AAvQuAALL7kAHwAD9EEJAAYAHwAWAB8AJgAfADYAHwAEXUEFAEUAHwBVAB8AAl24AALQuAACL0EFAEoAKQBaACkAAl1BCQAJACkAGQApACkAKQA5ACkABF24ACkQuQAVAAP0ugAaAAsAFRESObgAMNwAuAADL7gAAEVYuAAGLxu5AAYABT5ZuwAQAAEALgAEK7gABhC5ACQAAfRBGQAHACQAFwAkACcAJAA3ACQARwAkAFcAJABnACQAdwAkAIcAJACXACQApwAkALcAJAAMXUEFAMYAJADWACQAAl0wMQEHJzcXBwMiLgI1ND4CMzIeAhUUDgIDIg4CFRQeAjMyPgI1NC4CIwEziSixvC6NRWhGIyVHZ0NDaEclI0doRCtCLBYXLUEqKUEtFxYsQisC8E85gYE5/VY/Y3k7PHZcOTlcdjw7eWM/AlEsSFotMl9KLS1KYDItWUgsAAEAKP/wA0kCsgBIAKu4AEkvuAAAL7gASRC4ABvQuAAbL7kAMAAE9LgAC9C4AAsvuAAbELgAFtC4AAAQuQBIAAT0uAA50LgAOS+4AEgQuABD0LgASBC4AErcALgAES+4AABFWLgAAC8buQAAAAU+WbgAAEVYuAAcLxu5ABwABT5ZugApACoAAyu7ADMAAQAGAAQruAAqELgALNC6ADAABgAzERI5ugA5AAYAMxESObgABhC4AD3QMDEhNTQuAiMiDgIVFRQOAiMiLgI1JjQ0NjUBERc+Azc+AzMzFSMzIgYVBzY2MzIWFxYWFzY2NxUjIg4CFRwDFQJrDhMUBhUbEAcPGCAREiAYDwEB/vAoByAmJQwTHyo/M8ARATAxARNIMR0rFw0LCRErFwwSGhAJ/RkfEAURGyIQqRIeFwwMFx4STHx2fEv9uQExSA1EU1EaKEMyHBktJesvLQ8TCxUNIyAFZxMfJhMhNTM1IQADAB7/9wJLA1oAAwAXACwA7LgALS+4ACcvuAAtELgACdC4AAkvQQUASgAnAFoAJwACXUEJAAkAJwAZACcAKQAnADkAJwAEXbgAJxC5ABMAA/S6ABgACQATERI5uAAJELkAHQAD9EEJAAYAHQAWAB0AJgAdADYAHQAEXUEFAEUAHQBVAB0AAl24ABMQuAAu3AC4AAEvuAAARVi4AAQvG7kABAAFPlm7AA4AAQAsAAQruAAEELkAIgAB9EEZAAcAIgAXACIAJwAiADcAIgBHACIAVwAiAGcAIgB3ACIAhwAiAJcAIgCnACIAtwAiAAxdQQUAxgAiANYAIgACXTAxEzcXBwMiLgI1ND4CMzIeAhUUDgIDIg4CFRQeAjMyPgI1NC4CI7Qm2TFORWhGIyVHZ0NDaEclI0doRCtCLBYXLUEqKUEtFxYsQisDC0+CM/1SP2N5Ozx2XDk5XXU9O3liPwJRLEhaLTJfSi0tSmAyLVlILAAAAAACADz/9wIRA1oAAwAZAJK4ABovuAAEL7kABQAD9LgAGhC4ABHQuAARL7kAEgAD9LgABRC4ABvcALgAAi+4AABFWLgACy8buQALAAU+WboAEgALAAIREjm5ABYAAfRBGQAHABYAFwAWACcAFgA3ABYARwAWAFcAFgBnABYAdwAWAIcAFgCXABYApwAWALcAFgAMXUEFAMYAFgDWABYAAl0wMRMnNxcXMxEUDgIjIi4CNRE3ExQWNzY2Nd8y2SYYTSRAVjMxVT4kXgFGSkhRAqUzgk+F/lkzVj4hIj1VMwGZIf5STlUBAVhLAAAAAAIAPP/3AhEDWwAFABsAmrgAHC+4AAYvuAAcELgAE9C4ABMvuQAUAAP0uAAB0LgAAS+4AAYQuQAHAAP0uAAd3AC4AAMvuAAARVi4AA0vG7kADQAFPlm6ABQADQADERI5uQAYAAH0QRkABwAYABcAGAAnABgANwAYAEcAGABXABgAZwAYAHcAGACHABgAlwAYAKcAGAC3ABgADF1BBQDGABgA1gAYAAJdMDEBByc3FwcXMxEUDgIjIi4CNRE3ExQWNzY2NQEriiixuy4NTSRAVjMxVT4kXgFGSkhRAvBPOYGBORv+WTNWPiEiPVUzAZkh/lJOVQEBWEsAAgA8//cCEQNaAAMAGQCSuAAaL7gABC+5AAUAA/S4ABoQuAAR0LgAES+5ABIAA/S4AAUQuAAb3AC4AAEvuAAARVi4AAsvG7kACwAFPlm6ABIACwABERI5uQAWAAH0QRkABwAWABcAFgAnABYANwAWAEcAFgBXABYAZwAWAHcAFgCHABYAlwAWAKcAFgC3ABYADF1BBQDGABYA1gAWAAJdMDETNxcHFzMRFA4CIyIuAjURNxMUFjc2NjWsJtkyS00kQFYzMVU+JF4BRkpIUQMLT4IzH/5ZM1Y+ISI9VTMBmSH+Uk5VAQFYSwAAAAABAEkAAACfAdQAAwAiuwADAAMAAAAEKwC4AAIvuAAARVi4AAAvG7kAAAAFPlkwMTMRNxFJVgG1H/4sAAABABoB+gGFAq4ABQAPALgAAS+4AAUvuAADLzAxEwcnNxcHy4kosLsuAkdNOHx8NwABADMB+gGEAmUAFwAnALgADy+4ABcvuAADL7gACy+4AA8QuQAIAAH0uAADELkAFAAB9DAxAQYGIyIuAiMiBgcnNjY3Mh4CMzI2NwGEHzYmERsZGQ8TGRYnHzYmERsZGQ4TGRcCMh0aCgsKDxEyHRoBCgwKDxIAAAABADEB/gGVAkAAAwANALsAAQACAAAABCswMRM1IRcxAT8lAf5CQgAAAQAaAfsBhQKvAAUADwC4AAAvuAACL7gABC8wMRMnNxc3F8qwKImMLgH7fDhNTTgAAQBCAlEAvgLMAAsADQC7AAkAAQADAAQrMDETFAYjIiYnJjYzMha9JBkYJAEBJxoZIgKOGSQlGRkkJQAAAgA6Af0BBQLLABMAIACLuAAhL7gAHS+4ACEQuAAF0LgABS9BBQBKAB0AWgAdAAJdQQkACQAdABkAHQApAB0AOQAdAARduAAdELkADwAD9LgABRC5ABcAA/RBCQAGABcAFgAXACYAFwA2ABcABF1BBQBFABcAVQAXAAJduAAPELgAItwAuwAaAAIAAAAEK7sACgACABQABCswMRMiLgI1ND4CMzIeAhUUDgInIgYVFBYzMjY1NCYjnxUlGxAQHSUVFSQbEBAcJRMSGRkPERkXDwH9EB0mFRUlHBAQHSUVFSUdEJEZEREZGRARGQABAE3/RgEPACIAGgAtuwASAAQACgAEK7gAEhC5AAYAA/S4ABIQuAAc3AC4AAsvuwADAAIAFwAEKzAxFxYWMzI2NTQmIyM1MxUWFxYWFRQOAiMiJidlGBoPDRUXDihCCQMoHg4aKBkWLBdrCwYQDQ4MZy4CAQYvHQ8gGhAPDAAAAAIADAH4AWsC4wADAAcAEwC4AAEvuAAFL7gAAy+4AAcvMDETNxcHJzcXB6Z+R4Ldf0eCAgzXMrkU1zK5AAEAUf9GARIAMgAaABEAuAANL7sAFwACAAMABCswMQUGBiMiLgI1ND4CNxcHBgYHBh4CMzI2NwESFywWGiYbDRAZIhI0JxEOAwQDCg8IDxoYoAsPERkgDxspIR4QLCEOFQkMEw4IBwsAAQAo//oCSwKSADwAngC4AABFWLgABS8buQAFAAU+WbsAHAABACMABCu7AA4AAgALAAQruwAXAAIAFAAEK7gAFxC4ACjQuAAUELgAKtC4AA4QuAAu0LgACxC4ADDQuAAFELkANgAB9EEZAAcANgAXADYAJwA2ADcANgBHADYAVwA2AGcANgB3ADYAhwA2AJcANgCnADYAtwA2AAxdQQUAxgA2ANYANgACXTAxJQYGBwYjIyImJyYnIzUzJiY3NDQ3IzUzPgMXFhYXByYmIyIOAgczByMGFhczByMeAzMyNjc2NjcCSytPKSYmAT1dICYRQjgCAQEBNz8KKT9WNjdhLSUoRiYhMycZB+YM4QECAsoLtQgbJC8cJjcgCxsVUyEnCQg9MDhDPw4RDQcDBz8vWUUoAQIaIDwaEhstPiI/FBUUPyA4KRgSEgYPDAADAAj/+AG/AyMADAAZAE8BJrsAOwADACwABCu7AAkABAADAAQrQQUASgADAFoAAwACXUEJAAkAAwAZAAMAKQADADkAAwAEXUEJAAYAOwAWADsAJgA7ADYAOwAEXUEFAEUAOwBVADsAAl26ABAALAA7ERI5uAAQL7kAFgAE9LoAJAADAAkREjm4ACQvQQUASgAkAFoAJAACXUEJAAkAJAAZACQAKQAkADkAJAAEXbkARgAE9LgAUdwAuAAGL7gAEy+4AABFWLgATC8buQBMAAU+WbsAMQABADgABCu4ABMQuQAZAAH0uAAA0LgATBC5AB8AAfRBGQAHAB8AFwAfACcAHwA3AB8ARwAfAFcAHwBnAB8AdwAfAIcAHwCXAB8ApwAfALcAHwAMXUEFAMYAHwDWAB8AAl0wMQEiJjU0NjMyFhUUBiMHIiY3NDYzMhYVFAYjAx4DMzI2NzY1NCYnLgM1ND4CMzIWFwcmJiMmBgcUFhceAxcWFhUUBgcGBiMmJicBNhojIhoaIyMZwhkkASIZGiQjGkEPJistFiEiESotNiZOPicfN00uNVAnKx45JTY3ASs2GTMwKxIVEDAqIEMtOW8lAqYkGholJRoZJAIkGholJRkaJP3wDhoVDAoOISwjLRIMGilAMipGMhskHUQXGwEyKh0pEQgPFBwVGD0eL1MdFRIBMSQAAgAF//QBbwKzAAUAPgCmuwA5AAMAEgAEK0EFAEoAEgBaABIAAl1BCQAJABIAGQASACkAEgA5ABIABF24ADkQuABA3AC4AAIvuAAEL7gAAEVYuAAGLxu5AAYABT5ZuwAkAAEAKwAEK7gABhC5AA0AAfRBGQAHAA0AFwANACcADQA3AA0ARwANAFcADQBnAA0AdwANAIcADQCXAA0ApwANALcADQAMXUEFAMYADQDWAA0AAl0wMRMnNxc3FwMiJic3FhYzMj4CNTQuAicmJicuAzU0PgIzMhYXByYmIyIGBxQXFhYXFhYXFhYHFA4CI7WwJ4mMLsEoTSMmGzsaESEZDwwTFwoKFAsXLCMWHC45HiNDJSQfLhcdLAEeECkVFCkRFBsBIjRAHwH6gDlPTzn9ex4bPhcVCA8YEA0SDQgEBAgECRMdKh8iNSMSFxY/Eg8dGhkNCBAICBMODy0hJjgkEQAAAAAC/+0AAAHBA1oAAwAQADa7ABAAAwAEAAQrugAIAAQAEBESOQC4AAIvuAAARVi4AAQvG7kABAAFPlm6AAgABAACERI5MDETJzcXAxEDNxM2Njc2NxcDEY4y2Sa0ulqcFDUYHB5DvQKlM4JP/PUBKwFKIP7nJWAsMzUa/qf+3gAAAAAAAQABAQEBAQAMAPgI/wAIAAj//QAJAAj//QAKAAn//QALAAr//QAMAAv//AANAAz//AAOAA3//AAPAA7//AAQAA//+wARAA//+wASABD/+wATABH/+wAUABL/+gAVABP/+gAWABT/+gAXABX/+gAYABb/+QAZABb/+QAaABf/+QAbABj/+QAcABn/+AAdABr/+AAeABv/+AAfABz/+AAgAB3/9wAhAB3/9wAiAB7/9wAjAB//9wAkACD/9gAlACH/9gAmACL/9gAnACP/9gAoACT/9QApACT/9QAqACX/9QArACb/9QAsACf/9AAtACj/9AAuACn/9AAvACr/9AAwACv/8wAxACv/8wAyACz/8wAzAC3/8wA0AC7/8gA1AC//8gA2ADD/8gA3ADH/8gA4ADL/8QA5ADL/8QA6ADP/8QA7ADT/8QA8ADX/8AA9ADb/8AA+ADf/8AA/ADj/7wBAADn/7wBBADr/7wBCADr/7wBDADv/7gBEADz/7gBFAD3/7gBGAD7/7gBHAD//7QBIAED/7QBJAEH/7QBKAEH/7QBLAEL/7ABMAEP/7ABNAET/7ABOAEX/7ABPAEb/6wBQAEf/6wBRAEj/6wBSAEj/6wBTAEn/6gBUAEr/6gBVAEv/6gBWAEz/6gBXAE3/6QBYAE7/6QBZAE//6QBaAE//6QBbAFD/6ABcAFH/6ABdAFL/6ABeAFP/6ABfAFT/5wBgAFX/5wBhAFb/5wBiAFb/5wBjAFf/5gBkAFj/5gBlAFn/5gBmAFr/5gBnAFv/5QBoAFz/5QBpAF3/5QBqAF3/5QBrAF7/5ABsAF//5ABtAGD/5ABuAGH/5ABvAGL/4wBwAGP/4wBxAGT/4wByAGT/4wBzAGX/4gB0AGb/4gB1AGf/4gB2AGj/4gB3AGn/4QB4AGr/4QB5AGv/4QB6AGv/4QB7AGz/4AB8AG3/4AB9AG7/4AB+AG//3wB/AHD/3wCAAHH/3wCBAHL/3wCCAHP/3gCDAHP/3gCEAHT/3gCFAHX/3gCGAHb/3QCHAHf/3QCIAHj/3QCJAHn/3QCKAHr/3ACLAHr/3ACMAHv/3ACNAHz/3ACOAH3/2wCPAH7/2wCQAH//2wCRAID/2wCSAIH/2gCTAIH/2gCUAIL/2gCVAIP/2gCWAIT/2QCXAIX/2QCYAIb/2QCZAIf/2QCaAIj/2ACbAIj/2ACcAIn/2ACdAIr/2ACeAIv/1wCfAIz/1wCgAI3/1wChAI7/1wCiAI//1gCjAI//1gCkAJD/1gClAJH/1gCmAJL/1QCnAJP/1QCoAJT/1QCpAJX/1QCqAJb/1ACrAJb/1ACsAJf/1ACtAJj/1ACuAJn/0wCvAJr/0wCwAJv/0wCxAJz/0wCyAJ3/0gCzAJ3/0gC0AJ7/0gC1AJ//0gC2AKD/0QC3AKH/0QC4AKL/0QC5AKP/0QC6AKT/0AC7AKT/0AC8AKX/0AC9AKb/zwC+AKf/zwC/AKj/zwDAAKn/zwDBAKr/zgDCAKv/zgDDAKz/zgDEAKz/zgDFAK3/zQDGAK7/zQDHAK//zQDIALD/zQDJALH/zADKALL/zADLALP/zADMALP/zADNALT/ywDOALX/ywDPALb/ywDQALf/ywDRALj/ygDSALn/ygDTALr/ygDUALr/ygDVALv/yQDWALz/yQDXAL3/yQDYAL7/yQDZAL//yADaAMD/yADbAMH/yADcAMH/yADdAML/xwDeAMP/xwDfAMT/xwDgAMX/xwDhAMb/xgDiAMf/xgDjAMj/xgDkAMj/xgDlAMn/xQDmAMr/xQDnAMv/xQDoAMz/xQDpAM3/xADqAM7/xADrAM//xADsAM//xADtAND/wwDuANH/wwDvANL/wwDwANP/wwDxANT/wgDyANX/wgDzANb/wgD0ANb/wgD1ANf/wQD2ANj/wQD3ANn/wQD4ANr/wQD5ANv/wAD6ANz/wAD7AN3/wAD8AN7/vwD9AN7/vwD+AN//vwD/AOD/vwAUAEgAPwBcAHgAAQANAXwAEwIdAA8CWQACAAC4AAAsS7gACVBYsQEBjlm4Af+FuABEHbkACQADX14tuAABLCAgRWlEsAFgLbgAAiy4AAEqIS24AAMsIEawAyVGUlgjWSCKIIpJZIogRiBoYWSwBCVGIGhhZFJYI2WKWS8gsABTWGkgsABUWCGwQFkbaSCwAFRYIbBAZVlZOi24AAQsIEawBCVGUlgjilkgRiBqYWSwBCVGIGphZFJYI4pZL/0tuAAFLEsgsAMmUFhRWLCARBuwQERZGyEhIEWwwFBYsMBEGyFZWS24AAYsICBFaUSwAWAgIEV9aRhEsAFgLbgAByy4AAYqLbgACCxLILADJlNYsEAbsABZioogsAMmU1gjIbCAioobiiNZILADJlNYIyG4AMCKihuKI1kgsAMmU1gjIbgBAIqKG4ojWSCwAyZTWCMhuAFAioobiiNZILgAAyZTWLADJUW4AYBQWCMhuAGAIyEbsAMlRSMhIyFZGyFZRC24AAksS1NYRUQbISFZLQC4AAArALoAAQACAAIrAboAAwACAAIrAb8AAwA8ADEAJwAZAA8AAAAIK78ABAAuACYAHgAZAA8AAAAIKwC/AAEATQBEADUAJgAXAAAACCu/AAIAWABEADUAJgAXAAAACCsAugAFAAQAByu4AAAgRX1pGEQAAAAAAPcBAQEBRAEBAQFMAQEBTDtEAQE7AQEBAQEBTAEBTBxEAQFMRAEBAQEBAQEBTAFMAQFEOwE7AQFMO0wzTDtMAUwBAQEBAQEBOwEBATtMATM7AURETAEBASs7TExMATMBMwEBATMBAQEBAUwBAQE7O0RMTExETEwBIiIiLwEBASs3TExMTExEREQzATsBAS8BO0w3NzsBTAEBTAFEREwhTAEBAQEBAUwBAUwBRAEBAQEBAUQiRAEBAQEBTAEBAQEvAQEBJgEBAQEBTExETExMTAEBAQEBASJEAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBTEwBAAABAAAACgAeACwAAWxhdG4ACAAEAAAAAP//AAEAAAABa2VybgAIAAAAAQAAAAEABAACAAAAAQAIAAEKjgAEAAAASwCgAKoAtADCAPwBHgFIAcoB0AHWAdwB7gH4AgYCDAIWAiACUgJsAooCtALKAzwDUgNYA2YDbAO+A/gD/gQEBEIEpATOBPAFIgWwBdoGYAbKB2gH9ghwCHoInAiqCLQIugjICRIJIAkuCTQJOglACUYJXAlmCXgJigmUCZoJrAm2CcwJ1gnsCfYKBAoOCjAKQgpUCmoKgAACACr/2ABK/+gAAgAq/9AAQf/sAAMAEgAqAE//8ABTAFgADgAs/+wALf/sADD/7AA4/+wAOv/sAD3/zgA//+wAQP/sAEL/zgBL//AAUP/wAFj/9gBf/+IAYP/sAAgAHf/YACr/6AA9/9gAP//oAEH/0ABC/8gAQ//YAGH/6AAKACv/7AAs/+IAMP/sADj/7AA9/84AP//sAED/7ABC/9gAX//gAGD/6AAgABn/2AAa/+AAG//IABz/0AAd/4gAHv/gAB//6AAi/9gAKv+wADj/7AA8/+wAPQAeAD8AFABAABQAQgAeAEr/0ABM/9AATf/YAE7/2ABQ/8gAVv/QAFf/4ABY/9gAWf/QAFr/0ABb/9AAXP/YAF7/4ABf/+gAYP/gAGH/0ABi/+gAAQBF/9AAAQBF/+gAAQBF/9AABAAW/+AAGAAQACD/8ABF/8AAAgAYACAARf/YAAMAFv/wABgAGABF/8gAAQBF//AAAgAY//AAHf+wAAIAGAAQAEX/2AAMAAv/2AAQ/9gAFv/oADj/7AA9/8QAPv/sAD//zgBA/+wAQv/OAEX/yABf/+gAYP/oAAYAC//sAD3/zgBB/84AQv/OAEP/7ABF/+AABwAs//EAOP/sAD3/9gBA/+wAQf/iAEL/7ABD/+wACgAV/+wAF//iADP/4gA9/+IAPv/2AD//7ABB/84AQv/YAEP/4gBF/+gABQA6//YAPwAUAEAAFABCABQARQAgABwAFf/iABf/2AAw/+wAM//iADj/7AA6/+wAPwAUAEAAFABB/+IAQgAUAEUAKABK/9AATP/gAE3/6ABO/+gAUP/oAFb/6ABX/+gAWP/oAFn/4ABa/+AAW//oAFz/6ABe//AAX//4AGH/8ABi/+gAY//wAAUAPf/sAD//9gBB/+IAQv/2AEP/9gABAEH/7AADADj/9gBB/+wASv/wAAEAKv/sABQAFv/gACz/7AAw/9gAOP/gADr/6AA8//gAPv/wAEr/6ABM/+AATf/oAE7/8ABQ/9gAVf/wAFf/+ABY/+gAWv/gAFv/+ABe//IAX//lAGD/5QAOAAv/7AAt//YAMP/sADj/6AA6//AAPf/YAD7/6AA//9gAQP/wAEL/6ABQ//gAWP/wAF//8ABg//AAAQBB/+gAAQBB/+gADwAV/+wAF//sABj/7AAq/+wALv/2ADP/2AA9/+gAP//sAED/7ABB/8QAQv/sAEP/zgBF/+gASv/wAGH/8AAYABX/4gAW/+gAF//iABj/2AAq/8QALf/2ADP/0AA5//gAOv/4ADz/+AA9//gAQf/IAEP/2ABK/9AATP/oAE3/6ABO/+AAUP/gAFb/6ABX//gAWP/gAFn/+ABb/+gAXP/wAAoAFf/sADP/4AA9/+AAP//wAEH/wABC/+gAQ//YAEr/8ABc//gAYf/wAAgAPv/4AEH/2ABC//AASv/wAEz/8ABO//AAUP/wAFj/8AAMAAv/7AAQ/+wAM//wAD3/6AA///AAQf/YAEL/8ABD/+AAX//wAGD/8ABh//AAY//4ACMAFf/iABb/2AAX/9gAGP/YACr/xAAs//YAMP/sADP/4gA4//EAOv/wADz/+AA/ABgAQAAYAEH/6ABCABgARQAoAEr/qABM/7gATf/AAE7/sABQ/7gAVv+wAFf/sABY/6gAWf+oAFr/sABb/7gAXP+4AF3/8ABe/7YAX/+4AGD/yABh/8AAYv/AAGP/uAAKABj/7AAq/+wALv/sAC//9gAz/+wAOf/4ADr/+AA9/+gAQf/YAEP/2AAhABX/7AAW/+AAF//sABj/zgAq/84AMP/sADP/xAA4/+wAOv/wAD0AEAA/ABQAQAAUAEH/4gBCABQAQ//iAEUAEABK/8gATP/QAE3/2ABO/9gAUP/QAFb/2ABX/9gAWP/IAFn/yABa/9AAW//YAFz/2ABe//AAX//4AGH/6ABi/9gAY//gABoAFf/sABf/7AAY/9gAKv/sADP/2AA4/+wAPQAQAD8AFABAABQAQf/sAEIAFABFABAASv/QAEz/6ABN/9gATv/gAFD/2ABW//AAV//gAFj/4ABb/9gAXP/gAF7/6ABh/+gAYv/oAGP/4AAnABD/7AAW/9AAK//OACz/zgAt/+IALv/sAC//4gAw/8QAMf/sADL/7AA1//gANv/4ADf/6AA4/8QAOf/oADr/wAA7/+gAPP/YAD3/4AA+/9gAP//iAED/7ABB/9gAQv/sAEP/4gBK/9AAS//oAEz/2ABN/+IATv/iAFD/4gBY/90AWf/sAFr/4gBd/+IAXv/iAF//4gBg/+IAYv/lACMAFf/YABb/0AAX/+IAGP/YACr/zgAs/+wAMP/sADP/2AA4/+wAOv/oADz/+AA9ABAAPwAUAEAAFABB/+wAQ//sAEUAGABK/8AATP+4AE3/yABO/9AAUP/AAFb/yABX/9gAWP/AAFn/wABa/8AAW//IAFz/wABe/9AAX//gAGD/2ABh/9gAYv/YAGP/4AAeABb/4AAs/+IALf/iAC7/7AAv//YAMP/EADH/9gA4/84AOv/YADv/+AA8//gAPf/gAD7/2AA//+IAQP/sAEH/4gBC/+wAQ//sAEv/8ABM/+gATf/oAE7/8ABP//AAUP/wAFH/8ABY/+gAWf/4AFr/8ABf/+AAYP/oAAIARgAHAFMAQAAIADj/8AA9/8gAPv/oAD//yABA/8gAQv/IAFD/+ABf/+AAAwAL/+AAQv/AAEX/2AACAEL/0ABF/+gAAQBF/9gAAwA9/9AAQv/IAEX/2AASAAsAQAAQABQAEgBQABX/6AAX/+gALwAdADEAGAA0AAgANQAwAD0AKAA+AB4APwA4AEAAOABDABgARQBoAEYAOABK//IAZgAwAAMAC//wAEL/0ABF/+gAAwAL//AAQv/QAEX/6AABAFMAKAABAEL/6AABAEX/2AABAEX/6AAFABX/9gBD/+AARf/gAGH/7ABj/+UAAgBD/+AARf/gAAQAQ//gAFMATwBe//MAYf/zAAQAFf/sABf/8ABD/+AATwAOAAIAFv/wAEP/4AABAEP/4AAEABX/7AAX/+gAGP/wAEP/4AACABX/7AAX/+gABQAW/+gATP/lAFj/7ABZ//MAWv/lAAIARf/wAFMAGgAFABD/8ABF/+AATf/lAFj/5QBZ/+UAAgBP/+gAZgAkAAMAewA8AHwAMgB9AEkAAgB8AD4AfQA1AAgAegA9AHsALQB8AHwAfQByAMMAEgDEABIAxQASAMYAEgAEAHoAKgB7ADoAfABnAH0AXAAEAHwADgDEADwAxQBPAMYASwAFAHwADQDDADEAxAB9AMUAaQDGACsABQB8AA0AwwAmAMQAcgDFAF4AxgBJAAMAfAANAMQAPwDFACsAAgAMAAsACwAAABAAEQABABUAIAADACIAIgAPACoARQAQAEoATAAsAE4AUQAvAFMAVAAzAFYAXAA1AF4AZAA8AHoAfQBDAMMAxgBHAAA=') format('truetype');
   font-weight: bold;
   font-style: normal; }
-
 /* 
  * Generated by Font Squirrel (http://www.fontsquirrel.com) on July 2, 2013 10:19:24 AM America/New_York
  * Adobe Source Pro Sans, Open Source License: http://store1.adobe.com/cfusion/store/html/index.cfm?event=displayFontPackage&code=1959
@@ -3592,17 +3604,17 @@ span.highlighted {
   src: url("../fonts/SourceSansPro-Regular-webfont.eot?#iefix") format("embedded-opentype"), url("../fonts/SourceSansPro-Regular-webfont.woff") format("woff"), url("../fonts/SourceSansPro-Regular-webfont.ttf") format("truetype"), url("../fonts/SourceSansPro-Regular-webfont.svg#source_sans_proregular") format("svg");
   font-weight: normal;
   font-style: normal; }
-
 @font-face {
   font-family: 'SourceSansProBold';
   src: url("../fonts/SourceSansPro-Bold-webfont.eot");
   src: url("../fonts/SourceSansPro-Bold-webfont.eot?#iefix") format("embedded-opentype"), url("../fonts/SourceSansPro-Bold-webfont.woff") format("woff"), url("../fonts/SourceSansPro-Bold-webfont.ttf") format("truetype"), url("../fonts/SourceSansPro-Bold-webfont.svg#source_sans_probold") format("svg");
   font-weight: bold;
   font-style: normal; }
-
 @font-face {
   font-family: 'SourceSansProItalic';
   src: url("../fonts/SourceSansPro-It-webfont.eot");
   src: url("../fonts/SourceSansPro-It-webfont.eot?#iefix") format("embedded-opentype"), url("../fonts/SourceSansPro-It-webfont.woff") format("woff"), url("../fonts/SourceSansPro-It-webfont.ttf") format("truetype"), url("../fonts/SourceSansPro-It-webfont.svg#source_sans_proitalic") format("svg");
   font-weight: normal;
   font-style: italic; }
+
+/*# sourceMappingURL=style.css.map */

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1110,6 +1110,7 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
 }
 
 .download-list-widget { @extend .small-widget; }
+.active-release-list-widget { @extend .small-widget; }
 
 .blog-widget { @extend %indent-time-elements; }
 
@@ -1791,6 +1792,25 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
 }
 
 .release-number { font-family: $default-font-bold; }
+
+.release-version,
+.release-status,
+.release-start,
+.release-end,
+.release-pep {
+    display: block;
+}
+.release-version { font-family: $default-font-bold; }
+
+
+.active-release-list-widget {
+
+    .list-row-headings,
+    .list-row-container li { font-size: px2em( 14px ); }
+
+    .list-row-container { margin-bottom: .5em; }
+
+}
 
 .download-list-widget {
 

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -118,8 +118,6 @@
                 </div>
 
 
-
-
         		<div class="row">
 
         		    <div class="small-widget download-widget1">

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -92,8 +92,6 @@
 
                 <div class="row download-list-widget">
 
-                    {% render_active_banner %}
-
                     <h2 class="widget-title">Looking for a specific release?</h2>
                     <p class="success-quote">Python releases by version number:</p>
 

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -44,11 +44,11 @@
                     <p class="success-quote"><a href="https://devguide.python.org/#status-of-python-branches">For more information please visit the Python Developer's Guide</a>.</p>
 
                     <div class="list-row-headings">
-                        <span class="release-version">Python Version</span>
-                        <span class="release-status">Maintenance Status</span>
-                        <span class="release-start">First Released</span>
-                        <span class="release-end">End of Support</span>
-                        <span class="release-pep">Release Schedule</span>
+                        <span class="release-version">Python version</span>
+                        <span class="release-status">Maintenance status</span>
+                        <span class="release-start">First released</span>
+                        <span class="release-end">End of support</span>
+                        <span class="release-pep">Release schedule</span>
                     </div>
                     <ol class="list-row-container menu">
                         <li>

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -41,7 +41,7 @@
                     {% render_active_banner %}
 
                     <h2 class="widget-title">Active Python Releases</h2>
-                    <p class="success-quote"><a href="https://devguide.python.org/#status-of-python-branches">For more information please visit the Python Developer's Guide</a>.</p>
+                    <p class="success-quote"><a href="https://devguide.python.org/#status-of-python-branches">For more information visit the Python Developer's Guide</a>.</p>
 
                     <div class="list-row-headings">
                         <span class="release-version">Python version</span>

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -37,6 +37,59 @@
 {% endblock header_content %}
 
 {% block content %}
+                <div class="row active-release-list-widget">
+                    {% render_active_banner %}
+
+                    <h2 class="widget-title">Active Python Releases</h2>
+                    <p class="success-quote"><a href="https://devguide.python.org/#status-of-python-branches">For more information please visit the Python Developer's Guide</a></p>
+
+                    <div class="list-row-headings">
+                        <span class="release-version">Python Version</span>
+                        <span class="release-status">Maintenance Status</span>
+                        <span class="release-start">First Released</span>
+                        <span class="release-end">End of Support</span>
+                        <span class="release-pep">Release Schedule</span>
+                    </div>
+                    <ol class="list-row-container menu">
+                        <li>
+                            <span class="release-version">3.8</span>
+                            <span class="release-status">bugfix</span>
+                            <span class="release-start">2019-10-14</span>
+                            <span class="release-end">2024-10</span>
+                            <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0569">PEP 569</a></span>
+                        </li>
+                        <li>
+                            <span class="release-version">3.7</span>
+                            <span class="release-status">bugfix</span>
+                            <span class="release-start">2018-06-27</span>
+                            <span class="release-end">2023-06-27</span>
+                            <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0537">PEP 537</a></span>
+                        </li>
+                        <li>
+                            <span class="release-version">3.6</span>
+                            <span class="release-status">security</span>
+                            <span class="release-start">2016-12-23</span>
+                            <span class="release-end">2021-12-23</span>
+                            <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0494">PEP 494</a></span>
+                        </li>
+                        <li>
+                            <span class="release-version">3.5</span>
+                            <span class="release-status">security</span>
+                            <span class="release-start">2015-09-13</span>
+                            <span class="release-end">2020-09-13</span>
+                            <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0478">PEP 478</a></span>
+                        </li>
+                        <li>
+                            <span class="release-version">2.7</span>
+                            <span class="release-status">bugfix</span>
+                            <span class="release-start">2010-07-03</span>
+                            <span class="release-end">2020-01-01</span>
+                            <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0373">PEP 373</a></span>
+                        </li>
+                    </ol>
+                </div>
+
+
                 <div class="row download-list-widget">
 
                     {% render_active_banner %}
@@ -63,6 +116,8 @@
                     {% box 'download-otherreleases' %}
 
                 </div>
+
+
 
 
         		<div class="row">

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -41,7 +41,7 @@
                     {% render_active_banner %}
 
                     <h2 class="widget-title">Active Python Releases</h2>
-                    <p class="success-quote"><a href="https://devguide.python.org/#status-of-python-branches">For more information please visit the Python Developer's Guide</a></p>
+                    <p class="success-quote"><a href="https://devguide.python.org/#status-of-python-branches">For more information please visit the Python Developer's Guide</a>.</p>
 
                     <div class="list-row-headings">
                         <span class="release-version">Python Version</span>


### PR DESCRIPTION
#1302 raised that it would be nice to have information, similar to other languages, that clearly states which python versions are actively maintained.

![image](https://user-images.githubusercontent.com/638797/77801718-a363e800-7036-11ea-9ae6-cea4dc6738d3.png)
