### PR TITLE
Update table: Python 2.7 is EOL

### DIFF
--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -81,7 +81,7 @@
                         </li>
                         <li>
                             <span class="release-version">2.7</span>
-                            <span class="release-status">bugfix</span>
+                            <span class="release-status">EOL</span>
                             <span class="release-start">2010-07-03</span>
                             <span class="release-end">2020-01-01</span>
                             <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0373">PEP 373</a></span>


### PR DESCRIPTION
List it as EOL (or another status?) for a bit longer (how long?) or remove it now? 