### PR TITLE
change 2.7 status to end-of-life, remove in a few months?

### DIFF
--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -81,7 +81,7 @@
                         </li>
                         <li>
                             <span class="release-version">2.7</span>
-                            <span class="release-status">bugfix</span>
+                            <span class="release-status">end-of-life</span>
                             <span class="release-start">2010-07-03</span>
                             <span class="release-end">2020-01-01</span>
                             <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0373">PEP 373</a></span>


### PR DESCRIPTION
Oops, in #1569, we all overlooked that 2.7 is now end-of-life!  While this table is supposed to be active releases, suggest that we leave 2.7 in it for now since this is a major change and consider removing it from here sometime in the future, perhaps after 3.5 is end-of-lifed later this year.