### PR TITLE
Add pubDate to minutes RSS feed

### DIFF
--- a/minutes/feeds.py
+++ b/minutes/feeds.py
@@ -17,3 +17,6 @@ class MinutesFeed(Feed):
 
     def item_description(self, item):
         return item.content
+
+    def item_pubdate(self, item):
+        return item.date


### PR DESCRIPTION
This PR adds a `pubDate` field to the RSS items in the "minutes" RSS feed.

It seems like the same issue exists for the "jobs" feed but the `Job` model doesn't have a field corresponding to the date when it is approved, just the date when it expires, so it's not as straightforward.

ref: https://docs.djangoproject.com/en/3.0/ref/contrib/syndication/