### PR TITLE
Update nomination page titles

### DIFF
--- a/templates/nominations/nomination_detail.html
+++ b/templates/nominations/nomination_detail.html
@@ -1,7 +1,7 @@
 {% extends "psf/default.html" %}
 
 {% block page_title %}
-Nomination for {{ nomination.name }}
+Nomination for {{ nomination.name }} in {{ nomination.election.name }} Election
 | {{ SITE_INFO.site_name }}
 {% endblock %}
 

--- a/templates/nominations/nominee_detail.html
+++ b/templates/nominations/nominee_detail.html
@@ -2,7 +2,7 @@
 {% load nominations %}
 
 {% block page_title %}
-Nomination for {{ nomination.name }}
+Nominee for {{ election.name }} Election
 | {{ SITE_INFO.site_name }}
 {% endblock %}
 

--- a/templates/nominations/nominee_list.html
+++ b/templates/nominations/nominee_list.html
@@ -2,7 +2,7 @@
 {% load nominations %}
 
 {% block page_title %}
-Nomination for {{ nomination.name }}
+Nominees for {{ election.name }} Election
 | {{ SITE_INFO.site_name }}
 {% endblock %}
 


### PR DESCRIPTION
Right now these are all showing up as `Nomination for | Python.org`. This PR updates them to match the `<h1>` on the page.

(I can't actually see `nomination_detail.html` of them due to #1588)