### PR TITLE
Move Python 3.7 to *security* mode on downloads page

### DIFF
--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -60,7 +60,7 @@
                         </li>
                         <li>
                             <span class="release-version">3.7</span>
-                            <span class="release-status">bugfix</span>
+                            <span class="release-status">security</span>
                             <span class="release-start">2018-06-27</span>
                             <span class="release-end">2023-06-27</span>
                             <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0537">PEP 537</a></span>


### PR DESCRIPTION
As of 3.7.8 (2020-06-27), Python 3.7.x has moved from the `bugfix` to the `security` fix phase of its releae cycle.  Update the `Active Python Releases` table on https://www.python.org/downloads/.