### PR TITLE
switch to github flavored markdown for CMS pages

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -4,6 +4,7 @@ django-sitetree==1.10.0
 Django==2.0.13
 docutils==0.12
 Markdown==2.5.2
+cmarkgfm==0.4.2
 Pillow==5.1.0
 psycopg2==2.7.3.2
 python3-openid==3.1.0


### PR DESCRIPTION
More and more becoming defacto which leads to confused users... rather than battle with extensions and the Markdown python module... just use `cmarkgfm`.