### PR TITLE
drop html styling causing scrollbax missing

### DIFF
--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -38,12 +38,9 @@
 
 
 /* ===== GLOBAL TYPOGRAPHIC & ELEMENT STYLES ===== */
-html {
-    background-color: darken($blue, 10%);
-    font: normal 100%/1.625 $default-font;
-}
-
 body {
+   background-color: darken($blue, 10%);
+   font: normal 100%/1.625 $default-font;
    color: $default-color;
    background-color: $white;
 


### PR DESCRIPTION
I noticed that in Chrome:


Google Chrome | 85.0.4183.83 (Official Build) beta (64-bit)
-- | --
Revision | 94abc2237ae0c9a4cb5f035431c8adfb94324633-refs/branch-heads/4183@{#1658}
OS | macOS Version 10.15.6 (Build 19G73)


The scrollbars remained white which made scrolling very difficult:

![](https://cdn.zappy.app/4524855a8e4f11b94dbf12619d49e551.gif)

I'm not sure I follow why the change is necessary, but the change fixes the scrollbar. The styling is consistent with Firefox's behavior without the change. 

![](https://cdn.zappy.app/b9cca03d6b89d84615014d48717986d0.gif)