### PR TITLE
Remove story's creation time from the successstories template.

### DIFF
--- a/templates/successstories/story_detail.html
+++ b/templates/successstories/story_detail.html
@@ -31,7 +31,6 @@
         <p class="company-byline">
             Written by <strong>{{ story.author }}</strong>,
             <a rel="external" href="{{ story.get_company_url }}">{{ story.get_company_name }}</a>
-            — <time datetime="{{ story.created|date:'c' }}">{{ story.created|date:'F Y' }}</time>
         </p>
 
         {{ story.content.rendered|safe }}


### PR DESCRIPTION
The creation time is the time the story was imported to Django,
but it was not the time the story itself was initially written.

Closes https://github.com/python/pythondotorg/issues/1626