### PR TITLE
Fix Win8 icon filename

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -49,7 +49,7 @@
     <link rel="apple-touch-icon" href="{{ STATIC_URL }}apple-touch-icon-precomposed.png">
 
     {# Tile icon for Win8 (144x144 + tile color) #}
-    <meta name="msapplication-TileImage" content="{{ STATIC_URL }}metro-icon-144x144-precomposed.png"><!-- white shape -->
+    <meta name="msapplication-TileImage" content="{{ STATIC_URL }}metro-icon-144x144.png"><!-- white shape -->
     <meta name="msapplication-TileColor" content="#3673a5"><!-- python blue -->
     <meta name="msapplication-navbutton-color" content="#3673a5">
 


### PR DESCRIPTION
The file is https://www.python.org/static/metro-icon-144x144.png not https://www.python.org/static/metro-icon-144x144-precomposed.png

See https://github.com/python/pythondotorg/tree/master/static

---

This is the ["last line effect"](https://www.viva64.com/en/b/0260/) from the `apple-touch-icon-ETC-precomposed.png` icons :) 

![image](https://user-images.githubusercontent.com/1324225/93357965-98517e00-f849-11ea-9cef-84c678a31d9a.png)
