### PR TITLE
Ignore __pycache__ and sqlite3 database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ static-root/
 static/stylesheets/mq.css
 static/stylesheets/no-mq.css
 static/stylesheets/style.css
+__pycache__
+*.db


### PR DESCRIPTION
Hi everyone! 

I was setting up python.org locally following [the docs](https://pythondotorg.readthedocs.io/install.html) with SQLite db first. When I finished the process, I saw a lot of stuff from `git status` output that I maybe aren't necessary. This PR adds entries to `.gitignore` to avoid that.

Here's the output I got:

```
$ git status 
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   static/sass/style.css

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	banners/__pycache__/
	banners/migrations/__pycache__/
	banners/templatetags/__pycache__/
	blogs/__pycache__/
	blogs/management/__pycache__/
	blogs/management/commands/__pycache__/
	blogs/migrations/__pycache__/
	blogs/templatetags/__pycache__/
	blogs/tests/__pycache__/
	boxes/__pycache__/
	boxes/migrations/__pycache__/
	boxes/templatetags/__pycache__/
	cms/__pycache__/
	cms/management/__pycache__/
	cms/management/commands/__pycache__/
	cms/templatetags/__pycache__/
	codesamples/__pycache__/
	codesamples/migrations/__pycache__/
	community/__pycache__/
	community/migrations/__pycache__/
	community/templatetags/__pycache__/
	community/tests/__pycache__/
	companies/__pycache__/
	companies/migrations/__pycache__/
	companies/templatetags/__pycache__/
	downloads/__pycache__/
	downloads/migrations/__pycache__/
	downloads/templatetags/__pycache__/
	downloads/tests/__pycache__/
	events/__pycache__/
	events/management/__pycache__/
	events/management/commands/__pycache__/
	events/migrations/__pycache__/
	events/templatetags/__pycache__/
	events/tests/__pycache__/
	fastly/__pycache__/
	jobs/__pycache__/
	jobs/management/__pycache__/
	jobs/management/commands/__pycache__/
	jobs/migrations/__pycache__/
	jobs/tests/__pycache__/
	membership/__pycache__/
	membership/migrations/__pycache__/
	membership/tests/__pycache__/
	minutes/__pycache__/
	minutes/management/__pycache__/
	minutes/management/commands/__pycache__/
	minutes/migrations/__pycache__/
	minutes/tests/__pycache__/
	nominations/__pycache__/
	nominations/migrations/__pycache__/
	nominations/templatetags/__pycache__/
	pages/__pycache__/
	pages/management/__pycache__/
	pages/management/commands/__pycache__/
	pages/migrations/__pycache__/
	pages/tests/__pycache__/
	peps/__pycache__/
	peps/management/__pycache__/
	peps/management/commands/__pycache__/
	peps/templatetags/__pycache__/
	peps/tests/__pycache__/
	pydotorg/__pycache__/
	pydotorg/settings/__pycache__/
	pydotorg/tests/__pycache__/
	pythondotorg.db
	sponsors/__pycache__/
	sponsors/migrations/__pycache__/
	sponsors/templatetags/__pycache__/
	sponsors/tests/__pycache__/
	successstories/__pycache__/
	successstories/migrations/__pycache__/
	successstories/templatetags/__pycache__/
	successstories/tests/__pycache__/
	users/__pycache__/
	users/migrations/__pycache__/
	users/templatetags/__pycache__/
	users/tests/__pycache__/
	work_groups/__pycache__/
	work_groups/migrations/__pycache__/
	work_groups/tests/__pycache__/
```