### PR TITLE
Update Release Status of Python 3.5 on downloads page

### DIFF
--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -74,9 +74,9 @@
                         </li>
                         <li>
                             <span class="release-version">3.5</span>
-                            <span class="release-status">security</span>
+                            <span class="release-status">end-of-life</span>
                             <span class="release-start">2015-09-13</span>
-                            <span class="release-end">2020-09-13</span>
+                            <span class="release-end">2020-09-05</span>
                             <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0478">PEP 478</a></span>
                         </li>
                         <li>


### PR DESCRIPTION
EOL of Python 3.5 was announced yesterday. Updating this table to reflect that.

Also, could remove this from the table, but left it, as Python 2.7 has been left, to reflect its status.