### PR TITLE
Improvements on how to work with SCSS files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :media do
   gem "compass", "~>0.12.2"
   gem "sass", "~>3.2.5"
   gem "susy", "~>1.0.5"
+  gem "rb-inotify", "~>0.8.8"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,12 @@ GEM
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
+    ffi (1.13.1)
     foreman (0.61.0)
       thor (>= 0.13.6)
     fssm (0.2.10)
+    rb-inotify (0.8.8)
+      ffi (>= 0.5.0)
     sass (3.2.6)
     susy (1.0.5)
       compass (>= 0.12.2)
@@ -21,5 +24,9 @@ PLATFORMS
 DEPENDENCIES
   compass (~> 0.12.2)
   foreman (~> 0.61.0)
+  rb-inotify (~> 0.8.8)
   sass (~> 3.2.5)
   susy (~> 1.0.5)
+
+BUNDLED WITH
+   2.1.4

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+sass:
+	 cd static && sass --compass --scss -I $(dirname $(dirname $(gem which susy))) --trace --watch sass/style.scss:sass/style.css

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,8 @@
+runserver:
+	python manage.py runserver 0.0.0.0:8000
+
 sass:
 	 cd static && sass --compass --scss -I $(dirname $(dirname $(gem which susy))) --trace --watch sass/style.scss:sass/style.css
+
+run:
+	make -j2 runserver sass

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -132,6 +132,12 @@ To compile and compress static media, you will need *compass* and
    To install *yui-compressor*, use your OS's package manager or download it
    directly then add the executable to your ``PATH``.
 
+.. note::
+
+   You may need to have Ruby developer headers installed. Use your OS's
+   package manager to install them (usually named as ``ruby-dev`` or
+   ``ruby-devel``).
+
 To create initial data for the most used applications, run::
 
     $ ./manage.py create_initial_data

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -169,8 +169,7 @@ Due to performance issues of django-pipeline_, we are using a dummy compiler
 ``pydotorg.compilers.DummySASSCompiler`` in development mode. To generate CSS
 files, use ``sass`` itself in a separate terminal window::
 
-    $ cd static
-    $ sass --compass --scss -I $(dirname $(dirname $(gem which susy))) --trace --watch sass/style.scss:sass/style.css
+    $ make sass
 
 .. _django-pipeline: https://github.com/cyberdelia/django-pipeline/issues/313
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -171,6 +171,11 @@ files, use ``sass`` itself in a separate terminal window::
 
     $ make sass
 
+Or, if you want to run both ``manage.py runserver`` and ``sass`` in the same
+terminal window, use::
+
+    $ make run
+
 .. _django-pipeline: https://github.com/cyberdelia/django-pipeline/issues/313
 
 


### PR DESCRIPTION
Hi everyone! As my previous PR #1647, this one also comes after my experiences when setting up the project. 

While doing that, I ran into an issue when with the `sass` command. The brief summary is:

1. It askef for another dependency that I had to install with `gem install --version '~> 0.8.8' rb-inotify`;
2. This command raised an error because I didn't have ruby development headers installed;
3. I had to run `sudo apt install ruby-dev` to fix that;
4. Only after that I was able to install the missing dependency and run `sass` as expected;

To help people on advance, I added a small note in the installing instruction so people don't forget to install ruby's dev headers. Also, now `rb-inotify` is listed in `Gemfile`.

I'm also proposing 2 other things with this PR with a new `Makefile`:

1. A `make sass` command to avoid people from remembering how to run `sass`. The [current command](https://github.com/python/pythondotorg/blob/master/docs/source/install.rst#generating-css-files-automatically) can be very complicated to remember and this shortcut can help with that;
2. A `make run` command to allow people to, if they want to, run all the development commands using a single terminal window;

Before this work, I talked briefly with @ewdurbin about moving from Ruby's gems to Node.js' npm to handle the `.scss` files. On second thought, I realized the project would still with external dependencies to perform the same task, but from different technologies, and it didn't sound like a huge benefit IMHO. It would be nice to have second opinions on this as well and, maybe, having a new issue to address this topic.