### PR TITLE
Update Windows download popup and list for 3.9. (#1611)

### DIFF
--- a/templates/downloads/os_list.html
+++ b/templates/downloads/os_list.html
@@ -38,8 +38,12 @@
                     {% for r in releases %}
                     <li>
                         <a href="{{ r.get_absolute_url }}">{{ r.name }} - {{ r.release_date|date }}</a>
-                        {% if os.slug == 'windows' and r.name >= 'Python 3.5' %}
-                        <p><strong>Note that {{ r.name }} <em>cannot</em> be used on Windows XP or earlier.</strong></p>
+                        {% if os.slug == 'windows' %}
+                            {% if r.name >= 'Python 3.9' %}
+                            <p><strong>Note that {{ r.name }} <em>cannot</em> be used on Windows 7 or earlier.</strong></p>
+                            {% elif r.name >= 'Python 3.5' %}
+                            <p><strong>Note that {{ r.name }} <em>cannot</em> be used on Windows XP or earlier.</strong></p>
+                            {% endif %}
                         {% endif %}
                         <ul>
                             {% for f in r.files.all %}

--- a/templates/downloads/supernav.html
+++ b/templates/downloads/supernav.html
@@ -10,7 +10,7 @@
         <p>
             <a class="button" href="{{ data.python3.url }}">{{ data.python3.release.name }}</a>
         </p>
-        {% if data.os.slug == 'windows' %}<p><strong>Note that Python 3.5+ <em>cannot</em> be used on Windows XP or earlier.</strong></p>{% endif %}
+        {% if data.os.slug == 'windows' %}<p><strong>Note that Python 3.9+ <em>cannot</em> be used on Windows 7 or earlier.</strong></p>{% endif %}
         <p>Not the OS you are looking for? Python can be used on many operating systems and environments. <a href="{% url 'download:download' %}">View the full list of downloads</a>.</p>
     </div>
     {% endfor %}


### PR DESCRIPTION
As of Python 3.9, only Windows 7 and later systems are supported. With the release of 3.9.0, change the download popup to state that (since we assume the download popup button will never move back to 3.8.x or earlier) and change the Windows download list to show Windows 7 for 3.9 and later releases and continue to show Windows XP for 3.5 through 3.8..