### PR TITLE
Move "Active Python Releases" into a box

### DIFF
--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -43,50 +43,7 @@
                     <h2 class="widget-title">Active Python Releases</h2>
                     <p class="success-quote"><a href="https://devguide.python.org/#status-of-python-branches">For more information visit the Python Developer's Guide</a>.</p>
 
-                    <div class="list-row-headings">
-                        <span class="release-version">Python version</span>
-                        <span class="release-status">Maintenance status</span>
-                        <span class="release-start">First released</span>
-                        <span class="release-end">End of support</span>
-                        <span class="release-pep">Release schedule</span>
-                    </div>
-                    <ol class="list-row-container menu">
-                        <li>
-                            <span class="release-version">3.8</span>
-                            <span class="release-status">bugfix</span>
-                            <span class="release-start">2019-10-14</span>
-                            <span class="release-end">2024-10</span>
-                            <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0569">PEP 569</a></span>
-                        </li>
-                        <li>
-                            <span class="release-version">3.7</span>
-                            <span class="release-status">security</span>
-                            <span class="release-start">2018-06-27</span>
-                            <span class="release-end">2023-06-27</span>
-                            <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0537">PEP 537</a></span>
-                        </li>
-                        <li>
-                            <span class="release-version">3.6</span>
-                            <span class="release-status">security</span>
-                            <span class="release-start">2016-12-23</span>
-                            <span class="release-end">2021-12-23</span>
-                            <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0494">PEP 494</a></span>
-                        </li>
-                        <li>
-                            <span class="release-version">3.5</span>
-                            <span class="release-status">end-of-life</span>
-                            <span class="release-start">2015-09-13</span>
-                            <span class="release-end">2020-09-05</span>
-                            <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0478">PEP 478</a></span>
-                        </li>
-                        <li>
-                            <span class="release-version">2.7</span>
-                            <span class="release-status">end-of-life</span>
-                            <span class="release-start">2010-07-03</span>
-                            <span class="release-end">2020-01-01</span>
-                            <span class="release-pep"><a href="https://www.python.org/dev/peps/pep-0373">PEP 373</a></span>
-                        </li>
-                    </ol>
+                    {% box 'downloads-active-releases' %}
                 </div>
 
 


### PR DESCRIPTION
That way we don't have to redeploy the website every time we release a new point version of Python or change the status of a given branch.