### PR TITLE
Address feedback from initial review of application flow

### DIFF
--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -144,6 +144,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.admin',
     'django.contrib.admindocs',
+    'django.contrib.humanize',
 
     'pipeline',
     'sitetree',

--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -75,6 +75,7 @@ class SponsorshipPackageAdmin(OrderedModelAdmin):
 
 class SponsorContactInline(admin.TabularInline):
     model = SponsorContact
+    raw_id_fields = ["user"]
     extra = 0
 
 

--- a/sponsors/tests/test_views.py
+++ b/sponsors/tests/test_views.py
@@ -3,6 +3,7 @@ from model_bakery import baker
 from itertools import chain
 
 from django.contrib import messages
+from django.contrib.auth.models import Group
 from django.conf import settings
 from django.urls import reverse, reverse_lazy
 from django.test import TestCase
@@ -43,6 +44,9 @@ class SelectSponsorshipApplicationBenefitsViewTests(TestCase):
         self.user = baker.make(settings.AUTH_USER_MODEL, is_staff=True, is_active=True)
         self.client.force_login(self.user)
 
+        self.group = Group(name="Sponsorship Preview")
+        self.group.save()
+
     def test_display_template_with_form_and_context(self):
         psf_package = baker.make("sponsors.SponsorshipPackage")
         extra_package = baker.make("sponsors.SponsorshipPackage")
@@ -73,7 +77,7 @@ class SelectSponsorshipApplicationBenefitsViewTests(TestCase):
 
         self.assertRedirects(r, redirect_url)
 
-    def test_staff_required(self):
+    def test_not_staff_no_group_not_allowed(self):
         redirect_url = f"{settings.LOGIN_URL}?next={self.url}"
         self.user.is_staff = False
         self.user.save()
@@ -82,6 +86,16 @@ class SelectSponsorshipApplicationBenefitsViewTests(TestCase):
         r = self.client.get(self.url)
 
         self.assertRedirects(r, redirect_url, fetch_redirect_response=False)
+
+    def test_group_allowed(self):
+        redirect_url = f"{settings.LOGIN_URL}?next={self.url}"
+        self.user.groups.add(self.group)
+        self.user.save()
+        self.client.force_login(self.user)
+
+        r = self.client.get(self.url)
+
+        self.assertEqual(r.status_code, 200, "user in group should have access")
 
     def test_valid_post_redirect_user_to_next_form_step_and_save_info_in_cookies(self):
         package = baker.make("sponsors.SponsorshipPackage")

--- a/sponsors/tests/test_views.py
+++ b/sponsors/tests/test_views.py
@@ -112,6 +112,20 @@ class SelectSponsorshipApplicationBenefitsViewTests(TestCase):
 
         self.assertEqual(initial, r.context["form"].initial)
 
+    def test_capacity_flag(self):
+        psf_package = baker.make("sponsors.SponsorshipPackage")
+        r = self.client.get(self.url)
+        self.assertEqual(False, r.context["capacities_met"])
+
+    def test_capacity_flag_when_needed(self):
+        at_capacity_benefit = baker.make(
+            SponsorshipBenefit, program=self.psf, capacity=0, soft_capacity=False
+        )
+        psf_package = baker.make("sponsors.SponsorshipPackage")
+
+        r = self.client.get(self.url)
+        self.assertEqual(True, r.context["capacities_met"])
+
 
 class NewSponsorshipApplicationViewTests(TestCase):
     url = reverse_lazy("new_sponsorship_application")

--- a/sponsors/views.py
+++ b/sponsors/views.py
@@ -11,7 +11,13 @@ from django.views.generic import ListView, FormView
 from django.urls import reverse_lazy, reverse
 from django.shortcuts import redirect
 
-from .models import Sponsor, SponsorshipBenefit, SponsorshipPackage, Sponsorship
+from .models import (
+    Sponsor,
+    SponsorshipBenefit,
+    SponsorshipPackage,
+    SponsorshipProgram,
+    Sponsorship,
+)
 
 from sponsors.forms import SponsorshiptBenefitsForm, SponsorshipApplicationForm
 from sponsors import cookies
@@ -23,10 +29,20 @@ class SelectSponsorshipApplicationBenefitsView(FormView):
     template_name = "sponsors/sponsorship_benefits_form.html"
 
     def get_context_data(self, *args, **kwargs):
+        programs = SponsorshipProgram.objects.all()
+        packages = SponsorshipPackage.objects.all()
+        benefits_qs = SponsorshipBenefit.objects.select_related("program")
+        capacities_met = any(
+            [
+                any([not b.has_capacity for b in benefits_qs.filter(program=p)])
+                for p in programs
+            ]
+        )
         kwargs.update(
             {
                 "benefit_model": SponsorshipBenefit,
-                "sponsorship_packages": SponsorshipPackage.objects.all(),
+                "sponsorship_packages": packages,
+                "capacities_met": capacities_met,
             }
         )
         return super().get_context_data(*args, **kwargs)

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -47,6 +47,8 @@ $(document).ready(function(){
           let packageOnlyBenefit = $(this).attr("package_only");
           if (packageOnlyBenefit) $(this).attr("disabled", true);
           return;
+      } else {
+          $('label[benefit_id=' + benefit + ']').addClass("active");
       }
 
 

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -34,7 +34,7 @@ $(document).ready(function(){
       let data = $("form").serialize();
 
       let cost = packageInfo.attr("data-cost");
-      costLabel.html('Sponsorship cost is $' + cost + '.00')
+      costLabel.html('Sponsorship cost is $' + cost.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' USD')
     });
 
     $("input[id^=id_benefits_]").change(function(){

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -6,6 +6,10 @@ $(document).ready(function(){
     $("#clear_form_btn").click(function(){
         $("#application_form").trigger("reset");
         $("#application_form [class=active]").removeClass("active");
+        $("input[name=package]").prop("checked", false);
+        checkboxesContainer.find(':checkbox').each(function(){
+            $(this).prop('checked', false);
+        });
         $("#cost_label").html("Select a package or customize the benefits");
     });
 

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -10,7 +10,7 @@ $(document).ready(function(){
         checkboxesContainer.find(':checkbox').each(function(){
             $(this).prop('checked', false);
         });
-        $("#cost_label").html("Select a package or customize the benefits");
+        $("#cost_label").html("");
     });
 
     $("input[name=package]").change(function(){
@@ -44,7 +44,7 @@ $(document).ready(function(){
     $("input[id^=id_benefits_]").change(function(){
       let benefit = this.value;
       if (benefit.length == 0) return;
-      if (costLabel.html() != "Updating cost...") costLabel.html("Submit your application and we'll get in touch...");
+      if (costLabel.html() != "Updating cost...") costLabel.html("Please submit your customized sponsorship package application and we'll contact you within 2 business days.");
 
       let active = checkboxesContainer.find('[value=' + benefit + ']').prop("checked");
       if (!active) {

--- a/templates/sponsors/new_sponsorship_application_form.html
+++ b/templates/sponsors/new_sponsorship_application_form.html
@@ -10,7 +10,6 @@
     <h1>Submit Sponsorship Information</h1>
 
     <div id="sponsorship-info-container" class="user-feedback level-general">
-      <p style="display: inline">We need more information to proceed with your sponsorship application.</p>
       <p>
       {% if sponsorship_package %}
         You selected the <b>{{ sponsorship_package.name }}</b> package {% if sponsorship_price %}costing ${{ sponsorship_price|intcomma }} USD {% endif %}and the following benefits:
@@ -23,6 +22,7 @@
           <li>{{ benefit.name }}</li>
         {% endfor %}
       </ul>
+      <p><i>Please complete the form below.</i></p>
       <span class="remove"><label id="close-info-container">Close</label> | <a href="{% url 'select_sponsorship_application_benefits' %}">Back to select benefits</a></span>
     </div>
 
@@ -39,7 +39,7 @@
         <label>{{ form.sponsor.label }}</label>
         {% render_field form.sponsor %}
         <br/>
-        <span class="helptext">You have already filled previous sponsorship application forms. Select an existing sponsor or <span id="new-application-link">create a new one</span>.
+        <span class="helptext">Your user account is already associated with existing PSF Sponsors. Select an existing sponsor to submit this application on their behalf or <span id="new-application-link">create a new one</span>.
       </p>
       {% endif %}
 

--- a/templates/sponsors/new_sponsorship_application_form.html
+++ b/templates/sponsors/new_sponsorship_application_form.html
@@ -1,5 +1,6 @@
 {% extends "psf/full-width.html" %}
 {% load boxes widget_tweaks %}
+{% load humanize %}
 
 
 {% block page_title %}Submit Sponsorship Information{% endblock %}
@@ -9,16 +10,17 @@
     <h1>Submit Sponsorship Information</h1>
 
     <div id="sponsorship-info-container" class="user-feedback level-general">
-      <p style="display: inline">We need more information to proceed with your sponsorship application.
+      <p style="display: inline">We need more information to proceed with your sponsorship application.</p>
+      <p>
       {% if sponsorship_package %}
-        You selected the <b>{{ sponsorship_package.name }}</b> package {% if sponsorship_price %}costing ${{ sponsorship_price }}.00 {% endif %}and the following benefits:
+        You selected the <b>{{ sponsorship_package.name }}</b> package {% if sponsorship_price %}costing ${{ sponsorship_price|intcomma }} USD {% endif %}and the following benefits:
       {% else %}
         You selected the following benefits:
       {% endif %}
       </p>
       <ul>
         {% for benefit in sponsorship_benefits %}
-          <p>{{ benefit.name }}</p>
+          <li>{{ benefit.name }}</li>
         {% endfor %}
       </ul>
       <span class="remove"><label id="close-info-container">Close</label> | <a href="{% url 'select_sponsorship_application_benefits' %}">Back to select benefits</a></span>

--- a/templates/sponsors/sponsorship_application_finished.html
+++ b/templates/sponsors/sponsorship_application_finished.html
@@ -5,7 +5,11 @@
 
 {% block content %}
   <article class="text">
-    <h1>Application submited!</h1>
+    <h1>Application submitted!</h1>
+    <i>
+        Thank you for submitting your application to sponsor the PSF ecosystem.
+        We will contact you within 2 business days to discuss next steps.
+    </i>
   </article>
 
 {% endblock content %}

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -10,7 +10,12 @@
 {% block content %}
 
     <article id="sponsorship_application_container" class="text">
-        <h1>Sponsorship Application</h1>
+
+        <div id="sponsorship-application-box">
+        {% box 'sponsorship-application' %}
+        </div>
+
+        <hr>
 
         <form id="application_form" action="" method="POST">
           {% csrf_token %}
@@ -24,7 +29,7 @@
           </div>
 
           <div id="cost_container">
-            <span id="cost_label">Select a package or customize the benefits</span>
+            <span id="cost_label"></span>
           </div>
 
           <div id="clear_form_btn">

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -46,11 +46,11 @@
             <ul id="id_{{ field.name }}">
             {% for benefit in field.field.queryset %}
                 <li class="{% cycle '' 'highlight' %}">
-                    <label for="id_{{field.name}}_{{ forloop.counter0 }}" title="{{ benefit.unavailability_message }}">
+                    <label for="id_{{field.name}}_{{ forloop.counter0 }}">
                         <input id="id_{{field.name}}_{{ forloop.counter0 }}" name="{{ field.name }}" type="checkbox" value="{{ benefit.id }}" {% if benefit.unavailability_message %}disabled{% endif %} {% if benefit.id in field.initial %}checked{% endif %} {% if benefit.package_only %}package_only='true'{% endif %}>
                         {{ benefit.name }}
-                        {% if benefit.package_only %}<i class="fa fa-cubes"></i>{% endif %}
-                        {% if not benefit.has_capacity %}<i class="fa fa-close"></i>{% endif %}
+                        {% if benefit.package_only %}<i class="fa fa-cubes"  title="{{ benefit_model.PACKAGE_ONLY_MESSAGE }}"></i>{% endif %}
+                        {% if not benefit.has_capacity %}<i class="fa fa-close"  title="{{ benefit_model.NO_CAPACITY_MESSAGE }}"></i>{% endif %}
                     </label>
                 </li>
             {% endfor %}

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -48,7 +48,7 @@
                 <li class="{% cycle '' 'highlight' %}">
                     <label for="id_{{field.name}}_{{ forloop.counter0 }}">
                         <input id="id_{{field.name}}_{{ forloop.counter0 }}" name="{{ field.name }}" type="checkbox" value="{{ benefit.id }}" {% if benefit.unavailability_message %}disabled{% endif %} {% if benefit.id in field.initial %}checked{% endif %} {% if benefit.package_only %}package_only='true'{% endif %}>
-                        {{ benefit.name }}
+                        <span {% if benefit.description %}title="{{ benefit.description }}"{% endif %}>{{ benefit.name }}</span>
                         {% if benefit.package_only %}<i class="fa fa-cubes"  title="{{ benefit_model.PACKAGE_ONLY_MESSAGE }}"></i>{% endif %}
                         {% if not benefit.has_capacity %}<i class="fa fa-close"  title="{{ benefit_model.NO_CAPACITY_MESSAGE }}"></i>{% endif %}
                     </label>

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -46,7 +46,7 @@
             <ul id="id_{{ field.name }}">
             {% for benefit in field.field.queryset %}
                 <li class="{% cycle '' 'highlight' %}">
-                    <label for="id_{{field.name}}_{{ forloop.counter0 }}">
+                    <label for="id_{{field.name}}_{{ forloop.counter0 }}" benefit_id="{{ benefit.id }}">
                         <input id="id_{{field.name}}_{{ forloop.counter0 }}" name="{{ field.name }}" type="checkbox" value="{{ benefit.id }}" {% if benefit.unavailability_message %}disabled{% endif %} {% if benefit.id in field.initial %}checked{% endif %} {% if benefit.package_only %}package_only='true'{% endif %}>
                         <span {% if benefit.description %}title="{{ benefit.description }}"{% endif %}>{{ benefit.name }}</span>
                         {% if benefit.package_only %}<i class="fa fa-cubes"  title="{{ benefit_model.PACKAGE_ONLY_MESSAGE }}"></i>{% endif %}

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -34,7 +34,6 @@
           <div id="benefits_container">
             <div id="benefits_icons_legend">
               <div>
-                <span><i class="fa fa-asterisk"></i> {{ benefit_model.NEW_MESSAGE }}</span>
                 <span><i class="fa fa-cubes"></i> {{ benefit_model.PACKAGE_ONLY_MESSAGE }}</span>
                 <span><i class="fa fa-close"></i> {{ benefit_model.NO_CAPACITY_MESSAGE }}</span>
               </div>
@@ -50,7 +49,6 @@
                     <label for="id_{{field.name}}_{{ forloop.counter0 }}" title="{{ benefit.unavailability_message }}">
                         <input id="id_{{field.name}}_{{ forloop.counter0 }}" name="{{ field.name }}" type="checkbox" value="{{ benefit.id }}" {% if benefit.unavailability_message %}disabled{% endif %} {% if benefit.id in field.initial %}checked{% endif %} {% if benefit.package_only %}package_only='true'{% endif %}>
                         {{ benefit.name }}
-                        {% if benefit.new %}<span class="fa fa-asterisk"></span>{% endif %}
                         {% if benefit.package_only %}<i class="fa fa-cubes"></i>{% endif %}
                         {% if not benefit.has_capacity %}<i class="fa fa-close"></i>{% endif %}
                     </label>

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -35,7 +35,7 @@
             <div id="benefits_icons_legend">
               <div>
                 <span><i class="fa fa-cubes"></i> {{ benefit_model.PACKAGE_ONLY_MESSAGE }}</span>
-                <span><i class="fa fa-close"></i> {{ benefit_model.NO_CAPACITY_MESSAGE }}</span>
+                {% if capacities_met %}<span><i class="fa fa-close"></i> {{ benefit_model.NO_CAPACITY_MESSAGE }}</span>{% endif %}
               </div>
             </div>
 


### PR DESCRIPTION
- [x] Eliminate “New” display on the benefits selection form
- [x] Only show the “At Capacity” once anything has reached capacity!
- [x] Format $ as commas and USD.
- [x] Note: Highlighting for all benefits in a package has some kind of bug. Reproduce: Select “visionary” and look at “Language Summit recognition”
- [x] Confirmation list of selected benefits on the Sponsor Application page could use formatting/bullets
- [x] Add hover over pop up to display ‘benefit description’ field from python.org/admin/sponsors/sponsorshipbenefit/
- [x] Update copy across benefit selection, sponsor form, and submission confirmation
- [x] Add a CMS editable box for top of benefits selection form
- [x] Allow a group access for sponsorship preview/soft-launch