### PR TITLE
Change parameters order to avoid YUI Compressor bug

### DIFF
--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3661,7 +3661,7 @@ span.highlighted {
     display: block;
     width: 100vw;
     position: relative;
-    left: calc(-50vw + 50%); }
+    left: calc(50% - 50vw); }
     #sponsorship_application_container #benefits_container .title {
       margin: 0 0 1em 0;
       padding: 0;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2444,7 +2444,7 @@ span.highlighted {
         display: block;
         width: 100vw;
         position: relative;
-        left: calc(-50vw + 50%);
+        left: calc(50% - 50vw);
 
         .title {
             margin: 0 0 1em 0;


### PR DESCRIPTION
The previous code lead to an invalid value for the left property:

`left: calc(-50vw+50%);`

This was being caused due to a bug in YUI Compressor ([used by Django pipeline](https://github.com/python/pythondotorg/blob/master/pydotorg/settings/pipeline.py)). 
You can read a detailed explanation about it in this issue:

https://github.com/yui/yuicompressor/issues/59


This is fixed since [version 2.4.9-BSI-2](https://mvnrepository.com/artifact/com.yahoo.platform.yui/yuicompressor/2.4.9-BSI-2). But, until we don't update
prod's YUI Compressor, this PR work as a bugfix since it changes the
parameters order to one properly understood by the bugged version.
More aboute this in this issue comment:

https://github.com/yui/yuicompressor/issues/59#issuecomment-330514588