### PR TITLE
Better control of sponsor package's price display after customization

### DIFF
--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -4,14 +4,15 @@ $(document).ready(function(){
         costLabel: $("#cost_label"),
         clearFormBtn: $("#clear_form_btn"),
         packageInput: $("input[name=package]"),
+        applicationForm: $("#application_form")
     }
 
 
     let cost = 0;
 
     SELECTORS.clearFormBtn.click(function(){
-        $("#application_form").trigger("reset");
-        $("#application_form [class=active]").removeClass("active");
+        SELECTORS.applicationForm.trigger("reset");
+        SELECTORS.applicationForm.find("[class=active]").removeClass("active");
         SELECTORS.packageInput.prop("checked", false);
         SELECTORS.checkboxesContainer.find(':checkbox').each(function(){
             $(this).prop('checked', false);

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -1,39 +1,40 @@
 $(document).ready(function(){
     const SELECTORS = {
-        checkboxesContainer: $('#benefits_container'),
-        costLabel: $("#cost_label"),
-        clearFormBtn: $("#clear_form_btn"),
-        packageInput: $("input[name=package]"),
-        applicationForm: $("#application_form"),
+        checkboxesContainer: () => $('#benefits_container'),
+        costLabel:  () => $("#cost_label"),
+        clearFormBtn:  () => $("#clear_form_btn"),
+        packageInput:  () => $("input[name=package]"),
+        applicationForm:  () => $("#application_form"),
         getPackageInfo: (packageId) => $("#package_benefits_" + packageId),
         getPackageBenefits: (packageId) => SELECTORS.getPackageInfo(packageId).children(),
-        benefitsInputs: $("input[id^=id_benefits_]"),
+        benefitsInputs: () => $("input[id^=id_benefits_]"),
         getBenefitLabel: (benefitId) => $('label[benefit_id=' + benefitId + ']'),
-        getBenefitInput: (benefitId) => SELECTORS.benefitsInputs.filter('[value=' + benefitId + ']'),
+        getBenefitInput: (benefitId) => SELECTORS.benefitsInputs().filter('[value=' + benefitId + ']'),
         getBenefitConflicts: (benefitId) => $('#conflicts_with_' + benefitId).children(),
     }
 
 
     let cost = 0;
 
-    SELECTORS.clearFormBtn.click(function(){
-        SELECTORS.applicationForm.trigger("reset");
-        SELECTORS.applicationForm.find("[class=active]").removeClass("active");
-        SELECTORS.packageInput.prop("checked", false);
-        SELECTORS.checkboxesContainer.find(':checkbox').each(function(){
+
+    SELECTORS.clearFormBtn().click(function(){
+        SELECTORS.applicationForm().trigger("reset");
+        SELECTORS.applicationForm().find("[class=active]").removeClass("active");
+        SELECTORS.packageInput().prop("checked", false);
+        SELECTORS.checkboxesContainer().find(':checkbox').each(function(){
             $(this).prop('checked', false);
             if ($(this).attr("package_only")) $(this).attr("disabled", true);
         });
-        SELECTORS.costLabel.html("");
+        SELECTORS.costLabel().html("");
     });
 
-    SELECTORS.packageInput.change(function(){
+    SELECTORS.packageInput().change(function(){
       let package = this.value;
       if (package.length == 0) return;
 
-      SELECTORS.costLabel.html("Updating cost...")
+      SELECTORS.costLabel().html("Updating cost...")
 
-      SELECTORS.checkboxesContainer.find(':checkbox').each(function(){
+      SELECTORS.checkboxesContainer().find(':checkbox').each(function(){
           $(this).prop('checked', false);
           let packageOnlyBenefit = $(this).attr("package_only");
           if (packageOnlyBenefit) $(this).attr("disabled", true);
@@ -52,7 +53,7 @@ $(document).ready(function(){
       SELECTORS.costLabel.html('Sponsorship cost is $' + cost.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' USD')
     });
 
-    SELECTORS.benefitsInputs.change(function(){
+    SELECTORS.benefitsInputs().change(function(){
       let benefit = this.value;
       if (benefit.length == 0) return;
       if (SELECTORS.costLabel.html() != "Updating cost...") {

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -3,6 +3,7 @@ $(document).ready(function(){
         checkboxesContainer: $('#benefits_container'),
         costLabel: $("#cost_label"),
         clearFormBtn: $("#clear_form_btn"),
+        packageInput: $("input[name=package]"),
     }
 
 
@@ -11,7 +12,7 @@ $(document).ready(function(){
     SELECTORS.clearFormBtn.click(function(){
         $("#application_form").trigger("reset");
         $("#application_form [class=active]").removeClass("active");
-        $("input[name=package]").prop("checked", false);
+        SELECTORS.packageInput.prop("checked", false);
         SELECTORS.checkboxesContainer.find(':checkbox').each(function(){
             $(this).prop('checked', false);
             if ($(this).attr("package_only")) $(this).attr("disabled", true);
@@ -19,7 +20,7 @@ $(document).ready(function(){
         SELECTORS.costLabel.html("");
     });
 
-    $("input[name=package]").change(function(){
+    SELECTORS.packageInput.change(function(){
       let package = this.value;
       if (package.length == 0) return;
 

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -4,7 +4,9 @@ $(document).ready(function(){
         costLabel: $("#cost_label"),
         clearFormBtn: $("#clear_form_btn"),
         packageInput: $("input[name=package]"),
-        applicationForm: $("#application_form")
+        applicationForm: $("#application_form"),
+        getPackageInfo: (packageId) => $("#package_benefits_" + packageId),
+        getPackageBenefits: (packageId) => SELECTORS.getPackageInfo(packageId).children(),
     }
 
 
@@ -33,8 +35,8 @@ $(document).ready(function(){
           if (packageOnlyBenefit) $(this).attr("disabled", true);
       });
 
-      let packageInfo = $("#package_benefits_" + package);
-      packageInfo.children().each(function(){
+      let packageInfo = SELECTORS.getPackageInfo(package);
+      SELECTORS.getPackageBenefits(package).each(function(){
           let benefit = $(this).html()
           let benefitInput = SELECTORS.checkboxesContainer.find('[value=' + benefit + ']');
           let packageOnlyBenefit = benefitInput.attr("package_only");

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -42,9 +42,6 @@ $(document).ready(function(){
           benefitInput.trigger("click");
       });
 
-      let url = $("#cost_container").attr("calculate_cost_url");
-      let data = $("form").serialize();
-
       let cost = packageInfo.attr("data-cost");
       SELECTORS.costLabel.html('Sponsorship cost is $' + cost.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' USD')
     });

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -13,8 +13,12 @@ $(document).ready(function(){
         getBenefitConflicts: (benefitId) => $('#conflicts_with_' + benefitId).children(),
     }
 
+    displayPackageCost = (packageId) => {
+      let packageInfo = SELECTORS.getPackageInfo(packageId);
+      let cost = packageInfo.attr("data-cost");
+      SELECTORS.costLabel().html('Sponsorship cost is $' + cost.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' USD')
+    }
 
-    let cost = 0;
 
 
     SELECTORS.clearFormBtn().click(function(){
@@ -40,7 +44,6 @@ $(document).ready(function(){
           if (packageOnlyBenefit) $(this).attr("disabled", true);
       });
 
-      let packageInfo = SELECTORS.getPackageInfo(package);
       SELECTORS.getPackageBenefits(package).each(function(){
           let benefit = $(this).html()
           let benefitInput = SELECTORS.getBenefitInput(benefit);
@@ -48,9 +51,7 @@ $(document).ready(function(){
           benefitInput.removeAttr("disabled");
           benefitInput.trigger("click");
       });
-
-      let cost = packageInfo.attr("data-cost");
-      SELECTORS.costLabel.html('Sponsorship cost is $' + cost.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' USD')
+      displayPackageCost(package);
     });
 
     SELECTORS.benefitsInputs().change(function(){

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -2,12 +2,13 @@ $(document).ready(function(){
     const SELECTORS = {
         checkboxesContainer: $('#benefits_container'),
         costLabel: $("#cost_label"),
+        clearFormBtn: $("#clear_form_btn"),
     }
 
 
     let cost = 0;
 
-    $("#clear_form_btn").click(function(){
+    SELECTORS.clearFormBtn.click(function(){
         $("#application_form").trigger("reset");
         $("#application_form [class=active]").removeClass("active");
         $("input[name=package]").prop("checked", false);

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -1,10 +1,10 @@
 $(document).ready(function(){
     const SELECTORS = {
         checkboxesContainer: $('#benefits_container'),
+        costLabel: $("#cost_label"),
     }
 
 
-    let costLabel = $("#cost_label");
     let cost = 0;
 
     $("#clear_form_btn").click(function(){
@@ -15,14 +15,14 @@ $(document).ready(function(){
             $(this).prop('checked', false);
             if ($(this).attr("package_only")) $(this).attr("disabled", true);
         });
-        $("#cost_label").html("");
+        SELECTORS.costLabel.html("");
     });
 
     $("input[name=package]").change(function(){
       let package = this.value;
       if (package.length == 0) return;
 
-      costLabel.html("Updating cost...")
+      SELECTORS.costLabel.html("Updating cost...")
 
       SELECTORS.checkboxesContainer.find(':checkbox').each(function(){
           $(this).prop('checked', false);
@@ -43,13 +43,16 @@ $(document).ready(function(){
       let data = $("form").serialize();
 
       let cost = packageInfo.attr("data-cost");
-      costLabel.html('Sponsorship cost is $' + cost.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' USD')
+      SELECTORS.costLabel.html('Sponsorship cost is $' + cost.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' USD')
     });
 
     $("input[id^=id_benefits_]").change(function(){
       let benefit = this.value;
       if (benefit.length == 0) return;
-      if (costLabel.html() != "Updating cost...") costLabel.html("Please submit your customized sponsorship package application and we'll contact you within 2 business days.");
+      if (SELECTORS.costLabel.html() != "Updating cost...") {
+        let msg = "Please submit your customized sponsorship package application and we'll contact you within 2 business days."
+        SELECTORS.costLabel.html(msg);
+      }
 
       let active = SELECTORS.checkboxesContainer.find('[value=' + benefit + ']').prop("checked");
       if (!active) {

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -7,6 +7,10 @@ $(document).ready(function(){
         applicationForm: $("#application_form"),
         getPackageInfo: (packageId) => $("#package_benefits_" + packageId),
         getPackageBenefits: (packageId) => SELECTORS.getPackageInfo(packageId).children(),
+        benefitsInputs: $("input[id^=id_benefits_]"),
+        getBenefitLabel: (benefitId) => $('label[benefit_id=' + benefitId + ']'),
+        getBenefitInput: (benefitId) => SELECTORS.benefitsInputs.filter('[value=' + benefitId + ']'),
+        getBenefitConflicts: (benefitId) => $('#conflicts_with_' + benefitId).children(),
     }
 
 
@@ -38,7 +42,7 @@ $(document).ready(function(){
       let packageInfo = SELECTORS.getPackageInfo(package);
       SELECTORS.getPackageBenefits(package).each(function(){
           let benefit = $(this).html()
-          let benefitInput = SELECTORS.checkboxesContainer.find('[value=' + benefit + ']');
+          let benefitInput = SELECTORS.getBenefitInput(benefit);
           let packageOnlyBenefit = benefitInput.attr("package_only");
           benefitInput.removeAttr("disabled");
           benefitInput.trigger("click");
@@ -48,7 +52,7 @@ $(document).ready(function(){
       SELECTORS.costLabel.html('Sponsorship cost is $' + cost.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' USD')
     });
 
-    $("input[id^=id_benefits_]").change(function(){
+    SELECTORS.benefitsInputs.change(function(){
       let benefit = this.value;
       if (benefit.length == 0) return;
       if (SELECTORS.costLabel.html() != "Updating cost...") {
@@ -56,18 +60,17 @@ $(document).ready(function(){
         SELECTORS.costLabel.html(msg);
       }
 
-      let active = SELECTORS.checkboxesContainer.find('[value=' + benefit + ']').prop("checked");
+      let active = SELECTORS.getBenefitInput(benefit).prop("checked");
       if (!active) {
           return;
       } else {
-          $('label[benefit_id=' + benefit + ']').addClass("active");
+          SELECTORS.getBenefitLabel(benefit).addClass("active");
       }
 
 
-      $('#conflicts_with_' + benefit).children().each(function(){
+      SELECTORS.getBenefitConflicts(benefit).each(function(){
           let conflictId = $(this).html();
-          let conflictCheckbox = SELECTORS.checkboxesContainer.find('[value=' + conflictId + ']');
-          let checked = conflictCheckbox.prop("checked");
+          let checked = SELECTORS.getBenefitInput(conflictId).prop("checked");
           if (checked){
             conflictCheckbox.trigger("click");
             conflictCheckbox.parent().removeClass("active");

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -1,5 +1,9 @@
 $(document).ready(function(){
-    let checkboxesContainer = $('#benefits_container');
+    const SELECTORS = {
+        checkboxesContainer: $('#benefits_container'),
+    }
+
+
     let costLabel = $("#cost_label");
     let cost = 0;
 
@@ -7,7 +11,7 @@ $(document).ready(function(){
         $("#application_form").trigger("reset");
         $("#application_form [class=active]").removeClass("active");
         $("input[name=package]").prop("checked", false);
-        checkboxesContainer.find(':checkbox').each(function(){
+        SELECTORS.checkboxesContainer.find(':checkbox').each(function(){
             $(this).prop('checked', false);
             if ($(this).attr("package_only")) $(this).attr("disabled", true);
         });
@@ -20,7 +24,7 @@ $(document).ready(function(){
 
       costLabel.html("Updating cost...")
 
-      checkboxesContainer.find(':checkbox').each(function(){
+      SELECTORS.checkboxesContainer.find(':checkbox').each(function(){
           $(this).prop('checked', false);
           let packageOnlyBenefit = $(this).attr("package_only");
           if (packageOnlyBenefit) $(this).attr("disabled", true);
@@ -29,7 +33,7 @@ $(document).ready(function(){
       let packageInfo = $("#package_benefits_" + package);
       packageInfo.children().each(function(){
           let benefit = $(this).html()
-          let benefitInput = checkboxesContainer.find('[value=' + benefit + ']');
+          let benefitInput = SELECTORS.checkboxesContainer.find('[value=' + benefit + ']');
           let packageOnlyBenefit = benefitInput.attr("package_only");
           benefitInput.removeAttr("disabled");
           benefitInput.trigger("click");
@@ -47,7 +51,7 @@ $(document).ready(function(){
       if (benefit.length == 0) return;
       if (costLabel.html() != "Updating cost...") costLabel.html("Please submit your customized sponsorship package application and we'll contact you within 2 business days.");
 
-      let active = checkboxesContainer.find('[value=' + benefit + ']').prop("checked");
+      let active = SELECTORS.checkboxesContainer.find('[value=' + benefit + ']').prop("checked");
       if (!active) {
           return;
       } else {
@@ -57,7 +61,7 @@ $(document).ready(function(){
 
       $('#conflicts_with_' + benefit).children().each(function(){
           let conflictId = $(this).html();
-          let conflictCheckbox = checkboxesContainer.find('[value=' + conflictId + ']');
+          let conflictCheckbox = SELECTORS.checkboxesContainer.find('[value=' + conflictId + ']');
           let checked = conflictCheckbox.prop("checked");
           if (checked){
             conflictCheckbox.trigger("click");


### PR DESCRIPTION
This PR fixes the issue with the sponsor cost display when user customizes the benefits but customizes it back to package's ones without changing the package. Under this scenario, the price wasn't being displayed again and this PR fix this. 

To do so I had to do some refactoring in the frontend code because I was getting very confused with the current strategy to get the dom elements via jQuery. 

Here's a demo of the feature working:

![demo](https://user-images.githubusercontent.com/238223/100238663-3b400b80-2f0f-11eb-862c-a834a5a54c4f.gif)
