### PR TITLE
Remove TODO notes in sponsors app

### DIFF
--- a/sponsors/templatetags/sponsors.py
+++ b/sponsors/templatetags/sponsors.py
@@ -6,19 +6,6 @@ from ..models import Sponsor
 register = template.Library()
 
 
-@register.inclusion_tag("sponsors/templatetags/featured_sponsor_rotation.html")
-def featured_sponsor_rotation():
-    """
-    Retrieve featured Sponsors for rotation
-    """
-    # TODO remove this code completely if not necessary
-    # this templatetag logic was removed by the PR #1667
-    # the Sponsor model got updated and its previous use was deprecated
-    # this templated tag is used at https://www.python.org/psf-landing/ but since the prod
-    # DB doesn't have any published sponsor, the default message is being print
-    return {}
-
-
 @register.inclusion_tag("sponsors/partials/full_sponsorship.txt")
 def full_sponsorship(sponsorship):
     return {

--- a/sponsors/tests/test_templatetags.py
+++ b/sponsors/tests/test_templatetags.py
@@ -4,13 +4,7 @@ from django.test import TestCase
 from companies.models import Company
 
 from ..models import Sponsor
-from ..templatetags.sponsors import featured_sponsor_rotation, full_sponsorship
-
-
-class SponsorTemplatetagTests(TestCase):
-    def test_templatetag(self):
-        sponsors_context = featured_sponsor_rotation()
-        self.assertEqual({}, sponsors_context)
+from ..templatetags.sponsors import full_sponsorship
 
 
 class FullSponsorshipTemplatetagTests(TestCase):

--- a/sponsors/tests/test_views.py
+++ b/sponsors/tests/test_views.py
@@ -135,7 +135,7 @@ class SelectSponsorshipApplicationBenefitsViewTests(TestCase):
         form = r.context["form"]
 
         self.assertIsInstance(form, SponsorshiptBenefitsForm)
-        msg = "You have to allow python.org to use cookies to proceed."
+        msg = "You must allow cookies from python.org to proceed."
         self.assertEqual(form.non_field_errors(), [msg])
 
 

--- a/sponsors/views.py
+++ b/sponsors/views.py
@@ -60,7 +60,7 @@ class SelectSponsorshipApplicationBenefitsView(FormView):
     def form_valid(self, form):
         if not self.request.session.test_cookie_worked():
             error = ErrorList()
-            error.append("You have to allow python.org to use cookies to proceed.")
+            error.append("You must allow cookies from python.org to proceed.")
             form._errors.setdefault("__all__", error)
             return self.form_invalid(form)
 

--- a/sponsors/views.py
+++ b/sponsors/views.py
@@ -5,6 +5,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
+from django.forms.utils import ErrorList
 from django.utils.decorators import method_decorator
 from django.http import JsonResponse
 from django.views.generic import ListView, FormView
@@ -57,12 +58,21 @@ class SelectSponsorshipApplicationBenefitsView(FormView):
         return cookies.get_sponsorship_selected_benefits(self.request)
 
     def form_valid(self, form):
+        if not self.request.session.test_cookie_worked():
+            error = ErrorList()
+            error.append("You have to allow python.org to use cookies to proceed.")
+            form._errors.setdefault("__all__", error)
+            return self.form_invalid(form)
+
         response = super().form_valid(form)
         self._set_form_data_cookie(form, response)
         return response
 
+    def get(self, request, *args, **kwargs):
+        request.session.set_test_cookie()
+        return super().get(request, *args, **kwargs)
+
     def _set_form_data_cookie(self, form, response):
-        # TODO: make sure user accepts cookies with set_test_cookie
         data = {
             "package": "" if not form.get_package() else form.get_package().id,
         }

--- a/templates/psf/index.html
+++ b/templates/psf/index.html
@@ -54,7 +54,9 @@
 
                     <div class="small-widget psf-widget4 last">
                         <h2 class="widget-title">Sponsors</h2>
-                        {% featured_sponsor_rotation %}
+                        <div id="sponsor-rotation" class="flex-slideshow">
+                            <p>Without our sponsors we wouldn't be able to help the Python community grow and prosper.</p>
+                        </div>
                         <p><a class="button" href="/psf/sponsorship/">Sponsorship Possibilities</a></p>
                     </div>
 

--- a/templates/sponsors/templatetags/featured_sponsor_rotation.html
+++ b/templates/sponsors/templatetags/featured_sponsor_rotation.html
@@ -1,4 +1,0 @@
-{% load imagekit %}
-<div id="sponsor-rotation" class="flex-slideshow">
-    <p>Without our sponsors we wouldn't be able to help the Python community grow and prosper.</p>
-</div>


### PR DESCRIPTION
This PR removes 2 `TODO` comments and now the app:

1. The backend now validates if it can read/write cookies before redirecting the user to fill in the sponsor information;
2. Removed legacy code related to an old template tag;