### PR TITLE
Enable admin users to edit benefits from sponsorship application via django admin

### DIFF
--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -18,7 +18,7 @@ from .models import (
     LegalClause,
 )
 from sponsors import use_cases
-from sponsors.forms import SponsorshipReviewAdminForm
+from sponsors.forms import SponsorshipReviewAdminForm, SponsorBenefitAdminInlineForm
 from sponsors.exceptions import SponsorshipInvalidStatusException
 from cms.admin import ContentManageableModelAdmin
 
@@ -94,8 +94,8 @@ class SponsorAdmin(ContentManageableModelAdmin):
 
 class SponsorBenefitInline(admin.TabularInline):
     model = SponsorBenefit
-    readonly_fields = ["name", "benefit_internal_value"]
-    fields = ["name", "benefit_internal_value"]
+    form = SponsorBenefitAdminInlineForm
+    fields = ["sponsorship_benefit", "benefit_internal_value"]
     extra = 0
     can_delete = False
 

--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -284,17 +284,19 @@ class SponsorshipAdmin(admin.ModelAdmin):
 
     def get_sponsor_mailing_address(self, obj):
         sponsor = obj.sponsor
-        city_row = f'{sponsor.city} - {sponsor.get_country_display()} ({sponsor.country})'
+        city_row = (
+            f"{sponsor.city} - {sponsor.get_country_display()} ({sponsor.country})"
+        )
         if sponsor.state:
-            city_row = f'{sponsor.city} - {sponsor.state} - {sponsor.get_country_display()} ({sponsor.country})'
+            city_row = f"{sponsor.city} - {sponsor.state} - {sponsor.get_country_display()} ({sponsor.country})"
 
         mail_row = sponsor.mailing_address_line_1
         if sponsor.mailing_address_line_2:
-            mail_row += f' - {sponsor.mailing_address_line_2}'
+            mail_row += f" - {sponsor.mailing_address_line_2}"
 
-        html = f'<p>{city_row}</p>'
-        html += f'<p>{mail_row}</p>'
-        html += f'<p>{sponsor.postal_code}</p>'
+        html = f"<p>{city_row}</p>"
+        html += f"<p>{mail_row}</p>"
+        html += f"<p>{sponsor.postal_code}</p>"
         return mark_safe(html)
 
     get_sponsor_mailing_address.short_description = "Mailing/Billing Address"

--- a/sponsors/forms.py
+++ b/sponsors/forms.py
@@ -13,6 +13,7 @@ from sponsors.models import (
     Sponsor,
     SponsorContact,
     Sponsorship,
+    SponsorBenefit,
 )
 
 
@@ -331,3 +332,40 @@ class SponsorshipReviewAdminForm(forms.ModelForm):
             raise forms.ValidationError("End date must be greater than start date")
 
         return cleaned_data
+
+
+class SponsorBenefitAdminInlineForm(forms.ModelForm):
+    sponsorship_benefit = forms.ModelChoiceField(
+        queryset=SponsorshipBenefit.objects.select_related("program"),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if "benefit_internal_value" in self.fields:
+            self.fields["benefit_internal_value"].required = True
+
+    class Meta:
+        model = SponsorBenefit
+        fields = ["sponsorship_benefit", "sponsorship", "benefit_internal_value"]
+
+    def save(self, commit=True):
+        sponsorship = self.cleaned_data["sponsorship"]
+        benefit = self.cleaned_data["sponsorship_benefit"]
+        value = self.cleaned_data["benefit_internal_value"]
+
+        if not (self.instance and self.instance.pk):  # new benefit
+            self.instance = SponsorBenefit(sponsorship=sponsorship)
+        else:
+            self.instance.refresh_from_db()
+
+        self.instance.benefit_internal_value = value
+        if benefit.pk != self.instance.sponsorship_benefit_id:
+            self.instance.sponsorship_benefit = benefit
+            self.instance.name = benefit.name
+            self.instance.description = benefit.description
+            self.instance.program = benefit.program
+
+        if commit:
+            self.instance.save()
+
+        return self.instance

--- a/sponsors/models.py
+++ b/sponsors/models.py
@@ -362,6 +362,10 @@ class Sponsorship(models.Model):
         return self.benefits.filter(added_by_user=True)
 
     @property
+    def open_for_editing(self):
+        return self.status == self.APPLIED
+
+    @property
     def next_status(self):
         states_map = {
             self.APPLIED: [self.APPROVED, self.REJECTED],


### PR DESCRIPTION
My strategy with this PR is to change the default model form used by `SponsorBenefitInline` by a custom one. The new form has only two fields, one to pick the sponsorship benefit and another to select the internal value for the sponsor benefit. The form differs creation vs update operation and there are unit tests covering these operations.

@ewdurbin here's how the inline forms are looking like now:

![Screenshot from 2020-12-22 11-51-19](https://user-images.githubusercontent.com/238223/102901348-445bc400-444c-11eb-9e4a-d32f492c14fc.png)

This PR also adds permissions control on this inline as well. To keep it simple, I did this by implementing a property to flag if the sponsorship is or isn't open for changes. For now if an application was approved or rejected, it can't be edited anymore. I think this plus an admin action to roll back the sponsorship to an "editable" state makes the internal's state control more solid and less prune to errors. 

Once this PR gets merged into master, we can update this logic in #1702 because, let's imagine we want to edit an approved sponsorship which already has a draft version for the statement of work. There are more operations needed in this scenario (delete the SoW for example) that I think we have to talk about.