### PR TITLE
Enable to rollback sponsorship applications to editing 

### DIFF
--- a/sponsors/models.py
+++ b/sponsors/models.py
@@ -342,6 +342,15 @@ class Sponsorship(models.Model):
         self.status = self.APPROVED
         self.approved_on = timezone.now().date()
 
+    def rollback_to_editing(self):
+        accepts_rollback = [self.APPLIED, self.APPROVED, self.REJECTED]
+        if self.status not in accepts_rollback:
+            msg = f"Can't rollback to edit a {self.get_status_display()} sponsorship."
+            raise SponsorshipInvalidStatusException(msg)
+        self.status = self.APPLIED
+        self.approved_on = None
+        self.rejected_on = None
+
     @property
     def verified_emails(self):
         emails = [self.submited_by.email]

--- a/sponsors/tests/test_views.py
+++ b/sponsors/tests/test_views.py
@@ -321,6 +321,108 @@ class NewSponsorshipApplicationViewTests(TestCase):
         self.assertRedirects(r, reverse("select_sponsorship_application_benefits"))
 
 
+class RollbackSponsorshipToEditingAdminViewTests(TestCase):
+    def setUp(self):
+        self.user = baker.make(
+            settings.AUTH_USER_MODEL, is_staff=True, is_superuser=True
+        )
+        self.client.force_login(self.user)
+        self.sponsorship = baker.make(
+            Sponsorship,
+            status=Sponsorship.APPROVED,
+            submited_by=self.user,
+            _fill_optional=True,
+        )
+        self.url = reverse(
+            "admin:sponsors_sponsorship_rollback_to_edit", args=[self.sponsorship.pk]
+        )
+
+    def test_display_confirmation_form_on_get(self):
+        response = self.client.get(self.url)
+        context = response.context
+        self.sponsorship.refresh_from_db()
+
+        self.assertTemplateUsed(
+            response, "sponsors/admin/rollback_sponsorship_to_editing.html"
+        )
+        self.assertEqual(context["sponsorship"], self.sponsorship)
+        self.assertNotEqual(
+            self.sponsorship.status, Sponsorship.APPLIED
+        )  # did not update
+
+    def test_rollback_sponsorship_to_applied_on_post(self):
+        data = {"confirm": "yes"}
+        response = self.client.post(self.url, data=data)
+        self.sponsorship.refresh_from_db()
+
+        expected_url = reverse(
+            "admin:sponsors_sponsorship_change", args=[self.sponsorship.pk]
+        )
+        self.assertRedirects(response, expected_url, fetch_redirect_response=True)
+        self.assertEqual(self.sponsorship.status, Sponsorship.APPLIED)
+        msg = list(get_messages(response.wsgi_request))[0]
+        assertMessage(msg, "Sponsorship is now editable!", messages.SUCCESS)
+
+    def test_do_not_rollback_if_invalid_post(self):
+        response = self.client.post(self.url, data={})
+        self.sponsorship.refresh_from_db()
+        self.assertTemplateUsed(
+            response, "sponsors/admin/rollback_sponsorship_to_editing.html"
+        )
+        self.assertNotEqual(
+            self.sponsorship.status, Sponsorship.APPLIED
+        )  # did not update
+
+        response = self.client.post(self.url, data={"confirm": "invalid"})
+        self.sponsorship.refresh_from_db()
+        self.assertTemplateUsed(
+            response, "sponsors/admin/rollback_sponsorship_to_editing.html"
+        )
+        self.assertNotEqual(self.sponsorship.status, Sponsorship.APPLIED)
+
+    def test_404_if_sponsorship_does_not_exist(self):
+        self.sponsorship.delete()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_login_required(self):
+        login_url = reverse("admin:login")
+        redirect_url = f"{login_url}?next={self.url}"
+        self.client.logout()
+
+        r = self.client.get(self.url)
+
+        self.assertRedirects(r, redirect_url)
+
+    def test_staff_required(self):
+        login_url = reverse("admin:login")
+        redirect_url = f"{login_url}?next={self.url}"
+        self.user.is_staff = False
+        self.user.save()
+        self.client.force_login(self.user)
+
+        r = self.client.get(self.url)
+
+        self.assertRedirects(r, redirect_url, fetch_redirect_response=False)
+
+    def test_message_user_if_rejecting_invalid_sponsorship(self):
+        self.sponsorship.status = Sponsorship.FINALIZED
+        self.sponsorship.save()
+        data = {"confirm": "yes"}
+        response = self.client.post(self.url, data=data)
+        self.sponsorship.refresh_from_db()
+
+        expected_url = reverse(
+            "admin:sponsors_sponsorship_change", args=[self.sponsorship.pk]
+        )
+        self.assertRedirects(response, expected_url, fetch_redirect_response=True)
+        self.assertEqual(self.sponsorship.status, Sponsorship.FINALIZED)
+        msg = list(get_messages(response.wsgi_request))[0]
+        assertMessage(
+            msg, "Can't rollback to edit a Finalized sponsorship.", messages.ERROR
+        )
+
+
 class RejectedSponsorshipAdminViewTests(TestCase):
     def setUp(self):
         self.user = baker.make(

--- a/templates/sponsors/admin/rollback_sponsorship_to_editing.html
+++ b/templates/sponsors/admin/rollback_sponsorship_to_editing.html
@@ -1,0 +1,35 @@
+{% extends 'admin/base_site.html' %}
+{% load i18n admin_static sponsors %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+
+{% block title %}Rollback {{ sponsorship }} to editing| python.org{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &gt
+  <a href="{% url 'admin:app_list' app_label='sponsors' %}">{% trans 'Sponsors' %}</a> &gt
+  <a href="{% url 'admin:sponsors_sponsorship_changelist' %}">{% trans 'Sponsorship' %}</a> &gt
+  <a href="{% url 'admin:sponsors_sponsorship_change' sponsorship.pk %}">{{ sponsorship }}</a> &gt
+  {% trans 'Rollback to editing' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h1>Rollback to Editing</h1>
+<p>Please review the sponsorship application and click in the Rollback button if you want to proceed.</p>
+<div id="content-main">
+<form action="" method="post" id="new_psf_board_meeting_form">
+{% csrf_token %}
+
+<pre>{% full_sponsorship sponsorship display_fee=True %}</pre>
+
+<input name="confirm" value="yes" style="display:none">
+
+<div class="submit-row">
+    <input type="submit" value="Rollback" class="default">
+</div>
+
+</form>
+<div>
+</div>{% endblock %}

--- a/templates/sponsors/admin/sponsorship_change_form.html
+++ b/templates/sponsors/admin/sponsorship_change_form.html
@@ -16,6 +16,12 @@
     </li>
     {% endif %}
 
+    {% if sp.status != sp.FINALIZED and sp.status != sp.APPLIED %}
+    <li>
+        <a href="{% url 'admin:sponsors_sponsorship_rollback_to_edit' sp.pk %}">Rollback to Edit</a>
+    </li>
+    {% endif %}
+
   {% endwith %}
 
   {{ block.super }}


### PR DESCRIPTION
The discussion in #1710 introduced the idea of having an option to rollback the sponsorship to an editable state. Me and @ewdurbin talked briefly about this and agreed that the strategy is good because it prevents the code from unexpected changes in the application via admin.

This PR mirrors the same strategy as in Accept/Reject that's using a button + a simple page to confirm the rollback operation. This code doesn't know nothing about the statement of work yet. I'll update the PR #1702 with this branch and introduce SoW's required changes in this rollback workflow.