### PR TITLE
Issue #1701: Calendar events now shows the year for events which are not in the current year

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ static/stylesheets/no-mq.css
 static/stylesheets/style.css
 __pycache__
 *.db
+
+
+# Ignore Microsoft Visual Studio Code's and Jetbrain's Pycharm Files
+.vscode/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__
 # Ignore Microsoft Visual Studio Code's and Jetbrain's Pycharm Files
 .vscode/
 .idea/
+sass/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ factory-boy==2.9.2
 Faker==0.8.1
 tblib==1.3.2
 responses==0.10.5
+selenium==3.141.0
 
 # Extra stuff required for local dev
 

--- a/events/models.py
+++ b/events/models.py
@@ -181,6 +181,24 @@ class Event(ContentManageable):
         except IndexError:
             return None
 
+    def is_scheduled_to_start_this_year(self) -> bool:
+        current_year: int = datetime.datetime.now().year
+        try:
+            if self.next_time.dt_start.year == current_year:
+                return True
+        except Exception:
+            pass
+        return False
+
+    def is_scheduled_to_end_this_year(self) -> bool:
+        current_year: int = datetime.datetime.now().year
+        try:
+            if self.next_time.dt_end.year == current_year:
+                return True
+        except Exception:
+            pass
+        return False
+
     @property
     def previous_time(self):
         now = timezone.now()

--- a/events/tests/test_events_functional_test.py
+++ b/events/tests/test_events_functional_test.py
@@ -1,18 +1,38 @@
-from django.test import LiveServerTestCase, TestCase
+import datetime
+
+from django.contrib.auth import get_user_model
+from django.test import LiveServerTestCase
 from django.utils import timezone
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver import Chrome
 
-from .test_views import EventsViewsTests
-from ..models import Event
+from ..models import Event, OccurringRule, Calendar
 
 
-class EventsPageFunctionalTests(LiveServerTestCase, TestCase):
+class EventsPageFunctionalTests(LiveServerTestCase):
     @classmethod
     def setUpClass(cls):
-        EventsViewsTests().setUpTestData()
-        super().setUpClass()
         cls.now = timezone.now()
+        cls.user = get_user_model().objects.create_user(username='username', password='password')
+        cls.calendar = Calendar.objects.create(creator=cls.user, slug="test-calendar-2")
+        cls.event_future_start_following_year = Event.objects.create(title='Event Starts Following Year',
+                                                                     creator=cls.user, calendar=cls.calendar)
+        cls.event_future_end_following_year = Event.objects.create(title='Event Ends Following Year',
+                                                                   creator=cls.user, calendar=cls.calendar)
+        recurring_time_dtstart = cls.now + datetime.timedelta(days=3)
+        recurring_time_dtend = recurring_time_dtstart + datetime.timedelta(days=5)
+
+        cls.rule_future_start_year = OccurringRule.objects.create(
+            event=cls.event_future_start_following_year,
+            dt_start=recurring_time_dtstart + datetime.timedelta(weeks=52),
+            dt_end=recurring_time_dtstart + datetime.timedelta(weeks=53),
+        )
+        cls.rule_future_end_year = OccurringRule.objects.create(
+            event=cls.event_future_end_following_year,
+            dt_start=recurring_time_dtstart,
+            dt_end=recurring_time_dtend + datetime.timedelta(weeks=52)
+        )
+        super(EventsPageFunctionalTests, cls).setUpClass()
 
     def setUp(self) -> None:
         try:
@@ -25,17 +45,18 @@ class EventsPageFunctionalTests(LiveServerTestCase, TestCase):
             webdriver.Firefox(options=self.browser)
 
     def tearDown(self) -> None:
-        self.browser.quit()
+        super().tearDown()
+        try:
+            self.browser.quit()
+        except Exception:
+            pass
 
-    def test_event_starting_future_year_displays_year(self):
-        event = Event.objects.get(title=f"Event Starts Following Year")
+    def test_event_starting_and_ending_future_year_displays_year(self):
+        event = self.event_future_start_following_year
         self.browser.get(self.live_server_url + '/events/')
         future_event_span_value = self.browser.find_element_by_id(str(event.id))
         self.assertIn(str(event.next_time.dt_start.year), future_event_span_value.text)
 
-    def test_event_ending_future_year_displays_year(self):
-        event = Event.objects.get(title=f"Event Ends Following Year")
-        self.browser.get(self.live_server_url + '/events/')
-        future_event_span_value = self.browser.find_element_by_id(str(event.id))
-        self.assertIn(str(event.next_time.dt_end.year), future_event_span_value.text)
-
+        event_2 = Event.objects.get(title="Event Ends Following Year")
+        future_event_span_value = self.browser.find_element_by_id(str(event_2.id))
+        self.assertIn(str(event_2.next_time.dt_end.year), future_event_span_value.text)

--- a/events/tests/test_events_functional_test.py
+++ b/events/tests/test_events_functional_test.py
@@ -1,0 +1,41 @@
+from django.test import LiveServerTestCase, TestCase
+from django.utils import timezone
+from selenium.common.exceptions import WebDriverException
+from selenium.webdriver import Chrome
+
+from .test_views import EventsViewsTests
+from ..models import Event
+
+
+class EventsPageFunctionalTests(LiveServerTestCase, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        EventsViewsTests().setUpTestData()
+        super().setUpClass()
+        cls.now = timezone.now()
+
+    def setUp(self) -> None:
+        try:
+            self.browser = Chrome()
+            self.browser.implicitly_wait(5)
+        except WebDriverException:  # GitHub Actions Django CI
+            from selenium import webdriver
+            self.browser = webdriver.FirefoxOptions()
+            self.browser.headless = True
+            webdriver.Firefox(options=self.browser)
+
+    def tearDown(self) -> None:
+        self.browser.quit()
+
+    def test_event_starting_future_year_displays_year(self):
+        event = Event.objects.get(title=f"Event Starts Following Year")
+        self.browser.get(self.live_server_url + '/events/')
+        future_event_span_value = self.browser.find_element_by_id(str(event.id))
+        self.assertIn(str(event.next_time.dt_start.year), future_event_span_value.text)
+
+    def test_event_ending_future_year_displays_year(self):
+        event = Event.objects.get(title=f"Event Ends Following Year")
+        self.browser.get(self.live_server_url + '/events/')
+        future_event_span_value = self.browser.find_element_by_id(str(event.id))
+        self.assertIn(str(event.next_time.dt_end.year), future_event_span_value.text)
+

--- a/events/tests/test_models.py
+++ b/events/tests/test_models.py
@@ -62,7 +62,6 @@ class EventsModelsTests(TestCase):
         self.assertEqual(self.event.next_time.dt_start, recurring_time_dtstart)
         self.assertTrue(rt.valid_dt_end())
 
-
         rt.begin = now - datetime.timedelta(days=5)
         rt.finish = now - datetime.timedelta(days=3)
         rt.save()
@@ -186,3 +185,25 @@ class EventsModelsTests(TestCase):
         # 'Event.previous_event' can return None if there is no
         # OccurringRule or RecurringRule found.
         self.assertIsNone(self.event.previous_event)
+
+    def test_scheduled_to_start_this_year_method(self):
+        now = seconds_resolution(timezone.now())
+
+        occurring_time_dtstart = now + datetime.timedelta(days=3)
+        OccurringRule.objects.create(
+            event=self.event,
+            dt_start=occurring_time_dtstart,
+            dt_end=occurring_time_dtstart
+        )
+        self.assertTrue(self.event.is_scheduled_to_start_this_year())
+
+    def test_scheduled_to_end_this_year_method(self):
+        now = seconds_resolution(timezone.now())
+
+        occurring_time_dtstart = now + datetime.timedelta(days=3)
+        OccurringRule.objects.create(
+            event=self.event,
+            dt_start=occurring_time_dtstart,
+            dt_end=occurring_time_dtstart
+        )
+        self.assertTrue(self.event.is_scheduled_to_end_this_year())

--- a/events/tests/test_views.py
+++ b/events/tests/test_views.py
@@ -19,10 +19,6 @@ class EventsViewsTests(TestCase):
         cls.event = Event.objects.create(creator=cls.user, calendar=cls.calendar)
         cls.event_past = Event.objects.create(title='Past Event', creator=cls.user, calendar=cls.calendar)
         cls.event_single_day = Event.objects.create(title="Single Day Event", creator=cls.user, calendar=cls.calendar)
-        cls.event_future_start_following_year = Event.objects.create(title='Event Starts Following Year',
-                                                                     creator=cls.user, calendar=cls.calendar)
-        cls.event_future_end_following_year = Event.objects.create(title='Event Ends Following Year',
-                                                                   creator=cls.user, calendar=cls.calendar)
 
         cls.now = timezone.now()
 
@@ -44,21 +40,12 @@ class EventsViewsTests(TestCase):
             dt_start=recurring_time_dtstart,
             dt_end=recurring_time_dtstart
         )
-        cls.rule_future_start_year = OccurringRule.objects.create(
-            event=cls.event_future_start_following_year,
-            dt_start=recurring_time_dtstart + datetime.timedelta(weeks=52),
-            dt_end=recurring_time_dtstart + datetime.timedelta(weeks=53),
-        )
-        cls.rule_future_end_year = OccurringRule.objects.create(
-            event=cls.event_future_end_following_year,
-            dt_start=recurring_time_dtstart,
-            dt_end=recurring_time_dtend + datetime.timedelta(weeks=52)
-        )
+
     def test_events_homepage(self):
         url = reverse('events:events')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context['object_list']), 4)
+        self.assertEqual(len(response.context['object_list']), 2)
         self.assertIn(Event.objects.last().title, response.content.decode())
 
     def test_calendar_list(self):
@@ -74,7 +61,7 @@ class EventsViewsTests(TestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context['object_list']), 4)
+        self.assertEqual(len(response.context['object_list']), 2)
 
         url = reverse('events:event_list_past', kwargs={"calendar_slug": 'unexisting'})
         response = self.client.get(url)
@@ -134,7 +121,7 @@ class EventsViewsTests(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['object'], dt.date())
-        self.assertEqual(len(response.context['object_list']), 5)
+        self.assertEqual(len(response.context['object_list']), 3)
 
     def test_eventlocation_list(self):
         venue = EventLocation.objects.create(
@@ -170,12 +157,12 @@ class EventsViewsTests(TestCase):
         self.assertEqual(self.event, response.context['object'])
 
     def test_upcoming_tag(self):
-        self.assertEqual(len(get_events_upcoming()), 4)
+        self.assertEqual(len(get_events_upcoming()), 2)
         self.assertEqual(len(get_events_upcoming(only_featured=True)), 0)
         self.rule.begin = self.now - datetime.timedelta(days=3)
         self.rule.finish = self.now - datetime.timedelta(days=2)
         self.rule.save()
-        self.assertEqual(len(get_events_upcoming()), 3)
+        self.assertEqual(len(get_events_upcoming()), 1)
 
 
 class EventSubmitTests(TestCase):

--- a/templates/events/event_list.html
+++ b/templates/events/event_list.html
@@ -45,7 +45,11 @@
                         <h3 class="event-title"><a href="{{ object.get_absolute_url }}">{{ object.title|striptags }}</a></h3>
                         <p>
                             {% with object.next_time as next_time %}
+                            {% with object.is_scheduled_to_start_this_year as scheduled_start_this_year %}
+                            {% with object.is_scheduled_to_end_this_year as scheduled_end_this_year %}
                             {% include "events/includes/time_tag.html" %}
+                            {% endwith %}
+                            {% endwith %}
                             {% endwith %}
 
                             {% if object.venue %}
@@ -65,7 +69,11 @@
                     <h3 class="event-title"><a href="{{ object.get_absolute_url }}">{{ object.title|striptags }}</a></h3>
                     <p>
                         {% with object.previous_time as next_time %}
+                        {% with object.is_scheduled_to_start_this_year as scheduled_start_this_year %}
+                        {% with object.is_scheduled_to_end_this_year as scheduled_end_this_year %}
                         {% include "events/includes/time_tag.html" %}
+                        {% endwith %}
+                        {% endwith %}
                         {% endwith %}
 
                         {% if object.venue %}

--- a/templates/events/includes/time_tag.html
+++ b/templates/events/includes/time_tag.html
@@ -1,5 +1,32 @@
 {% if next_time.single_day %}
-<time datetime="{{ next_time.dt_start|date:'c' }}">{{ next_time.dt_start|date:"d N" }}<span class="say-no-more"> {{ next_time.dt_start|date:"Y" }}</span>{% if not next_time.all_day %} {{ next_time.dt_start|date:"fA"|lower }} {{ next_time.dt_start|date:"e" }}{% if next_time.valid_dt_end %} – {{ next_time.dt_end|date:"fA"|lower }} {{ next_time.dt_end|date:"e" }}{% endif %}{% endif %}</time>
+    <time id="{{ object.id }}" datetime="{{ next_time.dt_start|date:'c' }}">{{ next_time.dt_start|date:"d N" }}
+        <span {% if scheduled_start_this_year %}class="say-no-more"{% endif %}>
+            {{ next_time.dt_start|date:"Y" }}
+        </span>
+
+        <span {% if scheduled_end_this_year %}class="say-no-more"{% endif %}>
+            {{ next_time.dt_start|date:"Y" }}
+        </span>
+
+        {% if not next_time.all_day %}
+            {{ next_time.dt_start|date:"fA"|lower }} {{ next_time.dt_start|date:"e" }}
+                {% if next_time.valid_dt_end %} – {{ next_time.dt_end|date:"fA"|lower }}
+                    {{ next_time.dt_end|date:"e" }}
+                {% endif %}
+        {% endif %}
+    </time>
 {% else %}
-<time datetime="{{ next_time.dt_start|date:'c' }}">{{ next_time.dt_start|date:"d N" }}{% if next_time.valid_dt_end %} &ndash; {{ next_time.dt_end|date:"d N" }}{% endif %} <span class="say-no-more"> {{ next_time.dt_end|date:"Y" }}</span></time>
+    <time id="{{ object.id }}" datetime="{{ next_time.dt_start|date:'c' }}">{{ next_time.dt_start|date:"d N" }}
+        <span {% if scheduled_start_this_year %}class="say-no-more"{% endif %}>
+            {{ next_time.dt_start|date:"Y" }}
+        </span>
+
+        {% if next_time.valid_dt_end %} &ndash;
+            {{ next_time.dt_end|date:"d N" }}
+        {% endif %}
+
+        <span {% if scheduled_end_this_year %}class="say-no-more"{% endif %}>
+            {{ next_time.dt_end|date:"Y" }}
+        </span>
+    </time>
 {% endif %}


### PR DESCRIPTION
Any calendar event that is dated beyond the current year now displays the year at which it has been scheduled. This happens for both start date and end date. 

I must say that I encountered serious difficulty with Django's `LiveServerTestCase` and at the end, I decided to just merge the 2 functional test method into one. Django's `LiveServerTestCase` for some reason **cannot** run multiple test methods [belonging to the same test class] at a stretch. This is because at the end of executing each test method, django sort of resets the data base leading to a lot of integrity errors and confusing test results. 

Please feel free to ask me any questions. This is my first time contributing to the open source community. 
Thanks in anticipated reply. 