### PR TITLE
Refactor how logged user navbar is constructed

### DIFF
--- a/pydotorg/context_processors.py
+++ b/pydotorg/context_processors.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.urls import resolve, Resolver404
+from django.urls import resolve, Resolver404, reverse
 
 
 def site_info(request):
@@ -28,3 +28,38 @@ def blog_url(request):
     return {
         'BLOG_URL': settings.PYTHON_BLOG_URL,
     }
+
+
+def user_nav_bar_links(request):
+    nav = {}
+    if request.user.is_authenticated:
+        user = request.user.username
+        nav = {
+            "account": {
+                "label": "Your Account",
+                "urls": [
+                    {"url": reverse("users:user_detail", args=[user]), "label": "View profile"},
+                    {"url": reverse("users:user_profile_edit"), "label": "Edit profile"},
+                    {"url": reverse("account_change_password"), "label": "Change password"},
+                ],
+            },
+            "psf_membership": {
+                "label": "Membership",
+                "urls": [
+                    {"url": reverse("users:user_nominations_view"), "label": "Nominations"},
+                ],
+            }
+        }
+
+        if request.user.has_membership:
+            nav["psf_membership"]['urls'].append({
+                "url": reverse("users:user_membership_edit"),
+                "label": "Edit PSF membership"
+            })
+        else:
+            nav["psf_membership"]['urls'].append({
+                "url": reverse("users:user_membership_create"),
+                "label": "Become a PSF member"
+            })
+
+    return {"USER_NAV_BAR": nav}

--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -103,6 +103,7 @@ TEMPLATES = [
                 'pydotorg.context_processors.url_name',
                 'pydotorg.context_processors.get_host_with_scheme',
                 'pydotorg.context_processors.blog_url',
+                'pydotorg.context_processors.user_nav_bar_links',
             ],
         },
     },

--- a/pydotorg/tests/test_context_processors.py
+++ b/pydotorg/tests/test_context_processors.py
@@ -1,6 +1,10 @@
+from model_bakery import baker
+
+from django.urls import reverse
 from django.conf import settings
 from pydotorg import context_processors
 from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import AnonymousUser
 
 
 class TemplateProcessorsTestCase(TestCase):
@@ -26,3 +30,64 @@ class TemplateProcessorsTestCase(TestCase):
     def test_blog_url(self):
         request = self.factory.get('/about/')
         self.assertEqual({'BLOG_URL': settings.PYTHON_BLOG_URL}, context_processors.blog_url(request))
+
+    def test_user_nav_bar_links_for_non_psf_members(self):
+        request = self.factory.get('/about/')
+        request.user = baker.make(settings.AUTH_USER_MODEL, username='foo')
+
+        expected_nav = {
+            "account": {
+                "label": "Your Account",
+                "urls": [
+                    {"url": reverse("users:user_detail", args=['foo']), "label": "View profile"},
+                    {"url": reverse("users:user_profile_edit"), "label": "Edit profile"},
+                    {"url": reverse("account_change_password"), "label": "Change password"},
+                ],
+            },
+            "psf_membership": {
+                "label": "Membership",
+                "urls": [
+                    {"url": reverse("users:user_nominations_view"), "label": "Nominations"},
+                    {"url": reverse("users:user_membership_create"), "label": "Become a PSF member"},
+                ],
+            }
+        }
+
+        self.assertEqual(
+            {"USER_NAV_BAR": expected_nav},
+            context_processors.user_nav_bar_links(request)
+        )
+
+    def test_user_nav_bar_links_for_psf_members(self):
+        request = self.factory.get('/about/')
+        request.user = baker.make(settings.AUTH_USER_MODEL, username='foo')
+        baker.make('users.Membership', creator=request.user)
+
+        expected_nav = {
+            "account": {
+                "label": "Your Account",
+                "urls": [
+                    {"url": reverse("users:user_detail", args=['foo']), "label": "View profile"},
+                    {"url": reverse("users:user_profile_edit"), "label": "Edit profile"},
+                    {"url": reverse("account_change_password"), "label": "Change password"},
+                ],
+            },
+            "psf_membership": {
+                "label": "Membership",
+                "urls": [
+                    {"url": reverse("users:user_nominations_view"), "label": "Nominations"},
+                    {"url": reverse("users:user_membership_edit"), "label": "Edit PSF membership"},
+                ],
+            }
+        }
+
+        self.assertEqual(
+            {"USER_NAV_BAR": expected_nav},
+            context_processors.user_nav_bar_links(request)
+        )
+
+    def test_user_nav_bar_links_for_anonymous_user(self):
+        request = self.factory.get('/about/')
+        request.user = AnonymousUser()
+
+        self.assertEqual({"USER_NAV_BAR": {}}, context_processors.user_nav_bar_links(request))

--- a/pydotorg/tests/test_context_processors.py
+++ b/pydotorg/tests/test_context_processors.py
@@ -1,32 +1,28 @@
 from django.conf import settings
 from pydotorg import context_processors
-from django.test import TestCase
-
-
-class MockRequest:
-    def __init__(self, path):
-        self.path = path
-        super().__init__()
+from django.test import TestCase, RequestFactory
 
 
 class TemplateProcessorsTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
     def test_url_name(self):
-        mock_request = MockRequest(path='/inner/')
-        self.assertEqual({'URL_NAMESPACE': '', 'URL_NAME': 'inner'}, context_processors.url_name(mock_request))
+        request = self.factory.get('/inner/')
+        self.assertEqual({'URL_NAMESPACE': '', 'URL_NAME': 'inner'}, context_processors.url_name(request))
 
-        mock_request = MockRequest(path='/events/calendars/')
-        self.assertEqual({'URL_NAMESPACE': 'events', 'URL_NAME': 'events:calendar_list'}, context_processors.url_name(mock_request))
+        request = self.factory.get('/events/calendars/')
+        self.assertEqual({'URL_NAMESPACE': 'events', 'URL_NAME': 'events:calendar_list'}, context_processors.url_name(request))
 
-        mock_request = MockRequest(path='/getit-404/releases/3.3.3/not-an-actual-thing/')
-        self.assertEqual({}, context_processors.url_name(mock_request))
+        request = self.factory.get('/getit-404/releases/3.3.3/not-an-actual-thing/')
+        self.assertEqual({}, context_processors.url_name(request))
 
-        mock_request = MockRequest(path='/getit-404/releases/3.3.3/\r\n/')
-        self.assertEqual({}, context_processors.url_name(mock_request))
+        request = self.factory.get('/getit-404/releases/3.3.3/\r\n/')
+        self.assertEqual({}, context_processors.url_name(request))
 
-        mock_request = MockRequest(path='/nothing/here/')
-        self.assertEqual({}, context_processors.url_name(mock_request))
+        request = self.factory.get('/nothing/here/')
+        self.assertEqual({}, context_processors.url_name(request))
 
     def test_blog_url(self):
-        mock_request = MockRequest(path='/about/')
-        self.assertEqual({'BLOG_URL': settings.PYTHON_BLOG_URL}, context_processors.blog_url(mock_request))
-
+        request = self.factory.get('/about/')
+        self.assertEqual({'BLOG_URL': settings.PYTHON_BLOG_URL}, context_processors.blog_url(request))

--- a/templates/users/base.html
+++ b/templates/users/base.html
@@ -14,23 +14,18 @@
 
 
 {% block content %}
-
-    {% if request.user.is_authenticated %}
+  {% if USER_NAV_BAR %}
     <div class="user-profile-controls">
         <ul class="menu">
-            <li>Manage your Information: </li>
-            <li><a href="{% url 'users:user_detail' slug=request.user.username %}">View profile</a></li>
-            <li><a href="{% url 'users:user_nominations_view' %}">Nominations</a></li>
-            <li><a href="{% url 'users:user_profile_edit' %}">Edit profile</a></li>
-            {% if request.user.has_membership %}
-            <li><a href="{% url 'users:user_membership_edit' %}">Edit PSF membership</a></li>
-            {% else %}
-            <li><a href="{% url 'users:user_membership_create' %}">Become a PSF member</a></li>
-            {% endif %}
-            <li><a href="{% url 'account_change_password' %}">Change Password</a></li>
+          <li>Manage your Information: </li>
+          {% for section in USER_NAV_BAR.values %}
+            {% for url in section.urls %}
+            <li><a href="{{ url.url }}">{{ url.label }}</a></li>
+            {% endfor %}
+          {% endfor %}
         </ul>
     </div>
-    {% endif %}
     {% block user_content %}{% endblock %}
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
This PR opens path for us to work on #1728 and also makes #1729 work easier because not it comes down only to styling the nav bar.

@ewdurbin I decided to move the links construction to the backend via context processor, but I'm not sure how this will play with our cdn's cache. Let me know what you think about it.