### PR TITLE
Reinstate support for PEP_REPO_PATH setting.

### DIFF
--- a/peps/management/commands/generate_pep_pages.py
+++ b/peps/management/commands/generate_pep_pages.py
@@ -51,16 +51,19 @@ class Command(BaseCommand):
         verbose("== Starting PEP page generation")
 
         with ExitStack() as stack:
-            verbose(f"== Fetching PEP artifact from {settings.PEP_ARTIFACT_URL}")
-            temp_file = self.get_artifact_tarball(stack)
-            if not temp_file:
-                verbose("== No update to artifacts, we're done here!")
-                return
-            temp_dir = stack.enter_context(TemporaryDirectory())
-            tar_ball = stack.enter_context(TarFile.open(fileobj=temp_file, mode='r:gz'))
-            tar_ball.extractall(path=temp_dir, numeric_owner=False)
+            if settings.PEP_REPO_PATH is not None:
+                artifacts_path = settings.PEP_REPO_PATH
+            else:
+                verbose(f"== Fetching PEP artifact from {settings.PEP_ARTIFACT_URL}")
+                temp_file = self.get_artifact_tarball(stack)
+                if not temp_file:
+                    verbose("== No update to artifacts, we're done here!")
+                    return
+                temp_dir = stack.enter_context(TemporaryDirectory())
+                tar_ball = stack.enter_context(TarFile.open(fileobj=temp_file, mode='r:gz'))
+                tar_ball.extractall(path=temp_dir, numeric_owner=False)
 
-            artifacts_path = os.path.join(temp_dir, 'peps')
+                artifacts_path = os.path.join(temp_dir, 'peps')
 
             verbose("Generating RSS Feed")
             peps_rss = get_peps_rss(artifacts_path)

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -1,4 +1,5 @@
 from .base import *
+import os
 
 DEBUG = True
 
@@ -26,7 +27,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # Set the local pep repository path to fetch PEPs from,
 # or none to fallback to the tarball specified by PEP_ARTIFACT_URL.
-PEP_REPO_PATH = None  # directory path or None
+PEP_REPO_PATH = os.environ.get('PEP_REPO_PATH', None)  # directory path or None
 
 # Set the path to where to fetch PEP artifacts from.
 # The value can be a local path or a remote URL.

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -24,8 +24,13 @@ HAYSTACK_CONNECTIONS = {
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+# Set the local pep repository path to fetch PEPs from,
+# or none to fallback to the tarball specified by PEP_ARTIFACT_URL.
+PEP_REPO_PATH = None  # directory path or None
+
 # Set the path to where to fetch PEP artifacts from.
 # The value can be a local path or a remote URL.
+# Ignored if PEP_REPO_PATH is set.
 PEP_ARTIFACT_URL = os.path.join(BASE, 'peps/tests/peps.tar.gz')
 
 # Use Dummy SASS compiler to avoid performance issues and remove the need to


### PR DESCRIPTION
This setting is referenced by PEP generation documentation
in both this repository (at pythondotorg/docs/source/pep_generation.rst)
and in the PEPs repository (at peps/README.rst).