### PR TITLE
Bugfix: sponsorship package-only benefits disappearing 

### DIFF
--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -119,6 +119,21 @@ class SponsorBenefitInline(admin.TabularInline):
         return obj.open_for_editing
 
 
+class LevelNameFilter(admin.SimpleListFilter):
+    title = "level name"
+    parameter_name = "level"
+
+    def lookups(self, request, model_admin):
+        qs = SponsorshipPackage.objects.all()
+        return list(set([(program.name, program.name) for program in qs]))
+
+    def queryset(self, request, queryset):
+        if self.value() == "all":
+            return queryset
+        if self.value():
+            return queryset.filter(level_name=self.value())
+
+
 @admin.register(Sponsorship)
 class SponsorshipAdmin(admin.ModelAdmin):
     change_form_template = "sponsors/admin/sponsorship_change_form.html"
@@ -134,7 +149,7 @@ class SponsorshipAdmin(admin.ModelAdmin):
         "end_date",
         "display_sponsorship_link",
     ]
-    list_filter = ["status"]
+    list_filter = ["status", LevelNameFilter]
     readonly_fields = [
         "for_modified_package",
         "sponsor",

--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -127,6 +127,7 @@ class SponsorshipAdmin(admin.ModelAdmin):
     list_display = [
         "sponsor",
         "status",
+        "level_name",
         "applied_on",
         "approved_on",
         "start_date",

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -24,7 +24,7 @@ $(document).ready(function(){
 
     SELECTORS.clearFormBtn().click(function(){
         SELECTORS.applicationForm().trigger("reset");
-        SELECTORS.applicationForm().find("[class=active]").removeClass("active");
+        SELECTORS.applicationForm().find(".active").removeClass("active");
         SELECTORS.packageInput().prop("checked", false);
         SELECTORS.checkboxesContainer().find(':checkbox').each(function(){
             $(this).prop('checked', false);

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -54,7 +54,7 @@
             {% for benefit in field.field.queryset %}
                 <li class="{% cycle '' 'highlight' %}">
                     <label for="id_{{field.name}}_{{ forloop.counter0 }}" {% if benefit.package_only %} class='package_only'{% endif %} benefit_id="{{ benefit.id }}">
-                        <input id="id_{{field.name}}_{{ forloop.counter0 }}" name="{{ field.name }}" type="checkbox" value="{{ benefit.id }}" {% if benefit.unavailability_message %}disabled{% endif %} {% if benefit.id in field.initial %}checked{% endif %} {% if benefit.package_only %}package_only='true'{% endif %}>
+                        <input id="id_{{field.name}}_{{ forloop.counter0 }}" name="{{ field.name }}" type="checkbox" value="{{ benefit.id }}" {% if benefit.unavailability_message and benefit.id not in field.initial %}disabled{% endif %} {% if benefit.id in field.initial %}checked{% endif %} {% if benefit.package_only %}package_only='true'{% endif %}>
                         <span>{{ benefit.name }}</span>
                         {% if benefit.description %}<i class="fa fa-info" title="{{ benefit.description }}"></i>{% endif %}
                         {% if benefit.package_only %}<i class="fa fa-cubes"  title="{{ benefit_model.PACKAGE_ONLY_MESSAGE }}"></i>{% endif %}


### PR DESCRIPTION
Here are the steps listed by @ewdurbin to reproduce the error:

1. clear sponsorship_selected_benefits cookie
2. go to http://localhost:8000/sponsors/application/
3. Select ‘Supporting’
4. Click Submit
5. Click Back to select benefits
6. Note that Virtual Booth and Inclusion in a PSF blog about…. are in a weird mixed state (checked but disabled)
7. Click Submit
8. Note that benefits are missing
9. If you once again click “Back to select benefits” you will see the two benefits are now not checked at all.

Since the checkbox is disabled, the browser doesn't add it to the post body as part of the form data, even though it's being displayed as checked.

This PR fixes this by not disabling the checkbox if it's already checked and now, if you reproduce the steps above, you'll notice that both benefits are still checked but not disabled. 

I also added minor things to the sponsorship application admin. Both the new filter and the level name column helped me to investigate the database state faster, so I think it can help PSF staff as well.