### PR TITLE
Topic/sponsorship form fixes

### DIFF
--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -45,6 +45,9 @@ $(document).ready(function(){
       benefitInput.prop("checked", true);
     });
 
+    // hide previous custom fee messages
+    $('.custom-fee').hide();
+
     mobileUpdate(package);
   });
 });
@@ -80,9 +83,22 @@ function benefitUpdate(benefitId, packageId) {
   const hiddenInput = benefitsInputs.filter((b) => b.getAttribute('data-benefit-id') == benefitId)[0];
   hiddenInput.checked = !hiddenInput.checked;
   clickedImg.src = newSrc;
+
+  // Check if there are any type of customization. If so, display custom-fee label.
+  let pkgBenefits = Array(...document.getElementById(`package_benefits_${packageId}`).children).map(div => div.textContent).sort();
+  let checkedBenefis = Array(...document.querySelectorAll('[data-benefit-id]')).filter(e => e.checked).map(input => input.value).sort();
+
+  const hasAllBenefts = pkgBenefits.reduce((sum, id) => sum && checkedBenefis.includes(id), true);
+  const sameBenefitsNum = pkgBenefits.length === checkedBenefis.length;
+
+  if (hasAllBenefts && sameBenefitsNum) {
+    document.getElementById(`custom-fee-${packageId}`).style.display = 'none';
+  } else {
+    document.getElementById(`custom-fee-${packageId}`).style.display = 'initial';
+  }
 };
 
-
+// Callback function when user selects a package;
 function updatePackageInput(packageId){
   const packageInput = document.getElementById(`id_package_${ packageId }`);
   packageInput.click();

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -91,10 +91,11 @@ function benefitUpdate(benefitId, packageId) {
   const hasAllBenefts = pkgBenefits.reduce((sum, id) => sum && checkedBenefis.includes(id), true);
   const sameBenefitsNum = pkgBenefits.length === checkedBenefis.length;
 
+  const customFeeElems = Array(...document.getElementsByClassName(`custom-fee-${packageId}`));
   if (hasAllBenefts && sameBenefitsNum) {
-    document.getElementById(`custom-fee-${packageId}`).style.display = 'none';
+    customFeeElems.map(e => e.style.display = 'none');
   } else {
-    document.getElementById(`custom-fee-${packageId}`).style.display = 'initial';
+    customFeeElems.map(e => e.style.display = 'initial');
   }
 };
 

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3909,6 +3909,17 @@ span.highlighted {
     @media (max-width: 1200px) and (max-width: 640px) {
       #select_sponsorship_benefits_container #package-selection .row .col:not(first-child) {
         width: 80%; } }
+@media (min-width: 1200px) {
+  #select_sponsorship_benefits_container {
+    /* Destkop version have the package selection row as a fixed header after some scrolling.
+       This CSS block address this logic.
+     */ }
+    #select_sponsorship_benefits_container .sticky {
+      position: -webkit-sticky;
+      /* for Safari */
+      position: sticky;
+      top: 0;
+      background-color: white; } }
 
 #thank-you-container {
   background: #417DAF;

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3808,8 +3808,11 @@ span.highlighted {
     border-bottom: none; }
   #select_sponsorship_benefits_container #benefitsTable .package-input {
     cursor: pointer; }
-    #select_sponsorship_benefits_container #benefitsTable .package-input span {
+    #select_sponsorship_benefits_container #benefitsTable .package-input .package-price {
       padding-bottom: 0.5em; }
+    #select_sponsorship_benefits_container #benefitsTable .package-input .custom-fee {
+      font-size: 75%;
+      display: none; }
     #select_sponsorship_benefits_container #benefitsTable .package-input h4 {
       transform: rotateY(35deg); }
   #select_sponsorship_benefits_container #benefitsTable .selected {

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3922,7 +3922,14 @@ span.highlighted {
       /* for Safari */
       position: sticky;
       top: 0;
-      background-color: white; } }
+      background-color: #fcfcfc;
+      *zoom: 1;
+      filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFF9F9F9', endColorstr='#FFFCFCFC');
+      background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #f9f9f9), color-stop(90%, #fcfcfc));
+      background-image: -webkit-linear-gradient(#f9f9f9 10%, #fcfcfc 90%);
+      background-image: -moz-linear-gradient(#f9f9f9 10%, #fcfcfc 90%);
+      background-image: -o-linear-gradient(#f9f9f9 10%, #fcfcfc 90%);
+      background-image: linear-gradient(#f9f9f9 10%, #fcfcfc 90%); } }
 
 #thank-you-container {
   background: #417DAF;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2673,8 +2673,13 @@ $breakpoint-desktop: 1200px;
     }
 
     .package-input {
-      span {
+      .package-price {
         padding-bottom: 0.5em;
+      }
+
+      .custom-fee {
+        font-size: 75%;
+        display: none;
       }
 
       h4 {

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2846,7 +2846,8 @@ $breakpoint-desktop: 1200px;
       position: -webkit-sticky; /* for Safari */
       position: sticky;
       top: 0;
-      background-color: $white;
+//background-color: #fcfcfc;  /* same as content-wrapper */
+      @include vertical-gradient(#f9f9f9, #fcfcfc);
     }
   }
 

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2831,6 +2831,20 @@ $breakpoint-desktop: 1200px;
       }
     }
   }
+
+
+  @media (min-width: $breakpoint-desktop) {
+    /* Destkop version have the package selection row as a fixed header after some scrolling.
+       This CSS block address this logic.
+     */
+    .sticky {
+      position: -webkit-sticky; /* for Safari */
+      position: sticky;
+      top: 0;
+      background-color: $white;
+    }
+  }
+
 }
 
 #thank-you-container {

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -14,6 +14,7 @@
     <div id="select_sponsorship_benefits_container">
       <h1>Sponsor the PSF</h1>
       <p>Select a sponsorship package or customize the benefits that make the most sense for your business.</p>
+      <p><small>Obs: the listed fees are only valid if no changes were made to Sponsorship Package's default benefits.</small></p>
       <br/>
 
       <div class="row section-title">
@@ -44,8 +45,9 @@
              {% for package in form.fields.package.queryset %}
              <div class="col col-items package-input" data-package-id="{{ package.id}}" onclick="updatePackageInput({{forloop.counter0}})">
                <h4>{{ package.name|upper }}</h4>
-               <span>${{ package.sponsorship_amount|intcomma }}</span>
+               <span class="package-price">${{ package.sponsorship_amount|intcomma }}</span>
                <input type="radio" name="package" value="{{ package.id }}" id="id_package_{{ forloop.counter0 }}" {% if package.id == form.initial.package %}checked="checked"{% endif %} data-pos={{ forloop.counter0 }} />
+               <span id="custom-fee-{{ package.id }}" class="custom-fee">Fee can change</span>
              </div>
              {% endfor %}
           </div>

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -24,7 +24,7 @@
       <div id="benefitsTable">
 
         <!-- Package selection --!>
-        <div id="package-selection">
+        <div id="package-selection" class="sticky">
           <div class="row no-border">
              <span class="col">
                {% if form.errors %}

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -14,7 +14,7 @@
     <div id="select_sponsorship_benefits_container">
       <h1>Sponsor the PSF</h1>
       <p>Select a sponsorship package or customize the benefits that make the most sense for your business.</p>
-      <p><small>Obs: the listed fees are only valid if no changes were made to Sponsorship Package's default benefits.</small></p>
+      <p><small>The listed sponsorship costs are subject to change if customization to selected benefits are made.</small></p>
       <br/>
 
       <div class="row section-title">

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -45,9 +45,9 @@
              {% for package in form.fields.package.queryset %}
              <div class="col col-items package-input" data-package-id="{{ package.id}}" onclick="updatePackageInput({{forloop.counter0}})">
                <h4>{{ package.name|upper }}</h4>
-               <span class="package-price">${{ package.sponsorship_amount|intcomma }}</span>
+               <span class="package-price">${{ package.sponsorship_amount|intcomma }}<span class="custom-fee-{{ package.id }} custom-fee">*</span></span>
                <input type="radio" name="package" value="{{ package.id }}" id="id_package_{{ forloop.counter0 }}" {% if package.id == form.initial.package %}checked="checked"{% endif %} data-pos={{ forloop.counter0 }} />
-               <span id="custom-fee-{{ package.id }}" class="custom-fee">Fee can change</span>
+               <span class="custom-fee-{{ package.id }} custom-fee">* Subject to change</span>
              </div>
              {% endfor %}
           </div>


### PR DESCRIPTION
Fixes #1760 

Here's a screen shot of both sticky header and custom fee message:

![Screenshot from 2021-04-21 11-49-32](https://user-images.githubusercontent.com/238223/115574192-cd1e2b80-a297-11eb-9c4a-73153f38d4a0.png)

@ewdurbin I felt that adding a message was less disruptive with package header row organization than replacing the fee by a custom message. Even though, you can see that when the message appears, the header changes its heights and it annoys me a little bit. I didn't worry that much with the texting part as well, so review is needed.