### PR TITLE
fix input-output order in interpreter example

### DIFF
--- a/codesamples/factories.py
+++ b/codesamples/factories.py
@@ -33,7 +33,7 @@ def initial_data():
             >>> name = input('What is your name?\\n')
             <span class=\"output\">What is your name?
             Python</span>
-            >>> print('Hi, %s.' % name)
+            >>> print(f'Hi, {name}.')
             <span class=\"output\">Hi, Python.</span></code>
             </pre>
             """,

--- a/codesamples/factories.py
+++ b/codesamples/factories.py
@@ -31,10 +31,10 @@ def initial_data():
 
             <span class=\"comment\"># Input, assignment</span>
             >>> name = input('What is your name?\\n')
-            >>> print('Hi, %s.' % name)
             <span class=\"output\">What is your name?
-            Python
-            Hi, Python.</span></code>
+            Python</span>
+            >>> print('Hi, %s.' % name)
+            <span class=\"output\">Hi, Python.</span></code>
             </pre>
             """,
             """\


### PR DESCRIPTION
The output of `input()` function should be printed immediately, not merged with the output of `print()` function:

```
>>> name = input('What is your name?\n')
What is your name?\nPython
>>> print('Hi, %s.' % name)
Hi, Python.
>>>
```
