### PR TITLE
Correctly capitalize JavaScript in nojs message

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -140,7 +140,7 @@
     <div id="touchnav-wrapper">
 
         <div id="nojs" class="do-not-print">
-            <p><strong>Notice:</strong> While Javascript is not essential for this website, your interaction with the content will be limited. Please turn Javascript on for the full experience. </p>
+            <p><strong>Notice:</strong> While JavaScript is not essential for this website, your interaction with the content will be limited. Please turn JavasSript on for the full experience. </p>
         </div>
 
         <!--[if lte IE 8]>


### PR DESCRIPTION
Across the site, a message appears at the top of the page when a user has JavaScript disabled.  Within this message, JavaScript is incorrectly capitalized as Javascript. This pull request fixes that capitalization error.