### PR TITLE
Fix lingering Freenode referenece in https://www.python.org/community/

### DIFF
--- a/fixtures/boxes.json
+++ b/fixtures/boxes.json
@@ -129,7 +129,7 @@
 {
     "fields": {
         "label": "community-irc-channels",
-        "content": "<h2 class=\"widget-title\"><span aria-hidden=\"true\" class=\"icon-freenode\"></span>Internet Relay Chat</h2>\r\n<p><a href=\"http://freenode.net/\">Freenode IRC</a> hosts several channels. <a href=\"http://www.irchelp.org/\">Select an IRC client</a>, <a href=\"https://freenode.net/kb/answer/registration\">register your nickname with Freenode</a>, and you can be off and running!</p>\r\n    <h4>Freenode IRC General Channels</h4>\r\n    <ul class=\"menu\">\r\n        <li><strong>#python</strong> for general questions</li>\r\n        <li><strong>#python-dev</strong> for CPython developers</li>\r\n        <li><strong>#distutils</strong> for Python packaging discussion</li>\r\n    </ul>",
+        "content": "<h2 class=\"widget-title\"><span aria-hidden=\"true\" class=\"icon-freenode\"></span>Internet Relay Chat</h2>\r\n<p><a href=\"https://libera.chat/\">Libera.chat</a> hosts several channels. <a href=\"http://www.irchelp.org/\">Select an IRC client</a>, <a href=\"https://libera.chat/guides/registration\">register your nickname with Libera.chat</a>, and you can be off and running!</p>\r\n    <h4>Libera.chat IRC General Channels</h4>\r\n    <ul class=\"menu\">\r\n        <li><strong>#python</strong> for general questions</li>\r\n        <li><strong>#python-dev</strong> for CPython developers</li>\r\n        <li><strong>#distutils</strong> for Python packaging discussion</li>\r\n    </ul>",
         "content_markup_type": "html"
     }
 },

--- a/templates/community/microbit.html
+++ b/templates/community/microbit.html
@@ -52,9 +52,8 @@
             <li>There was a mailing list for discussion of MicroPython on the BBC
             micro:bit that is archived
             <a href="https://github.com/ntoll/microbit_mailman_archive">here</a>.</li>
-            <li>If old-school Internet Relay Chat (IRC) is your thing, then
-            join the #microbit channel on
-            <a href="https://freenode.net/">Freenode IRC</a>.</li>
+            <li><a href="https://tech.microbit.org/community/">micro:bit's
+            community page</a> links to their newsletter and chat room.</li>
             <li>Finally, our friends at
             <a href="https://community.computingatschool.org.uk/">Computing at
             School</a> have a wide range of teacher created resources and


### PR DESCRIPTION
Fixes #1777.

Also update the micro:bit docs to link to their community page, which currently
has a Slack invitation form and no mention of IRC.

There are still two remaining mentions of Freenode:

- The icon and corresponding CSS class is still named "freenode". As far as I
  can tell, this icon is not actually a Freenode icon. I'm not sure what it
  should signify, but it seems fine to leave the icon itself alone, and I've
  left the name alone in this PR to simplify the change.
- The README, the contributing docs, and the CI still mention #pydotorg on
  Freenode. That channel doesn't yet appear to have migrated but probably
  should.