### PR TITLE
Configure github-actions to ensure not have migrations to be created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
         run: |
           pip install -U pip setuptools wheel
           pip install -r dev-requirements.txt
+      - name: Check for missing migrations
+        run: |
+          python manage.py makemigrations --dry-run --check
+        env:
+          DATABASE_URL: postgres://postgres:@127.0.0.1:5432/python.org
       - name: Run Tests
         run: |
           python -Wd -m coverage run manage.py test -v2


### PR DESCRIPTION
This pull-request adds `python manage.py makemigrations --dry-run --check` to the github actions configuration to avoid forget to create a migration file when modifying a django model or update a dependency.

--
#### Pull-request sponsored by

[![image](https://s3-us-west-2.amazonaws.com/labcodes.com.br/lab/labcodes-328x120.png)](https://labcodes.com.br/)
