### PR TITLE
Finalize sponsorships with existing contracts

### DIFF
--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -296,6 +296,11 @@ class SponsorshipAdmin(admin.ModelAdmin):
                 name="sponsors_sponsorship_reject",
             ),
             path(
+                "<int:pk>/approve-existing",
+                self.admin_site.admin_view(self.approve_signed_sponsorship_view),
+                name="sponsors_sponsorship_approve_existing_contract",
+            ),
+            path(
                 "<int:pk>/approve",
                 self.admin_site.admin_view(self.approve_sponsorship_view),
                 name="sponsors_sponsorship_approve",
@@ -397,6 +402,9 @@ class SponsorshipAdmin(admin.ModelAdmin):
 
     def approve_sponsorship_view(self, request, pk):
         return views_admin.approve_sponsorship_view(self, request, pk)
+
+    def approve_signed_sponsorship_view(self, request, pk):
+        return views_admin.approve_signed_sponsorship_view(self, request, pk)
 
 
 @admin.register(LegalClause)

--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -4,7 +4,7 @@ from polymorphic.admin import PolymorphicInlineSupportMixin, StackedPolymorphicI
 from django.template import Context, Template
 from django.contrib import admin
 from django.contrib.humanize.templatetags.humanize import intcomma
-from django.urls import path
+from django.urls import path, reverse
 from django.utils.html import mark_safe
 
 from .models import (
@@ -212,6 +212,7 @@ class SponsorshipAdmin(admin.ModelAdmin):
                     "get_estimated_cost",
                     "start_date",
                     "end_date",
+                    "get_contract"
                 ),
             },
         ),
@@ -262,6 +263,7 @@ class SponsorshipAdmin(admin.ModelAdmin):
             "get_sponsor_primary_phone",
             "get_sponsor_mailing_address",
             "get_sponsor_contacts",
+            "get_contract",
         ]
 
         if obj and obj.status != Sponsorship.APPLIED:
@@ -282,8 +284,15 @@ class SponsorshipAdmin(admin.ModelAdmin):
             cost = intcomma(obj.estimated_cost)
             html = f"{cost} USD <br/><b>Important: </b> {msg}"
         return mark_safe(html)
-
     get_estimated_cost.short_description = "Estimated cost"
+
+    def get_contract(self, obj):
+        if not obj.contract:
+            return "---"
+        url = reverse("admin:sponsors_contract_change", args=[obj.contract.pk])
+        html = f"<a href='{url}' target='_blank'>{obj.contract}</a>"
+        return mark_safe(html)
+    get_contract.short_description = "Contract"
 
     def get_urls(self):
         urls = super().get_urls()
@@ -438,7 +447,7 @@ class ContractModelAdmin(admin.ModelAdmin):
         (
             "Info",
             {
-                "fields": ("sponsorship", "status", "revision"),
+                "fields": ("get_sponsorship_url", "status", "revision"),
             },
         ),
         (
@@ -483,6 +492,7 @@ class ContractModelAdmin(admin.ModelAdmin):
             "sponsorship",
             "revision",
             "document",
+            "get_sponsorship_url",
         ]
 
         if obj and not obj.is_draft:
@@ -512,8 +522,16 @@ class ContractModelAdmin(admin.ModelAdmin):
         if url and msg:
             html = f'<a href="{url}" target="_blank">{msg}</a>'
         return mark_safe(html)
-
     document_link.short_description = "Contract document"
+
+
+    def get_sponsorship_url(self, obj):
+        if not obj.sponsorship:
+            return "---"
+        url = reverse("admin:sponsors_sponsorship_change", args=[obj.sponsorship.pk])
+        html = f"<a href='{url}' target='_blank'>{obj.sponsorship}</a>"
+        return mark_safe(html)
+    get_sponsorship_url.short_description = "Sponsorship"
 
     def get_urls(self):
         urls = super().get_urls()

--- a/sponsors/forms.py
+++ b/sponsors/forms.py
@@ -361,6 +361,13 @@ class SponsorshipReviewAdminForm(forms.ModelForm):
         return cleaned_data
 
 
+class SignedSponsorshipReviewAdminForm(SponsorshipReviewAdminForm):
+    """
+    Form to approve sponsorships that already have a signed contract
+    """
+    signed_contract = forms.FileField(help_text="File for the signed contract")
+
+
 class SponsorBenefitAdminInlineForm(forms.ModelForm):
     sponsorship_benefit = forms.ModelChoiceField(
         queryset=SponsorshipBenefit.objects.select_related("program"),

--- a/sponsors/forms.py
+++ b/sponsors/forms.py
@@ -365,7 +365,7 @@ class SignedSponsorshipReviewAdminForm(SponsorshipReviewAdminForm):
     """
     Form to approve sponsorships that already have a signed contract
     """
-    signed_contract = forms.FileField(help_text="File for the signed contract")
+    signed_contract = forms.FileField(help_text="Please upload the final version of the signed contract.")
 
 
 class SponsorBenefitAdminInlineForm(forms.ModelForm):

--- a/sponsors/models.py
+++ b/sponsors/models.py
@@ -840,8 +840,8 @@ class Contract(models.Model):
         self.status = self.AWAITING_SIGNATURE
         self.save()
 
-    def execute(self, commit=True):
-        if self.EXECUTED not in self.next_status:
+    def execute(self, commit=True, force=False):
+        if not force and self.EXECUTED not in self.next_status:
             msg = f"Can't execute a {self.get_status_display()} contract."
             raise InvalidStatusException(msg)
 

--- a/sponsors/models.py
+++ b/sponsors/models.py
@@ -1,3 +1,4 @@
+import uuid
 from abc import ABC
 from pathlib import Path
 from itertools import chain
@@ -665,6 +666,16 @@ class LegalClause(OrderedModel):
         pass
 
 
+def signed_contract_random_path(instance, filename):
+    """
+    Use random UUID to name signed contracts
+    """
+    dir = instance.SIGNED_PDF_DIR
+    ext = "".join(Path(filename).suffixes)
+    name = uuid.uuid4()
+    return f"{dir}{name}{ext}"
+
+
 class Contract(models.Model):
     """
     Contract model to oficialize a Sponsorship
@@ -697,7 +708,7 @@ class Contract(models.Model):
         verbose_name="Unsigned PDF",
     )
     signed_document = models.FileField(
-        upload_to=SIGNED_PDF_DIR,
+        upload_to=signed_contract_random_path,
         blank=True,
         verbose_name="Signed PDF",
     )

--- a/sponsors/notifications.py
+++ b/sponsors/notifications.py
@@ -155,6 +155,19 @@ class ExecutedContractLogger():
         )
 
 
+class ExecutedExistingContractLogger():
+
+    def notify(self, request, contract, **kwargs):
+        LogEntry.objects.log_action(
+            user_id=request.user.id,
+            content_type_id=ContentType.objects.get_for_model(Contract).pk,
+            object_id=contract.pk,
+            object_repr=str(contract),
+            action_flag=CHANGE,
+            change_message="Existing Contract Uploaded and Executed"
+        )
+
+
 class NullifiedContractLogger():
 
     def notify(self, request, contract, **kwargs):

--- a/sponsors/notifications.py
+++ b/sponsors/notifications.py
@@ -1,7 +1,7 @@
 from django.core.mail import EmailMessage
 from django.template.loader import render_to_string
 from django.conf import settings
-from django.contrib.admin.models import LogEntry, CHANGE
+from django.contrib.admin.models import LogEntry, CHANGE, ADDITION
 from django.contrib.contenttypes.models import ContentType
 
 from sponsors.models import Sponsorship, Contract
@@ -110,7 +110,7 @@ class ContractNotificationToSponsors(BaseEmailSponsorshipNotification):
 
 class SponsorshipApprovalLogger():
 
-    def notify(self, request, sponsorship, **kwargs):
+    def notify(self, request, sponsorship, contract, **kwargs):
         LogEntry.objects.log_action(
             user_id=request.user.id,
             content_type_id=ContentType.objects.get_for_model(Sponsorship).pk,
@@ -118,6 +118,14 @@ class SponsorshipApprovalLogger():
             object_repr=str(sponsorship),
             action_flag=CHANGE,
             change_message="Sponsorship Approval"
+        )
+        LogEntry.objects.log_action(
+            user_id=request.user.id,
+            content_type_id=ContentType.objects.get_for_model(Contract).pk,
+            object_id=contract.pk,
+            object_repr=str(contract),
+            action_flag=ADDITION,
+            change_message="Created After Sponsorship Approval"
         )
 
 

--- a/sponsors/tests/test_notifications.py
+++ b/sponsors/tests/test_notifications.py
@@ -5,7 +5,8 @@ from django.conf import settings
 from django.core import mail
 from django.template.loader import render_to_string
 from django.test import TestCase, RequestFactory
-from django.contrib.admin.models import LogEntry, CHANGE
+from django.contrib.admin.models import LogEntry, CHANGE, ADDITION
+from django.contrib.contenttypes.models import ContentType
 
 from sponsors import notifications
 from sponsors.models import Sponsorship, Contract
@@ -233,24 +234,34 @@ class SponsorshipApprovalLoggerTests(TestCase):
         self.request = RequestFactory().get('/')
         self.request.user = baker.make(settings.AUTH_USER_MODEL)
         self.sponsorship = baker.make(Sponsorship, status=Sponsorship.APPROVED, sponsor__name='foo', _fill_optional=True)
+        self.contract = baker.make_recipe("sponsors.tests.empty_contract", sponsorship=self.sponsorship)
         self.kwargs = {
             "request": self.request,
             "sponsorship": self.sponsorship,
+            "contract": self.contract
         }
         self.logger = notifications.SponsorshipApprovalLogger()
 
     def test_create_log_entry_for_change_operation_with_approval_message(self):
         self.assertEqual(LogEntry.objects.count(), 0)
+        sponsorship_content_id = ContentType.objects.get_for_model(Sponsorship).pk
+        contract_id = ContentType.objects.get_for_model(Contract).pk
 
         self.logger.notify(**self.kwargs)
 
-        self.assertEqual(LogEntry.objects.count(), 1)
-        log_entry = LogEntry.objects.get()
+        self.assertEqual(LogEntry.objects.count(), 2)
+        log_entry = LogEntry.objects.get(content_type_id=sponsorship_content_id)
         self.assertEqual(log_entry.user, self.request.user)
         self.assertEqual(log_entry.object_id, str(self.sponsorship.pk))
         self.assertEqual(str(self.sponsorship), log_entry.object_repr)
         self.assertEqual(log_entry.action_flag, CHANGE)
         self.assertEqual(log_entry.change_message, "Sponsorship Approval")
+        log_entry = LogEntry.objects.get(content_type_id=contract_id)
+        self.assertEqual(log_entry.user, self.request.user)
+        self.assertEqual(log_entry.object_id, str(self.contract.pk))
+        self.assertEqual(str(self.contract), log_entry.object_repr)
+        self.assertEqual(log_entry.action_flag, ADDITION)
+        self.assertEqual(log_entry.change_message, "Created After Sponsorship Approval")
 
 
 class SentContractLoggerTests(TestCase):

--- a/sponsors/tests/test_notifications.py
+++ b/sponsors/tests/test_notifications.py
@@ -316,6 +316,32 @@ class ExecutedContractLoggerTests(TestCase):
         self.assertEqual(log_entry.change_message, "Contract Executed")
 
 
+class ExecutedExistingContractLoggerTests(TestCase):
+
+    def setUp(self):
+        self.request = RequestFactory().get('/')
+        self.request.user = baker.make(settings.AUTH_USER_MODEL)
+        self.contract = baker.make_recipe('sponsors.tests.empty_contract')
+        self.kwargs = {
+            "request": self.request,
+            "contract": self.contract,
+        }
+        self.logger = notifications.ExecutedExistingContractLogger()
+
+    def test_create_log_entry_for_change_operation_with_approval_message(self):
+        self.assertEqual(LogEntry.objects.count(), 0)
+
+        self.logger.notify(**self.kwargs)
+
+        self.assertEqual(LogEntry.objects.count(), 1)
+        log_entry = LogEntry.objects.get()
+        self.assertEqual(log_entry.user, self.request.user)
+        self.assertEqual(log_entry.object_id, str(self.contract.pk))
+        self.assertEqual(str(self.contract), log_entry.object_repr)
+        self.assertEqual(log_entry.action_flag, CHANGE)
+        self.assertEqual(log_entry.change_message, "Existing Contract Uploaded and Executed")
+
+
 class NullifiedContractLoggerTests(TestCase):
 
     def setUp(self):

--- a/sponsors/tests/test_use_cases.py
+++ b/sponsors/tests/test_use_cases.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from model_bakery import baker
 from datetime import timedelta, date
 
@@ -185,11 +185,13 @@ class ExecuteExistingContractUseCaseTests(TestCase):
         self.file = SimpleUploadedFile("contract.txt", b"Contract content")
         self.contract = baker.make_recipe("sponsors.tests.empty_contract", status=Contract.DRAFT)
 
+    @patch("sponsors.models.uuid.uuid4", Mock(return_value="1234"))
     def test_execute_and_update_database_object(self):
         self.use_case.execute(self.contract, self.file)
         self.contract.refresh_from_db()
         self.assertEqual(self.contract.status, Contract.EXECUTED)
         self.assertEqual(b"Contract content", self.contract.signed_document.read())
+        self.assertEqual(f"{Contract.SIGNED_PDF_DIR}1234.txt", self.contract.signed_document.name)
 
     def test_build_use_case_with_default_notificationss(self):
         uc = use_cases.ExecuteExistingContractUseCase.build()

--- a/sponsors/tests/test_use_cases.py
+++ b/sponsors/tests/test_use_cases.py
@@ -122,7 +122,7 @@ class ApproveSponsorshipApplicationUseCaseTests(TestCase):
                 contract=self.sponsorship.contract,
             )
 
-    def test_build_use_case_without_notificationss(self):
+    def test_build_use_case_with_default_notificationss(self):
         uc = use_cases.ApproveSponsorshipApplicationUseCase.build()
         self.assertEqual(len(uc.notifications), 1)
         self.assertIsInstance(uc.notifications[0], SponsorshipApprovalLogger)
@@ -147,7 +147,7 @@ class SendContractUseCaseTests(TestCase):
                 contract=self.contract,
             )
 
-    def test_build_use_case_without_notificationss(self):
+    def test_build_use_case_with_default_notificationss(self):
         uc = use_cases.SendContractUseCase.build()
         self.assertEqual(len(uc.notifications), 2)
         self.assertIsInstance(uc.notifications[0], ContractNotificationToPSF)
@@ -168,7 +168,7 @@ class ExecuteContractUseCaseTests(TestCase):
         self.contract.refresh_from_db()
         self.assertEqual(self.contract.status, Contract.EXECUTED)
 
-    def test_build_use_case_without_notificationss(self):
+    def test_build_use_case_with_default_notificationss(self):
         uc = use_cases.ExecuteContractUseCase.build()
         self.assertEqual(len(uc.notifications), 1)
         self.assertIsInstance(
@@ -188,7 +188,7 @@ class NullifyContractUseCaseTests(TestCase):
         self.contract.refresh_from_db()
         self.assertEqual(self.contract.status, Contract.NULLIFIED)
 
-    def test_build_use_case_without_notificationss(self):
+    def test_build_use_case_with_default_notificationss(self):
         uc = use_cases.NullifyContractUseCase.build()
         self.assertEqual(len(uc.notifications), 1)
         self.assertIsInstance(

--- a/sponsors/tests/test_views_admin.py
+++ b/sponsors/tests/test_views_admin.py
@@ -1,3 +1,4 @@
+import io
 import json
 from model_bakery import baker
 from datetime import date, timedelta
@@ -12,7 +13,7 @@ from django.urls import reverse
 
 from .utils import assertMessage
 from ..models import Sponsorship, Contract, SponsorshipBenefit, SponsorBenefit
-from ..forms import SponsorshipReviewAdminForm, SponsorshipsListForm
+from ..forms import SponsorshipReviewAdminForm, SponsorshipsListForm, SignedSponsorshipReviewAdminForm
 
 
 class RollbackSponsorshipToEditingAdminViewTests(TestCase):
@@ -264,6 +265,128 @@ class ApproveSponsorshipAdminViewTests(TestCase):
         self.assertEqual(self.sponsorship.status, Sponsorship.APPROVED)
         msg = list(get_messages(response.wsgi_request))[0]
         assertMessage(msg, "Sponsorship was approved!", messages.SUCCESS)
+
+    def test_do_not_approve_if_no_confirmation_in_the_post(self):
+        self.data.pop("confirm")
+        response = self.client.post(self.url, data=self.data)
+        self.sponsorship.refresh_from_db()
+        self.assertTemplateUsed(response, "sponsors/admin/approve_application.html")
+        self.assertNotEqual(
+            self.sponsorship.status, Sponsorship.APPROVED
+        )  # did not update
+
+        self.data["confirm"] = "invalid"
+        response = self.client.post(self.url, data=self.data)
+        self.sponsorship.refresh_from_db()
+        self.assertTemplateUsed(response, "sponsors/admin/approve_application.html")
+        self.assertNotEqual(self.sponsorship.status, Sponsorship.APPROVED)
+
+    def test_do_not_approve_if_form_with_invalid_data(self):
+        self.data = {"confirm": "yes"}
+        response = self.client.post(self.url, data=self.data)
+        self.sponsorship.refresh_from_db()
+        self.assertTemplateUsed(response, "sponsors/admin/approve_application.html")
+        self.assertNotEqual(
+            self.sponsorship.status, Sponsorship.APPROVED
+        )  # did not update
+        self.assertTrue(response.context["form"].errors)
+
+    def test_404_if_sponsorship_does_not_exist(self):
+        self.sponsorship.delete()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_login_required(self):
+        login_url = reverse("admin:login")
+        redirect_url = f"{login_url}?next={self.url}"
+        self.client.logout()
+
+        r = self.client.get(self.url)
+
+        self.assertRedirects(r, redirect_url)
+
+    def test_staff_required(self):
+        login_url = reverse("admin:login")
+        redirect_url = f"{login_url}?next={self.url}"
+        self.user.is_staff = False
+        self.user.save()
+        self.client.force_login(self.user)
+
+        r = self.client.get(self.url)
+
+        self.assertRedirects(r, redirect_url, fetch_redirect_response=False)
+
+    def test_message_user_if_approving_invalid_sponsorship(self):
+        self.sponsorship.status = Sponsorship.FINALIZED
+        self.sponsorship.save()
+        response = self.client.post(self.url, data=self.data)
+        self.sponsorship.refresh_from_db()
+
+        expected_url = reverse(
+            "admin:sponsors_sponsorship_change", args=[self.sponsorship.pk]
+        )
+        self.assertRedirects(response, expected_url, fetch_redirect_response=True)
+        self.assertEqual(self.sponsorship.status, Sponsorship.FINALIZED)
+        msg = list(get_messages(response.wsgi_request))[0]
+        assertMessage(msg, "Can't approve a Finalized sponsorship.", messages.ERROR)
+
+
+class ApproveSignedSponsorshipAdminViewTests(TestCase):
+    def setUp(self):
+        self.user = baker.make(
+            settings.AUTH_USER_MODEL, is_staff=True, is_superuser=True
+        )
+        self.client.force_login(self.user)
+        self.sponsorship = baker.make(
+            Sponsorship, status=Sponsorship.APPLIED, _fill_optional=True
+        )
+        self.url = reverse(
+            "admin:sponsors_sponsorship_approve_existing_contract", args=[self.sponsorship.pk]
+        )
+        today = date.today()
+        self.data = {
+            "confirm": "yes",
+            "start_date": today,
+            "end_date": today + timedelta(days=100),
+            "level_name": "Level",
+            "sponsorship_fee": 500,
+            "signed_contract": io.BytesIO(b"Signed contract")
+        }
+
+    def test_display_confirmation_form_on_get(self):
+        response = self.client.get(self.url)
+        context = response.context
+        form = context["form"]
+        self.sponsorship.refresh_from_db()
+
+        self.assertTemplateUsed(response, "sponsors/admin/approve_application.html")
+        self.assertEqual(context["sponsorship"], self.sponsorship)
+        self.assertIsInstance(form, SignedSponsorshipReviewAdminForm)
+        self.assertEqual(form.initial["level_name"], self.sponsorship.level_name)
+        self.assertEqual(form.initial["start_date"], self.sponsorship.start_date)
+        self.assertEqual(form.initial["end_date"], self.sponsorship.end_date)
+        self.assertEqual(
+            form.initial["sponsorship_fee"], self.sponsorship.sponsorship_fee
+        )
+        self.assertNotEqual(
+            self.sponsorship.status, Sponsorship.APPROVED
+        )  # did not update
+
+    def test_approve_sponsorship_and_execute_contract_on_post(self):
+        response = self.client.post(self.url, data=self.data)
+
+        self.sponsorship.refresh_from_db()
+        contract = self.sponsorship.contract
+
+        expected_url = reverse(
+            "admin:sponsors_sponsorship_change", args=[self.sponsorship.pk]
+        )
+        self.assertRedirects(response, expected_url, fetch_redirect_response=True)
+        self.assertEqual(self.sponsorship.status, Sponsorship.FINALIZED)
+        self.assertEqual(contract.status, Contract.EXECUTED)
+        self.assertEqual(contract.signed_document.read(), b"Signed contract")
+        msg = list(get_messages(response.wsgi_request))[0]
+        assertMessage(msg, "Signed sponsorship was approved!", messages.SUCCESS)
 
     def test_do_not_approve_if_no_confirmation_in_the_post(self):
         self.data.pop("confirm")

--- a/sponsors/tests/test_views_admin.py
+++ b/sponsors/tests/test_views_admin.py
@@ -230,6 +230,7 @@ class ApproveSponsorshipAdminViewTests(TestCase):
             "start_date": today,
             "end_date": today + timedelta(days=100),
             "level_name": "Level",
+            "sponsorship_fee": 500,
         }
 
     def test_display_confirmation_form_on_get(self):

--- a/sponsors/use_cases.py
+++ b/sponsors/use_cases.py
@@ -102,6 +102,20 @@ class ExecuteContractUseCase(BaseUseCaseWithNotifications):
         )
 
 
+class ExecuteExistingContractUseCase(BaseUseCaseWithNotifications):
+    notifications = [
+        notifications.ExecutedExistingContractLogger(),
+    ]
+
+    def execute(self, contract, contract_file, **kwargs):
+        contract.signed_document = contract_file
+        contract.execute(force=True)
+        self.notify(
+            request=kwargs.get("request"),
+            contract=contract,
+        )
+
+
 class NullifyContractUseCase(BaseUseCaseWithNotifications):
     notifications = [
         notifications.NullifiedContractLogger(),

--- a/sponsors/views_admin.py
+++ b/sponsors/views_admin.py
@@ -43,6 +43,9 @@ def reject_sponsorship_view(ModelAdmin, request, pk):
 
 
 def approve_sponsorship_view(ModelAdmin, request, pk):
+    """
+    Approves a sponsorship and create an empty contract
+    """
     sponsorship = get_object_or_404(ModelAdmin.get_queryset(request), pk=pk)
     initial = {
         "level_name": sponsorship.level_name,
@@ -54,7 +57,7 @@ def approve_sponsorship_view(ModelAdmin, request, pk):
     form = SponsorshipReviewAdminForm(initial=initial, force_required=True)
 
     if request.method.upper() == "POST" and request.POST.get("confirm") == "yes":
-        form = SponsorshipReviewAdminForm(data=request.POST)
+        form = SponsorshipReviewAdminForm(data=request.POST, force_required=True)
         if form.is_valid():
             kwargs = form.cleaned_data
             kwargs["request"] = request

--- a/sponsors/views_admin.py
+++ b/sponsors/views_admin.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 from django.db import transaction
 
 from sponsors import use_cases
-from sponsors.forms import SponsorshipReviewAdminForm, SponsorshipsListForm
+from sponsors.forms import SponsorshipReviewAdminForm, SponsorshipsListForm, SignedSponsorshipReviewAdminForm
 from sponsors.exceptions import InvalidStatusException
 from sponsors.pdf import render_contract_to_pdf_response
 from sponsors.models import Sponsorship, SponsorBenefit
@@ -66,6 +66,47 @@ def approve_sponsorship_view(ModelAdmin, request, pk):
                 use_case.execute(sponsorship, **kwargs)
                 ModelAdmin.message_user(
                     request, "Sponsorship was approved!", messages.SUCCESS
+                )
+            except InvalidStatusException as e:
+                ModelAdmin.message_user(request, str(e), messages.ERROR)
+
+            redirect_url = reverse(
+                "admin:sponsors_sponsorship_change", args=[sponsorship.pk]
+            )
+            return redirect(redirect_url)
+
+    context = {"sponsorship": sponsorship, "form": form}
+    return render(request, "sponsors/admin/approve_application.html", context=context)
+
+
+def approve_signed_sponsorship_view(ModelAdmin, request, pk):
+    """
+    Approves a sponsorship and execute contract for existing file
+    """
+    sponsorship = get_object_or_404(ModelAdmin.get_queryset(request), pk=pk)
+    initial = {
+        "level_name": sponsorship.level_name,
+        "start_date": sponsorship.start_date,
+        "end_date": sponsorship.end_date,
+        "sponsorship_fee": sponsorship.sponsorship_fee,
+    }
+
+    form = SignedSponsorshipReviewAdminForm(initial=initial, force_required=True)
+
+    if request.method.upper() == "POST" and request.POST.get("confirm") == "yes":
+        form = SignedSponsorshipReviewAdminForm(request.POST, request.FILES, force_required=True)
+        if form.is_valid():
+            kwargs = form.cleaned_data
+            kwargs["request"] = request
+            try:
+                # create the sponsorship + contract
+                use_case = use_cases.ApproveSponsorshipApplicationUseCase.build()
+                sponsorship = use_case.execute(sponsorship, **kwargs)
+                # execute it using existing contract
+                use_case = use_cases.ExecuteExistingContractUseCase.build()
+                use_case.execute(sponsorship.contract, kwargs["signed_contract"], request=request)
+                ModelAdmin.message_user(
+                    request, "Signed sponsorship was approved!", messages.SUCCESS
                 )
             except InvalidStatusException as e:
                 ModelAdmin.message_user(request, str(e), messages.ERROR)

--- a/templates/sponsors/admin/approve_application.html
+++ b/templates/sponsors/admin/approve_application.html
@@ -17,10 +17,15 @@
 {% endblock %}
 
 {% block content %}
-<h1>Approve Sponsorship</h1>
+{% if form.fields.signed_contract %}
+<h1>Upload Finalized Contract</h1>
+{% else %}
+<h1>Generate Contract for Signing</h1>
+{% endif %}
 <p>Please review the sponsorship application and click in the Approve button if you want to proceed.</p>
 <div id="content-main">
-<form action="" method="post" id="new_psf_board_meeting_form">
+
+<form action="" method="post" id="new_psf_board_meeting_form" enctype="multipart/form-data">
 {% csrf_token %}
 
 <pre>{% full_sponsorship sponsorship display_fee=True %}</pre>

--- a/templates/sponsors/admin/sponsorship_change_form.html
+++ b/templates/sponsors/admin/sponsorship_change_form.html
@@ -6,7 +6,10 @@
 
     {% if sp.APPROVED in sp.next_status %}
     <li>
-        <a href="{% url 'admin:sponsors_sponsorship_approve' sp.pk %}" style="background: #70bf2b">Approve</a>
+        <a href="{% url 'admin:sponsors_sponsorship_approve' sp.pk %}" style="background: #70bf2b">Generate Contract for Signing</a>
+    </li>
+    <li>
+        <a href="{% url 'admin:sponsors_sponsorship_approve_existing_contract' sp.pk %}" style="background: #70bf2b">Upload Finalized Contract</a>
     </li>
     {% endif %}
 


### PR DESCRIPTION
Fixes #1836

This PR introduces 2 possible ways to approve sponsorships:

- By generating a contract for signing (default logic)
- By uploading an existing and signed contract (to handle already signed contracts)

These options are displayed as buttons in the sponsorships change form when its under the `Applied` stage:

![Screenshot from 2021-08-17 11-04-27](https://user-images.githubusercontent.com/238223/129741061-8e8e703c-69cc-4eea-a5da-d3024e3f3f02.png)

Both buttons use the same HTML to control the page content. The only difference is the page title and the file input for the signed contract. Here's the example of the form with the contract upload:

![Screenshot from 2021-08-17 11-04-34](https://user-images.githubusercontent.com/238223/129741242-d5e3d659-5799-4d4c-9827-a4456115234f.png)

The history for the contract has 2 entries, one for the object creation and another one to keep track of the uploaded contract:

![Screenshot from 2021-08-17 11-05-07](https://user-images.githubusercontent.com/238223/129741577-4349e0f5-cc50-48e3-bd69-e5bff751633f.png)
