### PR TITLE
Fix usage of BaseAPITestCase

### DIFF
--- a/downloads/tests/test_views.py
+++ b/downloads/tests/test_views.py
@@ -90,7 +90,7 @@ class RegressionTests(DownloadMixin, TestCase):
         self.assertEqual(len(response.context['python_files']), 3)
 
 
-class BaseDownloadApiViewsTest(BaseAPITestCase):
+class BaseDownloadApiViewsTest(BaseDownloadTests, BaseAPITestCase):
     # This API used by add-to-pydotorg.py in python/release-tools.
     app_label = 'downloads'
 

--- a/downloads/tests/test_views.py
+++ b/downloads/tests/test_views.py
@@ -435,6 +435,15 @@ class BaseDownloadApiViewsTest(BaseDownloadTests, BaseAPITestCase):
 class DownloadApiV1ViewsTest(BaseDownloadApiViewsTest, BaseDownloadTests):
     api_version = 'v1'
 
+    def setUp(self):
+        super().setUp()
+        self.staff_key = self.staff_user.api_key.key
+        self.token_header = 'ApiKey'
+        self.Authorization = '{} {}:{}'.format(
+            self.token_header, self.staff_user.username, self.staff_key,
+        )
+        self.Authorization_invalid = '%s invalid:token' % self.token_header
+
 
 class DownloadApiV2ViewsTest(BaseDownloadApiViewsTest, BaseDownloadTests, APITestCase):
     api_version = 'v2'

--- a/downloads/tests/test_views.py
+++ b/downloads/tests/test_views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.test import TestCase, override_settings
 
+from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
 from .base import BaseDownloadTests, DownloadMixin
@@ -101,12 +102,8 @@ class BaseDownloadApiViewsTest(BaseDownloadTests, BaseAPITestCase):
             password='passworduser',
             is_staff=True,
         )
-        self.staff_key = self.staff_user.api_key.key
-        self.token_header = 'ApiKey'
-        self.Authorization = '{} {}:{}'.format(
-            self.token_header, self.staff_user.username, self.staff_key,
-        )
-        self.Authorization_invalid = '%s invalid:token' % self.token_header
+        self.Authorization = f'Token {self.staff_user.api_v2_token}'
+        self.Authorization_invalid = 'Token invalid-token'
 
     def get_json(self, response):
         json_response = response.json()

--- a/pydotorg/drf.py
+++ b/pydotorg/drf.py
@@ -65,6 +65,10 @@ class BaseFilterSet(filters.FilterSet):
 
 
 class BaseAPITestCase:
+    """
+    This is mixin base class to be combined with a real Django's TestCase or
+    DRF's APITestCase implementation in order to run the tests.
+    """
 
     api_version = 'v2'
     app_label = None

--- a/users/models.py
+++ b/users/models.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 
 from markupfield.fields import MarkupField
 from tastypie.models import create_api_key
+from rest_framework.authtoken.models import Token
 
 from .managers import UserManager
 
@@ -54,6 +55,13 @@ class User(AbstractUser):
     def sponsorships(self):
         from sponsors.models import Sponsorship
         return Sponsorship.objects.visible_to(self)
+
+    @property
+    def api_v2_token(self):
+        try:
+            return Token.objects.get(user=self).key
+        except Token.DoesNotExist:
+            return ""
 
 
 models.signals.post_save.connect(create_api_key, sender=User)


### PR DESCRIPTION
Fix #1850 

This PR updates the tests under `downloads` app to use `pydot.drf.BaseAPITestCase` accordingly. The base class **must** be combined with a real test case implementation, the same way [the `pages` app does here](https://github.com/python/pythondotorg/blob/main/pages/tests/test_api.py#L9).

There were 2 test suites (API v1 and v2) for the `download` app that weren't running because of the missing `TestCase` class. This PR both test suites to inherit also from a valid `TestCase` class and, thus, to run its tests.