### PR TITLE
Purge FTP index listing all Python versions from fastly cache

### DIFF
--- a/downloads/models.py
+++ b/downloads/models.py
@@ -276,6 +276,7 @@ def purge_fastly_download_pages(sender, instance, **kwargs):
         purge_url('/downloads/macos/')
         purge_url('/downloads/source/')
         purge_url('/downloads/windows/')
+        purge_url('/ftp/python/')
         if instance.get_version() is not None:
             purge_url(f'/ftp/python/{instance.get_version()}/')
         # See issue #584 for details


### PR DESCRIPTION
I could be wrong but I believe this is the reason why at the time of writing, https://www.python.org/ftp/python/ doesn't list the 2 new Python releases (3.6.15 & 3.7.12).

A manual cache may also be triggered for this page because this PR only addresses future Python releases.

![Screenshot from 2021-09-07 07-49-12](https://user-images.githubusercontent.com/1457576/132291051-d7d0afea-b6e0-42ff-9b65-b14c57ac2f06.png)


Thank you :heart:   