### PR TITLE
Bugfix: enable to execute draft contracts

### DIFF
--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -536,6 +536,7 @@ class ContractModelAdmin(admin.ModelAdmin):
             "revision",
             "document",
             "document_docx",
+            "signed_document",
             "get_sponsorship_url",
         ]
 

--- a/sponsors/models/contract.py
+++ b/sponsors/models/contract.py
@@ -193,7 +193,7 @@ class Contract(models.Model):
     @property
     def next_status(self):
         states_map = {
-            self.DRAFT: [self.AWAITING_SIGNATURE],
+            self.DRAFT: [self.AWAITING_SIGNATURE, self.EXECUTED],
             self.OUTDATED: [],
             self.AWAITING_SIGNATURE: [self.EXECUTED, self.NULLIFIED],
             self.EXECUTED: [],

--- a/sponsors/tests/test_models.py
+++ b/sponsors/tests/test_models.py
@@ -485,7 +485,7 @@ class ContractModelTests(TestCase):
     def test_control_contract_next_status(self):
         SOW = Contract
         states_map = {
-            SOW.DRAFT: [SOW.AWAITING_SIGNATURE],
+            SOW.DRAFT: [SOW.AWAITING_SIGNATURE, SOW.EXECUTED],
             SOW.OUTDATED: [],
             SOW.AWAITING_SIGNATURE: [SOW.EXECUTED, SOW.NULLIFIED],
             SOW.EXECUTED: [],
@@ -547,7 +547,7 @@ class ContractModelTests(TestCase):
 
     def test_raise_invalid_status_when_trying_to_execute_contract_if_not_awaiting_signature(self):
         contract = baker.make_recipe(
-            "sponsors.tests.empty_contract", status=Contract.DRAFT
+            "sponsors.tests.empty_contract", status=Contract.OUTDATED
         )
 
         with self.assertRaises(InvalidStatusException):

--- a/sponsors/tests/test_use_cases.py
+++ b/sponsors/tests/test_use_cases.py
@@ -11,7 +11,6 @@ from django.core.mail import EmailMessage
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from sponsors import use_cases
-from sponsors.exceptions import ContractWithoutSignedDocumentException
 from sponsors.notifications import *
 from sponsors.models import Sponsorship, Contract, SponsorEmailNotificationTemplate
 

--- a/sponsors/use_cases.py
+++ b/sponsors/use_cases.py
@@ -91,31 +91,26 @@ class SendContractUseCase(BaseUseCaseWithNotifications):
         )
 
 
-class ExecuteContractUseCase(BaseUseCaseWithNotifications):
-    notifications = [
-        notifications.ExecutedContractLogger(),
-    ]
-
-    def execute(self, contract, **kwargs):
-        contract.execute()
-        self.notify(
-            request=kwargs.get("request"),
-            contract=contract,
-        )
-
-
 class ExecuteExistingContractUseCase(BaseUseCaseWithNotifications):
     notifications = [
         notifications.ExecutedExistingContractLogger(),
     ]
+    force_execute = True
 
     def execute(self, contract, contract_file, **kwargs):
         contract.signed_document = contract_file
-        contract.execute(force=True)
+        contract.execute(force=self.force_execute)
         self.notify(
             request=kwargs.get("request"),
             contract=contract,
         )
+
+
+class ExecuteContractUseCase(ExecuteExistingContractUseCase):
+    notifications = [
+        notifications.ExecutedContractLogger(),
+    ]
+    force_execute = False
 
 
 class NullifyContractUseCase(BaseUseCaseWithNotifications):

--- a/templates/sponsors/admin/contract_change_form.html
+++ b/templates/sponsors/admin/contract_change_form.html
@@ -14,10 +14,14 @@
     <li>
         <a href="{% url 'admin:sponsors_contract_send' contract.pk %}" style="background: #70bf2b">Send document</a>
     </li>
-    {% elif contract.status == contract.AWAITING_SIGNATURE %}
+    {% endif %}
+
+    {% if contract.EXECUTED in contract.next_status %}
     <li>
         <a href="{% url 'admin:sponsors_contract_execute' contract.pk %}" style="background: #70bf2b">Execute</a>
     </li>
+    {% endif %}
+    {% if contract.NULLIFY in contract.next_status %}
     <li>
         <a href="{% url 'admin:sponsors_contract_nullify' contract.pk %}" style="background: #ba2121" >Nullify</a>
     </li>

--- a/templates/sponsors/admin/execute_contract.html
+++ b/templates/sponsors/admin/execute_contract.html
@@ -20,9 +20,21 @@
 
 <div id="content-main">
 <p><b>Important: </b>By executing this contract, the sponsor logo will be placed accordingly to the benefits linked to the sponsorship during the sponsorship period (from {{ contract.sponsorship.start_date|date }} until {{ contract.sponsorship.end_date|date }})</p>
+<p>To finalize and execute this contract, you have to upload the final signed document and update it.</p>
 
-<form action="" method="post">
+<form action="" method="post" enctype="multipart/form-data">
 {% csrf_token %}
+
+{% if error_msg %}
+  <p style="color: red">{{ error_msg }}</p>
+{% endif %}
+
+{% if not contract.signed_document %}
+  <p>
+    <p><b><label for="id_signed_document">Signed Contract</label></b></p>
+    <input type="file" id="id_signed_document" name="signed_document" required>
+  </p>
+{% endif %}
 
 <input name="confirm" value="yes" style="display:none">
 


### PR DESCRIPTION
This PR changes the behavior of the contract detail under Django's admin. It changes the `signed_document` field to be a read-only and, thus, avoid PSF staff from by-passing the views that ensures the control of the objects states. It also adds displays that Execute button that was only being displayed for contracts under "Awaiting Signature" state. This button leads to the same old execute contract page, but now it requires a new input for the user to upload the signed contract before executing it.

**Signed document as read only**

![Screenshot from 2021-11-12 11-18-18](https://user-images.githubusercontent.com/238223/141482840-f2e24c2b-5aaf-4c45-bfff-cf59e097d9a3.png)

**New button being displayed for a draft contract**

![Screenshot from 2021-11-12 11-18-09](https://user-images.githubusercontent.com/238223/141482615-725cfff1-cf1b-4968-82b6-fa7fb8d2e305.png)

**Execute contract page with file input**

![Screenshot from 2021-11-12 11-18-31](https://user-images.githubusercontent.com/238223/141482805-ebc6ead4-ed56-4a76-a600-ffa780f96b3d.png)

**State of the contract after a valid submit**

![Screenshot from 2021-11-12 11-18-51](https://user-images.githubusercontent.com/238223/141482951-c95e5bb3-844e-46b2-8181-1d9a6aaed44c.png)

![Screenshot from 2021-11-12 11-18-59](https://user-images.githubusercontent.com/238223/141482961-bd779998-b78b-450c-b31b-c3e2aa76cb26.png)
