### PR TITLE
Bugfix to don't ignore add-ons

### DIFF
--- a/sponsors/forms.py
+++ b/sponsors/forms.py
@@ -89,11 +89,15 @@ class SponsorshiptBenefitsForm(forms.Form):
                 conflicts[benefit.id] = list(benefits_conflicts)
         return conflicts
 
-    def get_benefits(self, cleaned_data=None):
+    def get_benefits(self, cleaned_data=None, include_add_ons=False):
         cleaned_data = cleaned_data or self.cleaned_data
-        return list(
+        benefits = list(
             chain(*(cleaned_data.get(bp.name) for bp in self.benefits_programs))
         )
+        add_ons = cleaned_data.get("add_ons_benefits")
+        if include_add_ons and add_ons:
+            benefits.extend([b for b in add_ons])
+        return benefits
 
     def get_package(self):
         return self.cleaned_data.get("package")

--- a/sponsors/tests/test_forms.py
+++ b/sponsors/tests/test_forms.py
@@ -125,6 +125,24 @@ class SponsorshiptBenefitsFormTests(TestCase):
             form.errors["__all__"],
         )
 
+    def test_get_benefits_from_cleaned_data(self):
+        benefit = self.program_1_benefits[0]
+
+        data = {"benefits_psf": [benefit.id],
+                "add_ons_benefits": [b.id for b in self.add_ons]}
+        form = SponsorshiptBenefitsForm(data=data)
+        self.assertTrue(form.is_valid())
+
+        benefits = form.get_benefits()
+        self.assertEqual(1, len(benefits))
+        self.assertIn(benefit, benefits)
+
+        benefits = form.get_benefits(include_add_ons=True)
+        self.assertEqual(3, len(benefits))
+        self.assertIn(benefit, benefits)
+        for add_on in self.add_ons:
+            self.assertIn(add_on, benefits)
+
     def test_package_only_benefit_without_package_should_not_validate(self):
         SponsorshipBenefit.objects.all().update(package_only=True)
 

--- a/sponsors/views.py
+++ b/sponsors/views.py
@@ -154,7 +154,7 @@ class NewSponsorshipApplicationView(FormView):
         sponsorship = uc.execute(
             self.request.user,
             sponsor,
-            benefits_form.get_benefits(),
+            benefits_form.get_benefits(include_add_ons=True),
             benefits_form.get_package(),
             request=self.request,
         )


### PR DESCRIPTION
This PR addresses the following feedback about the sponsorships module:

```
Add-on items did not work when being added to a package for Meta

Not confirmed, but report of add-on items being selected and displayed while
applying and confirming, but not associated with the resulting sponsorship application.
```

The bug has happening due to a missing logic to `SponsorshiptBenefitsForm.get_benefits` method. This method is used to get all the benefits that should be used during the new sponsorship creation. But it wasn't returning the add ons benefits, even though the data was present in `form.cleaned_data`. 

This PR fixes this logic and also updates the views tests to be more accurate about the benefits creation. 