### PR TITLE
Enable admin staff to add benefits to Sponsorship via admin

### DIFF
--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -166,7 +166,6 @@ class SponsorBenefitInline(admin.TabularInline):
     form = SponsorBenefitAdminInlineForm
     fields = ["sponsorship_benefit", "benefit_internal_value"]
     extra = 0
-    max_num = 0
 
     def has_add_permission(self, request, obj=None):
         has_add_permission = super().has_add_permission(request, obj=obj)

--- a/sponsors/forms.py
+++ b/sponsors/forms.py
@@ -395,7 +395,9 @@ class SponsorBenefitAdminInlineForm(forms.ModelForm):
             self.instance.refresh_from_db()
 
         self.instance.benefit_internal_value = value
+        updated_sponsorship_benefit = False
         if benefit.pk != self.instance.sponsorship_benefit_id:
+            updated_sponsorship_benefit = True
             self.instance.sponsorship_benefit = benefit
             self.instance.name = benefit.name
             self.instance.description = benefit.description
@@ -403,6 +405,11 @@ class SponsorBenefitAdminInlineForm(forms.ModelForm):
 
         if commit:
             self.instance.save()
+
+            if updated_sponsorship_benefit:
+                self.instance.features.all().delete()
+                for feature_config in benefit.features_config.all():
+                    feature_config.create_benefit_feature(self.instance)
 
         return self.instance
 

--- a/sponsors/forms.py
+++ b/sponsors/forms.py
@@ -394,7 +394,9 @@ class SponsorBenefitAdminInlineForm(forms.ModelForm):
         else:
             self.instance.refresh_from_db()
 
-        self.instance.benefit_internal_value = value
+        self.instance.benefit_internal_value = benefit.internal_value
+        if value:
+            self.instance.benefit_internal_value = value
         updated_sponsorship_benefit = False
         if benefit.pk != self.instance.sponsorship_benefit_id:
             updated_sponsorship_benefit = True

--- a/sponsors/tests/test_forms.py
+++ b/sponsors/tests/test_forms.py
@@ -480,7 +480,8 @@ class SponsorBenefitAdminInlineFormTests(TestCase):
 
         # new benefit requires text instead of logo
         new_benefit = baker.make(SponsorshipBenefit)
-        baker.make(RequiredTextAssetConfiguration, benefit=new_benefit)
+        baker.make(RequiredTextAssetConfiguration, benefit=new_benefit, internal_name='foo',
+                   related_to=AssetsRelatedTo.SPONSORSHIP.value)
         self.data["sponsorship_benefit"] = new_benefit.pk
 
         form = SponsorBenefitAdminInlineForm(data=self.data, instance=sponsor_benefit)

--- a/sponsors/tests/test_forms.py
+++ b/sponsors/tests/test_forms.py
@@ -16,7 +16,7 @@ from sponsors.forms import (
     SendSponsorshipNotificationForm, SponsorRequiredAssetsForm,
 )
 from sponsors.models import SponsorshipBenefit, SponsorContact, RequiredTextAssetConfiguration, \
-    RequiredImgAssetConfiguration, ImgAsset
+    RequiredImgAssetConfiguration, ImgAsset, RequiredTextAsset
 from .utils import get_static_image_file_as_upload
 from ..models.enums import AssetsRelatedTo
 
@@ -455,7 +455,6 @@ class SponsorBenefitAdminInlineFormTests(TestCase):
             sponsorship=self.sponsorship,
             sponsorship_benefit=self.benefit,
         )
-        new_benefit = baker.make(SponsorshipBenefit)
 
         form = SponsorBenefitAdminInlineForm(data=self.data, instance=sponsor_benefit)
         self.assertTrue(form.is_valid(), form.errors)
@@ -469,6 +468,28 @@ class SponsorBenefitAdminInlineFormTests(TestCase):
         self.assertEqual(sponsor_benefit.sponsorship_benefit, self.benefit)
         self.assertNotEqual(sponsor_benefit.name, "new name")
         self.assertEqual(sponsor_benefit.benefit_internal_value, 200)
+
+    def test_update_existing_benefit_features(self):
+        sponsor_benefit = baker.make(
+            SponsorBenefit,
+            sponsorship=self.sponsorship,
+            sponsorship_benefit=self.benefit,
+        )
+        # existing benefit depends on logo
+        baker.make_recipe('sponsors.tests.logo_at_download_feature', sponsor_benefit=sponsor_benefit)
+
+        # new benefit requires text instead of logo
+        new_benefit = baker.make(SponsorshipBenefit)
+        baker.make(RequiredTextAssetConfiguration, benefit=new_benefit)
+        self.data["sponsorship_benefit"] = new_benefit.pk
+
+        form = SponsorBenefitAdminInlineForm(data=self.data, instance=sponsor_benefit)
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        sponsor_benefit.refresh_from_db()
+
+        self.assertEqual(sponsor_benefit.features.count(), 1)
+        self.assertIsInstance(sponsor_benefit.features.get(), RequiredTextAsset)
 
 
 class SponsorshipsFormTestCase(TestCase):


### PR DESCRIPTION
This PR addresses the following feedback from sponsorship app:  

    - I can delete benefits from a sponsorship application, but I can't add them.

    Once application is complete, being able to add a sponsor benefit to an 
    application before approving/generating contract/finalizing will require logic to be added to 
    admin routes to correctly handle creation of sponsorship benefit objects.

It does so by not disabling the link add new entries by `SponsorshipAdmin`. It also updates the form used to inline display the sponsors to make sure the benefit features are updated as expected as well.