### PR TITLE
Improves response time of sponsors page

### DIFF
--- a/pydotorg/settings/heroku.py
+++ b/pydotorg/settings/heroku.py
@@ -11,6 +11,15 @@ DEBUG = TEMPLATE_DEBUG = False
 DATABASE_CONN_MAX_AGE = 600
 DATABASES['default']['CONN_MAX_AGE'] = DATABASE_CONN_MAX_AGE
 
+## Django Caching
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'django_cache_table',
+    }
+}
+
 HAYSTACK_SEARCHBOX_SSL_URL = config(
     'SEARCHBOX_SSL_URL'
 )

--- a/sponsors/notifications.py
+++ b/sponsors/notifications.py
@@ -1,4 +1,5 @@
 from django.core.mail import EmailMessage
+from django.core.cache import cache
 from django.template.loader import render_to_string
 from django.conf import settings
 from django.contrib.admin.models import LogEntry, CHANGE, ADDITION
@@ -209,3 +210,9 @@ class SendSponsorNotificationLogger():
             action_flag=CHANGE,
             change_message=msg
         )
+
+
+class RefreshSponsorshipsCache:
+    def notify(self, *args, **kwargs):
+        # clean up cached used by "sponsors/partials/sponsors-list.html"
+        cache.delete("CACHED_SPONSORS_LIST")

--- a/sponsors/templatetags/sponsors.py
+++ b/sponsors/templatetags/sponsors.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 from django import template
+from django.conf import settings
+from django.core.cache import cache
 
 from ..models import Sponsorship, SponsorshipPackage, TieredQuantityConfiguration
 from sponsors.models.enums import PublisherChoices, LogoPlacementChoices
@@ -23,7 +25,7 @@ def full_sponsorship(sponsorship, display_fee=False):
 def list_sponsors(logo_place, publisher=PublisherChoices.FOUNDATION.value):
     sponsorships = Sponsorship.objects.enabled().with_logo_placement(
         logo_place=logo_place, publisher=publisher
-    ).order_by('package').select_related('sponsor')
+    ).order_by('package').select_related('sponsor', 'package')
     packages = SponsorshipPackage.objects.all()
 
     context = {
@@ -50,6 +52,7 @@ def list_sponsors(logo_place, publisher=PublisherChoices.FOUNDATION.value):
             'packages': SponsorshipPackage.objects.all(),
             'sponsorships_by_package': sponsorships_by_package,
         })
+
     return context
 
 

--- a/sponsors/tests/test_use_cases.py
+++ b/sponsors/tests/test_use_cases.py
@@ -187,9 +187,12 @@ class ExecuteContractUseCaseTests(TestCase):
 
     def test_build_use_case_with_default_notificationss(self):
         uc = use_cases.ExecuteContractUseCase.build()
-        self.assertEqual(len(uc.notifications), 1)
+        self.assertEqual(len(uc.notifications), 2)
         self.assertIsInstance(
             uc.notifications[0], ExecutedContractLogger
+        )
+        self.assertIsInstance(
+            uc.notifications[1], RefreshSponsorshipsCache,
         )
 
 
@@ -219,9 +222,12 @@ class ExecuteExistingContractUseCaseTests(TestCase):
 
     def test_build_use_case_with_default_notificationss(self):
         uc = use_cases.ExecuteExistingContractUseCase.build()
-        self.assertEqual(len(uc.notifications), 1)
+        self.assertEqual(len(uc.notifications), 2)
         self.assertIsInstance(
             uc.notifications[0], ExecutedExistingContractLogger
+        )
+        self.assertIsInstance(
+            uc.notifications[1], RefreshSponsorshipsCache,
         )
 
 
@@ -239,9 +245,12 @@ class NullifyContractUseCaseTests(TestCase):
 
     def test_build_use_case_with_default_notificationss(self):
         uc = use_cases.NullifyContractUseCase.build()
-        self.assertEqual(len(uc.notifications), 1)
+        self.assertEqual(len(uc.notifications), 2)
         self.assertIsInstance(
             uc.notifications[0], NullifiedContractLogger
+        )
+        self.assertIsInstance(
+            uc.notifications[1], RefreshSponsorshipsCache,
         )
 
 

--- a/sponsors/use_cases.py
+++ b/sponsors/use_cases.py
@@ -94,6 +94,7 @@ class SendContractUseCase(BaseUseCaseWithNotifications):
 class ExecuteExistingContractUseCase(BaseUseCaseWithNotifications):
     notifications = [
         notifications.ExecutedExistingContractLogger(),
+        notifications.RefreshSponsorshipsCache(),
     ]
     force_execute = True
 
@@ -109,6 +110,7 @@ class ExecuteExistingContractUseCase(BaseUseCaseWithNotifications):
 class ExecuteContractUseCase(ExecuteExistingContractUseCase):
     notifications = [
         notifications.ExecutedContractLogger(),
+        notifications.RefreshSponsorshipsCache(),
     ]
     force_execute = False
 
@@ -116,6 +118,7 @@ class ExecuteContractUseCase(ExecuteExistingContractUseCase):
 class NullifyContractUseCase(BaseUseCaseWithNotifications):
     notifications = [
         notifications.NullifiedContractLogger(),
+        notifications.RefreshSponsorshipsCache(),
     ]
 
     def execute(self, contract, **kwargs):

--- a/templates/sponsors/partials/sponsors-list.html
+++ b/templates/sponsors/partials/sponsors-list.html
@@ -1,4 +1,8 @@
 {% load thumbnail %}
+{% load cache %}
+
+{% comment %}30-days cache{% endcomment %}
+{% cache 2592000 CACHED_SPONSORS_LIST %}
 
 {% if logo_place == "download" %}
   <h2 class="widget-title">Sponsors</h2>
@@ -51,3 +55,4 @@
   {% endif %}
   {% endfor %}
 {% endif %}
+{% endcache CACHED_SPONSORS_LIST %}

--- a/templates/sponsors/partials/sponsors-list.html
+++ b/templates/sponsors/partials/sponsors-list.html
@@ -1,8 +1,8 @@
 {% load thumbnail %}
 {% load cache %}
 
-{% comment %}30-days cache{% endcomment %}
-{% cache 2592000 CACHED_SPONSORS_LIST %}
+{% comment %}cache for 1 day{% endcomment %}
+{% cache 86400 CACHED_SPONSORS_LIST %}
 
 {% if logo_place == "download" %}
   <h2 class="widget-title">Sponsors</h2>


### PR DESCRIPTION
This PR adds an internal cache to not rely only on CDN caching. 

The sponsors list page takes time to finish the request for the first time because it performs a lot of database queries. It has to:

- List all packages;
- List all finalized sponsorships with logo placement for that page (here the Django's polymorphic models play an important role);
- Per image, run `solr-thumbnail` queries to locate the expected image thumbnail path;

This PR does reduce the initial load time, but there's still some room for improvements. Here's the difference between a cold-cache from a warm one:

**Cold-cache**

![Screenshot from 2021-12-27 10-44-23](https://user-images.githubusercontent.com/238223/147478932-90847b74-f105-4e28-b6c6-65de64f59fc5.png)

**Warm-cache**

![Screenshot from 2021-12-27 10-44-32](https://user-images.githubusercontent.com/238223/147478961-1516228e-0272-46f5-a89d-96829614ddab.png)

**Improvements**

The high volume of DB queries (79 on cold-cache) is mostly `solr-thumbnail`'s responsibility. Under the hood, it uses a [Key Value Store](https://sorl-thumbnail.readthedocs.io/en/latest/requirements.html#key-value-store) to store the path of a specific thumbnail generated from an image. If we don't customize anything, it uses a **cached database** and this results in what we're seeing: multiple I/O operations in the database being called. 

To reduce I/O and, thus, CPU usage, we could switch the key value store to use memcached and, thus, have faster in-memory I/O operations. [From their docs](https://sorl-thumbnail.readthedocs.io/en/latest/requirements.html#cached-db), if we set up Django Cache to use memcached, it should be enough to improve the performance. 

Since this touches infra configuration as well, I didn't move on with that because I'd like to sync with @ewdurbin first to check if it makes sense to enable Django's cache on Pythondotorg's current stack.