### PR TITLE
New admin fieldset section to display user customizations on packages benefits

### DIFF
--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -289,6 +289,16 @@ class SponsorshipAdmin(admin.ModelAdmin):
         ),
     ]
 
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = []
+        for title, cfg in super().get_fieldsets(request, obj):
+            # disable collapse option in case of sponsorships with customizations
+            if title == "User Customizations" and obj:
+                if obj.user_customizations["added_by_user"] or obj.user_customizations["removed_by_user"]:
+                    cfg["classes"] = []
+            fieldsets.append((title, cfg))
+        return fieldsets
+
     def get_queryset(self, *args, **kwargs):
         qs = super().get_queryset(*args, **kwargs)
         return qs.select_related("sponsor", "package", "submited_by")

--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -266,6 +266,16 @@ class SponsorshipAdmin(admin.ModelAdmin):
             },
         ),
         (
+            "User Customizations",
+            {
+                "fields": (
+                    "get_custom_benefits_added_by_user",
+                    "get_custom_benefits_removed_by_user",
+                ),
+                "classes": ["collapse"],
+            },
+        ),
+        (
             "Events dates",
             {
                 "fields": (
@@ -307,6 +317,9 @@ class SponsorshipAdmin(admin.ModelAdmin):
             "get_sponsor_mailing_address",
             "get_sponsor_contacts",
             "get_contract",
+            "get_added_by_user",
+            "get_custom_benefits_added_by_user",
+            "get_custom_benefits_removed_by_user",
         ]
 
         if obj and obj.status != Sponsorship.APPLIED:
@@ -443,6 +456,30 @@ class SponsorshipAdmin(admin.ModelAdmin):
         return mark_safe(html)
 
     get_sponsor_contacts.short_description = "Contacts"
+
+    def get_custom_benefits_added_by_user(self, obj):
+        benefits = obj.user_customizations["added_by_user"]
+        if not benefits:
+            return "---"
+
+        html = "".join(
+            [f"<p>{b}</p>" for b in benefits]
+        )
+        return mark_safe(html)
+
+    get_custom_benefits_added_by_user.short_description = "Added by User"
+
+    def get_custom_benefits_removed_by_user(self, obj):
+        benefits = obj.user_customizations["removed_by_user"]
+        if not benefits:
+            return "---"
+
+        html = "".join(
+            [f"<p>{b}</p>" for b in benefits]
+        )
+        return mark_safe(html)
+
+    get_custom_benefits_removed_by_user.short_description = "Removed by User"
 
     def rollback_to_editing_view(self, request, pk):
         return views_admin.rollback_to_editing_view(self, request, pk)

--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -237,10 +237,10 @@ class SponsorshipAdmin(admin.ModelAdmin):
             "Sponsorship Data",
             {
                 "fields": (
+                    "for_modified_package",
                     "sponsor",
                     "status",
                     "package",
-                    "for_modified_package",
                     "sponsorship_fee",
                     "get_estimated_cost",
                     "start_date",

--- a/sponsors/models/sponsorship.py
+++ b/sponsors/models/sponsorship.py
@@ -76,6 +76,17 @@ class SponsorshipPackage(OrderedModel):
         )
         return not has_all_conflicts
 
+    def get_user_customization(self, benefits):
+        """
+        Given a list of benefits this method returns the customizations
+        """
+        benefits = set(tuple(benefits))
+        pkg_benefits = set(tuple(self.benefits.all()))
+        return {
+          "added_by_user": benefits - pkg_benefits,
+          "removed_by_user": pkg_benefits - benefits,
+        }
+
 
 class SponsorshipProgram(OrderedModel):
     """

--- a/sponsors/models/sponsorship.py
+++ b/sponsors/models/sponsorship.py
@@ -141,7 +141,7 @@ class Sponsorship(models.Model):
 
     for_modified_package = models.BooleanField(
         default=False,
-        help_text="If true, it means the user customized the package's benefits.",
+        help_text="If true, it means the user customized the package's benefits. Changes are listed under section 'User Customizations'.",
     )
     level_name_old = models.CharField(max_length=64, default="", blank=True, help_text="DEPRECATED: shall be removed "
                                                                                        "after manual data sanity "
@@ -164,6 +164,11 @@ class Sponsorship(models.Model):
     @level_name.setter
     def level_name(self, value):
         self.level_name_old = value
+
+    @cached_property
+    def user_customizations(self):
+        benefits = [b.sponsorship_benefit for b in self.benefits.select_related("sponsorship_benefit")]
+        return self.package.get_user_customization(benefits)
 
     def __str__(self):
         repr = f"{self.level_name} ({self.get_status_display()}) for sponsor {self.sponsor.name}"

--- a/sponsors/tests/test_models.py
+++ b/sponsors/tests/test_models.py
@@ -294,7 +294,6 @@ class SponsorshipModelTests(TestCase):
             self.assertEqual(sponsorship.agreed_fee, 2000)
 
 
-
 class SponsorshipPackageTests(TestCase):
     def setUp(self):
         self.package = baker.make("sponsors.SponsorshipPackage")
@@ -303,19 +302,24 @@ class SponsorshipPackageTests(TestCase):
 
     def test_has_user_customization_if_benefit_from_other_package(self):
         extra = baker.make(SponsorshipBenefit)
-        customization = self.package.has_user_customization(
-            [extra] + self.package_benefits
-        )
-        self.assertTrue(customization)
+        benefits = [extra] + self.package_benefits
+        has_customization = self.package.has_user_customization(benefits)
+        customization = {"added_by_user": {extra}, "removed_by_user": set()}
+        self.assertTrue(has_customization)
+        self.assertEqual(customization, self.package.get_user_customization(benefits))
 
     def test_no_user_customization_if_all_benefits_from_package(self):
-        customization = self.package.has_user_customization(self.package_benefits)
-        self.assertFalse(customization)
+        has_customization = self.package.has_user_customization(self.package_benefits)
+        customization = {"added_by_user": set(), "removed_by_user": set()}
+        self.assertFalse(has_customization)
+        self.assertEqual(customization, self.package.get_user_customization(self.package_benefits))
 
     def test_has_user_customization_if_missing_package_benefit(self):
-        self.package_benefits.pop()
-        customization = self.package.has_user_customization(self.package_benefits)
-        self.assertTrue(customization)
+        removed_benefit = self.package_benefits.pop()
+        has_customization = self.package.has_user_customization(self.package_benefits)
+        customization = {"added_by_user": set(), "removed_by_user": {removed_benefit}}
+        self.assertTrue(has_customization)
+        self.assertEqual(customization, self.package.get_user_customization(self.package_benefits))
 
     def test_no_user_customization_if_at_least_one_of_conflicts_is_passed(self):
         benefits = baker.make(SponsorshipBenefit, _quantity=3)


### PR DESCRIPTION
This PR updates the `SponsorshipAdmin` edit page to have a new read-only section listing user customization on sponsorships. The new section has 2 fields, one to list added benefits and another for the removed ones. By default the section is collapsed, but it appears as a regular one if there's any customization to list.

![Screenshot from 2022-01-04 15-05-07](https://user-images.githubusercontent.com/238223/148103723-a7263435-88a1-41f3-9de3-7bdc24e45a6d.png)

It also gives more importance to the `For Modified Package` flag by making it the first field displayed in the page.

![Screenshot from 2022-01-04 15-00-15](https://user-images.githubusercontent.com/238223/148103232-02e80562-c023-4f1a-8e38-2f47cda5031c.png)
