### PR TITLE
Improvements to sponsorship form layout

### DIFF
--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -1,3 +1,5 @@
+const DESKTOP_WIDTH_LIMIT = 1500;
+
 $(document).ready(function(){
   const SELECTORS = {
     packageInput:  function() { return $("input[name=package]"); },
@@ -63,10 +65,10 @@ $(document).ready(function(){
 
 
 function mobileUpdate(packageId) {
-  // Mobile version lists a single column to controle the selected
-  // benefits and potential add-ons. So, this part of the code
-  // controls this logic.
-  const mobileVersion = $(".benefit-within-package:hidden").length > 0;
+  const width = window.innerWidth
+    || document.documentElement.clientWidth
+    || document.body.clientWidth;
+  const mobileVersion = width <= DESKTOP_WIDTH_LIMIT;
   if (!mobileVersion) return;
   $(".benefit-within-package").hide();  // hide all ticks and potential add-ons inputs
   $(`div[data-package-reference=${packageId}]`).show()  // display only package's ones

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -24,7 +24,6 @@ $(document).ready(function(){
   SELECTORS.packageInput().click(function(){
     let package = this.value;
     if (package.length == 0) return;
-    $(".section-content").show();
 
     // clear previous customizations
     SELECTORS.tickImages().each((i, img) => {

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -7,10 +7,17 @@ $(document).ready(function(){
     getBenefitInput: function(benefitId) { return SELECTORS.benefitsInputs().filter('[value=' + benefitId + ']'); },
     getSelectedBenefits: function() { return SELECTORS.benefitsInputs().filter(":checked"); },
     tickImages: function() { return $(`.benefit-within-package img`) },
+    sectionToggleBtns: function() { return $(".toggle_btn")}
   }
 
   const initialPackage = $("input[name=package]:checked").val();
   if (initialPackage && initialPackage.length > 0) mobileUpdate(initialPackage);
+
+  SELECTORS.sectionToggleBtns().click(function(){
+    const section = $(this).data('section');
+    const className = ".section-" + section + "-content";
+    $(className).toggle();
+  });
 
   SELECTORS.packageInput().click(function(){
     let package = this.value;

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -35,6 +35,7 @@ $(document).ready(function(){
     });
 
     // update package benefits display
+    $(`#pkg_container_${package}`).addClass("selected");
     $(`.package-${package}-benefit`).addClass("selected");
     $(`.package-${package}-benefit input`).prop("disabled", false);
 

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -1,4 +1,4 @@
-const DESKTOP_WIDTH_LIMIT = 1500;
+const DESKTOP_WIDTH_LIMIT = 1200;
 
 $(document).ready(function(){
   const SELECTORS = {

--- a/static/js/sponsors/applicationForm.js
+++ b/static/js/sponsors/applicationForm.js
@@ -22,6 +22,7 @@ $(document).ready(function(){
   SELECTORS.packageInput().click(function(){
     let package = this.value;
     if (package.length == 0) return;
+    $(".section-content").show();
 
     // clear previous customizations
     SELECTORS.tickImages().each((i, img) => {
@@ -110,5 +111,10 @@ function benefitUpdate(benefitId, packageId) {
 // Callback function when user selects a package;
 function updatePackageInput(packageId){
   const packageInput = document.getElementById(`id_package_${ packageId }`);
+
+  // no need to update if package is already selected
+  const container = packageInput.parentElement;
+  if (container.classList.contains("selected")) return;
+
   packageInput.click();
 }

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3815,12 +3815,18 @@ span.highlighted {
           width: 70%; } }
   #select_sponsorship_benefits_container #benefitsTable .separator {
     flex-shrink: 0;
-    justify-content: flex-start;
-    border-bottom: 3px solid #ffd343; }
+    border-bottom: 3px solid #ffd343;
+    display: block; }
     #select_sponsorship_benefits_container #benefitsTable .separator h4 {
       font-size: 23px;
       line-height: 29px;
-      font-weight: 700; }
+      font-weight: 700;
+      float: left; }
+    #select_sponsorship_benefits_container #benefitsTable .separator .toggle_btn {
+      margin-top: 2em;
+      float: right;
+      cursor: pointer;
+      text-decoration: underline dotted; }
   #select_sponsorship_benefits_container #benefitsTable .no-border {
     border-bottom: none; }
   #select_sponsorship_benefits_container #benefitsTable .package-input {

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3804,13 +3804,13 @@ span.highlighted {
       padding: 0 1em;
       text-align: center;
       margin: 0 0.25em; }
-      @media (max-width: 1200px) {
+      @media (max-width: 1500px) {
         #select_sponsorship_benefits_container #benefitsTable .row .col:not(first-child) {
           width: 30%; } }
     #select_sponsorship_benefits_container #benefitsTable .row .col:first-child {
       width: 20%;
       text-align: left; }
-      @media (max-width: 1200px) {
+      @media (max-width: 1500px) {
         #select_sponsorship_benefits_container #benefitsTable .row .col:first-child {
           width: 70%; } }
   #select_sponsorship_benefits_container #benefitsTable .separator {
@@ -3847,7 +3847,7 @@ span.highlighted {
     #select_sponsorship_benefits_container #benefitsTable .selected img {
       padding: 0.5em 1em;
       cursor: pointer; }
-  @media (max-width: 1200px) {
+  @media (max-width: 1500px) {
     #select_sponsorship_benefits_container #benefitsTable .benefit-within-package {
       display: none; }
     #select_sponsorship_benefits_container #benefitsTable .selected {
@@ -3870,7 +3870,7 @@ span.highlighted {
     color: #000000;
     margin: 0;
     padding: 0; }
-  @media (max-width: 1200px) {
+  @media (max-width: 1500px) {
     #select_sponsorship_benefits_container .custom-benefits {
       margin: 0;
       padding: 1em; }
@@ -3903,14 +3903,14 @@ span.highlighted {
     #select_sponsorship_benefits_container .submit-row .btn:hover, #select_sponsorship_benefits_container .submit-row .btn:focus {
       background: #ffd95c;
       text-shadow: 0 0 5px rgba(255, 211, 67, 0.2); }
-  @media (max-width: 1200px) {
+  @media (max-width: 1500px) {
     #select_sponsorship_benefits_container .submit-row {
       flex-flow: column nowrap !important;
       width: 100%;
       padding: 0; }
       #select_sponsorship_benefits_container .submit-row .btn {
         margin: 1em; } }
-@media (max-width: 1200px) {
+@media (max-width: 1500px) {
   #select_sponsorship_benefits_container #package-selection .row {
     /* Mobile's layout lists the package selection as a single column instead of multiple
        ones as in the desktop version. That's why this strange flex-flow change is being
@@ -3938,10 +3938,10 @@ span.highlighted {
       order: 3; }
     #select_sponsorship_benefits_container #package-selection .package-input input {
       order: 1; } }
-    @media (max-width: 1200px) and (max-width: 640px) {
+    @media (max-width: 1500px) and (max-width: 640px) {
       #select_sponsorship_benefits_container #package-selection .row .col:not(first-child) {
         width: 80%; } }
-@media (min-width: 1200px) {
+@media (min-width: 1500px) {
   #select_sponsorship_benefits_container {
     /* Destkop version have the package selection row as a fixed header after some scrolling.
        This CSS block address this logic.

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3745,6 +3745,9 @@ span.highlighted {
   line-height: 28px;
   color: #444444;
   margin-top: 1em; }
+  @media (max-width: 1320px) {
+    #select_sponsorship_benefits_container h4 {
+      font-size: 16px; } }
 #select_sponsorship_benefits_container p {
   font-size: 18px;
   line-height: 28px;
@@ -3804,13 +3807,13 @@ span.highlighted {
       padding: 0 1em;
       text-align: center;
       margin: 0 0.25em; }
-      @media (max-width: 1500px) {
+      @media (max-width: 1200px) {
         #select_sponsorship_benefits_container #benefitsTable .row .col:not(first-child) {
           width: 30%; } }
     #select_sponsorship_benefits_container #benefitsTable .row .col:first-child {
       width: 20%;
       text-align: left; }
-      @media (max-width: 1500px) {
+      @media (max-width: 1200px) {
         #select_sponsorship_benefits_container #benefitsTable .row .col:first-child {
           width: 70%; } }
   #select_sponsorship_benefits_container #benefitsTable .separator {
@@ -3847,7 +3850,7 @@ span.highlighted {
     #select_sponsorship_benefits_container #benefitsTable .selected img {
       padding: 0.5em 1em;
       cursor: pointer; }
-  @media (max-width: 1500px) {
+  @media (max-width: 1200px) {
     #select_sponsorship_benefits_container #benefitsTable .benefit-within-package {
       display: none; }
     #select_sponsorship_benefits_container #benefitsTable .selected {
@@ -3870,7 +3873,7 @@ span.highlighted {
     color: #000000;
     margin: 0;
     padding: 0; }
-  @media (max-width: 1500px) {
+  @media (max-width: 1200px) {
     #select_sponsorship_benefits_container .custom-benefits {
       margin: 0;
       padding: 1em; }
@@ -3903,14 +3906,14 @@ span.highlighted {
     #select_sponsorship_benefits_container .submit-row .btn:hover, #select_sponsorship_benefits_container .submit-row .btn:focus {
       background: #ffd95c;
       text-shadow: 0 0 5px rgba(255, 211, 67, 0.2); }
-  @media (max-width: 1500px) {
+  @media (max-width: 1200px) {
     #select_sponsorship_benefits_container .submit-row {
       flex-flow: column nowrap !important;
       width: 100%;
       padding: 0; }
       #select_sponsorship_benefits_container .submit-row .btn {
         margin: 1em; } }
-@media (max-width: 1500px) {
+@media (max-width: 1200px) {
   #select_sponsorship_benefits_container #package-selection .row {
     /* Mobile's layout lists the package selection as a single column instead of multiple
        ones as in the desktop version. That's why this strange flex-flow change is being
@@ -3933,15 +3936,17 @@ span.highlighted {
      items are being displayed using the order property.*/
     margin: 0.25rem 0 !important; }
     #select_sponsorship_benefits_container #package-selection .package-input h4 {
-      order: 2; }
+      order: 2;
+      padding-left: 1em; }
     #select_sponsorship_benefits_container #package-selection .package-input span {
-      order: 3; }
+      order: 3;
+      padding-right: 1em; }
     #select_sponsorship_benefits_container #package-selection .package-input input {
       order: 1; } }
-    @media (max-width: 1500px) and (max-width: 640px) {
+    @media (max-width: 1200px) and (max-width: 640px) {
       #select_sponsorship_benefits_container #package-selection .row .col:not(first-child) {
         width: 80%; } }
-@media (min-width: 1500px) {
+@media (min-width: 1200px) {
   #select_sponsorship_benefits_container {
     /* Destkop version have the package selection row as a fixed header after some scrolling.
        This CSS block address this logic.

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3804,7 +3804,6 @@ span.highlighted {
     border-bottom: 1px solid #e6e8ea; }
     #select_sponsorship_benefits_container #benefitsTable .row .col:not(first-child) {
       width: 10%;
-      padding: 0 1em;
       text-align: center;
       margin: 0 0.25em; }
       @media (max-width: 1200px) {

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3802,7 +3802,8 @@ span.highlighted {
     #select_sponsorship_benefits_container #benefitsTable .row .col:not(first-child) {
       width: 10%;
       padding: 0 1em;
-      text-align: center; }
+      text-align: center;
+      margin: 0 0.25em; }
       @media (max-width: 1200px) {
         #select_sponsorship_benefits_container #benefitsTable .row .col:not(first-child) {
           width: 30%; } }
@@ -3823,19 +3824,22 @@ span.highlighted {
   #select_sponsorship_benefits_container #benefitsTable .no-border {
     border-bottom: none; }
   #select_sponsorship_benefits_container #benefitsTable .package-input {
-    cursor: pointer; }
-    #select_sponsorship_benefits_container #benefitsTable .package-input .package-price {
-      padding-bottom: 0.5em; }
+    cursor: pointer;
+    padding-bottom: 0.5em !important;
+    border: 1px solid #caccce;
+    border-radius: 15px; }
     #select_sponsorship_benefits_container #benefitsTable .package-input .custom-fee {
       font-size: 75%;
+      display: none; }
+    #select_sponsorship_benefits_container #benefitsTable .package-input input {
       display: none; }
     #select_sponsorship_benefits_container #benefitsTable .package-input h4 {
       transform: rotateY(35deg); }
   #select_sponsorship_benefits_container #benefitsTable .selected {
     background-color: #e9f1f8;
-    border-radius: 15px;
-    padding: 0.5em 1em !important; }
+    border-radius: 15px; }
     #select_sponsorship_benefits_container #benefitsTable .selected img {
+      padding: 0.5em 1em;
       cursor: pointer; }
   @media (max-width: 1200px) {
     #select_sponsorship_benefits_container #benefitsTable .benefit-within-package {

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3845,7 +3845,9 @@ span.highlighted {
     #select_sponsorship_benefits_container #benefitsTable .benefit-within-package {
       display: none; }
     #select_sponsorship_benefits_container #benefitsTable .selected {
-      background-color: transparent; } }
+      background-color: transparent; }
+    #select_sponsorship_benefits_container #benefitsTable .package-input.selected {
+      background-color: #e9f1f8; } }
 #select_sponsorship_benefits_container .custom-benefits {
   margin: 2em 0;
   padding: 0 2em; }
@@ -3922,7 +3924,8 @@ span.highlighted {
   #select_sponsorship_benefits_container #package-selection .package-input {
     /* The internal disposition of the package name, price and checkbox for the mobile version differs
      from the desktop one. To avoid having 2 type of HTML structures, we're rearranging how the
-     items are being displayed using the order property.*/ }
+     items are being displayed using the order property.*/
+    margin: 0.25rem 0 !important; }
     #select_sponsorship_benefits_container #package-selection .package-input h4 {
       order: 2; }
     #select_sponsorship_benefits_container #package-selection .package-input span {

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2439,7 +2439,7 @@ span.highlighted {
 }
 
 $breakpoint-phone: 640px;
-$breakpoint-desktop: 1200px;
+$breakpoint-desktop: 1500px;
 
 #new_sponsorship_application_container, #edit-sponsor-information {
 

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2741,6 +2741,10 @@ $breakpoint-desktop: 1200px;
     @media (max-width: $breakpoint-desktop) {
       .benefit-within-package {display: none;}
       .selected {background-color: transparent;}
+
+      .package-input.selected {
+          background-color: lighten($blue, 50%);
+      }
     };
   }
 
@@ -2871,6 +2875,7 @@ $breakpoint-desktop: 1200px;
          input { // input
            order: 1;
          }
+         margin: 0.25rem 0 !important;
       }
     }
   }

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2692,13 +2692,21 @@ $breakpoint-desktop: 1200px;
 
     .separator {
       flex-shrink: 0;
-      justify-content: flex-start;
       border-bottom: 3px solid #FFD343;
+      display: block;
 
       h4 {
         font-size: 23px;
         line-height: 29px;
         font-weight: 700;
+        float: left;
+      }
+
+      .toggle_btn {
+        margin-top: 2em;
+        float: right;
+        cursor: pointer;
+        text-decoration: underline dotted;
       }
     }
 

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2677,6 +2677,7 @@ $breakpoint-desktop: 1200px;
         width: 10%;
         padding: 0 1em;
         text-align: center;
+        margin: 0 0.25em;
 
         @media (max-width: $breakpoint-desktop) {width: 30%};
       }
@@ -2706,12 +2707,13 @@ $breakpoint-desktop: 1200px;
     }
 
     .package-input {
-      .package-price {
-        padding-bottom: 0.5em;
-      }
 
       .custom-fee {
         font-size: 75%;
+        display: none;
+      }
+
+      input {
         display: none;
       }
 
@@ -2720,14 +2722,17 @@ $breakpoint-desktop: 1200px;
       }
 
       cursor: pointer;
+      padding-bottom: 0.5em !important;
+      border: 1px solid $default-border-color;
+      border-radius: 15px;
     }
 
     .selected {
       background-color: lighten($blue, 50%);
       border-radius: 15px;
-      padding: 0.5em 1em !important;
 
       img {
+        padding: 0.5em 1em;
         cursor: pointer;
       }
     }

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2439,7 +2439,7 @@ span.highlighted {
 }
 
 $breakpoint-phone: 640px;
-$breakpoint-desktop: 1500px;
+$breakpoint-desktop: 1200px;
 
 #new_sponsorship_application_container, #edit-sponsor-information {
 
@@ -2586,6 +2586,7 @@ $breakpoint-desktop: 1500px;
       line-height: 28px;
       color: #444444;
       margin-top: 1em;
+      @media (max-width: $breakpoint-desktop*1.1) { font-size: 16px; }
     }
 
     p {
@@ -2675,7 +2676,6 @@ $breakpoint-desktop: 1500px;
 
       .col:not(first-child) {
         width: 10%;
-        padding: 0 1em;
         text-align: center;
         margin: 0 0.25em;
 
@@ -2876,9 +2876,11 @@ $breakpoint-desktop: 1500px;
           items are being displayed using the order property.*/
          h4 { // package name
            order: 2;
+           padding-left: 1em;
          }
          span { // package fee
            order: 3;
+           padding-right: 1em;
          }
          input { // input
            order: 1;

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -61,7 +61,7 @@
 
         <!-- Benefits listing (as rows) --!>
         {% for benefit in field.field.queryset %}
-        <div class="row {% if forloop.last %}no-border{% endif %} section-{{ sectionNum }}-content">
+        <div class="row {% if forloop.last %}no-border{% endif %} section-{{ sectionNum }}-content section-content">
           <div class="col benefit">
             <h4 class="benefit-title">{{ benefit.name }}</h4>
             <span class="benefit-description">{{ benefit.description }}</span>

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -53,13 +53,15 @@
         </div>
 
         {% for field in form.benefits_programs %}
+        {% with forloop.counter as sectionNum %}
         <div class="row separator">
-          <h4>{{ field.label }}</h4>
+           <h4>{{ field.label }}</h4>
+           <small class="toggle_btn" data-section={{ sectionNum }}>Collapse/expand section</small>
         </div>
 
         <!-- Benefits listing (as rows) --!>
         {% for benefit in field.field.queryset %}
-        <div class="row {% if forloop.last %}no-border{% endif %}">
+        <div class="row {% if forloop.last %}no-border{% endif %} section-{{ sectionNum }}-content">
           <div class="col benefit">
             <h4 class="benefit-title">{{ benefit.name }}</h4>
             <span class="benefit-description">{{ benefit.description }}</span>
@@ -122,6 +124,7 @@
         </div>
         {% endfor %}
 
+        {% endwith %}
         {% endfor %}
       </div>
 

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -42,7 +42,7 @@
                {% endif %}
              </span>
              {% for package in form.fields.package.queryset %}
-             <div class="col col-items package-input" data-package-id="{{ package.id}}" onclick="updatePackageInput({{forloop.counter0}})">
+             <div id="pkg_container_{{ package.id }}" class="col col-items package-input {% if package.id == form.initial.package %}selected{% endif %}" data-package-id="{{ package.id}}" onclick="updatePackageInput({{forloop.counter0}})">
                <h4>{{ package.name|upper }}</h4>
                <span class="package-price">${{ package.sponsorship_amount|intcomma }}<span class="custom-fee-{{ package.id }} custom-fee">*</span></span>
                <input type="radio" name="package" value="{{ package.id }}" id="id_package_{{ forloop.counter0 }}" {% if package.id == form.initial.package %}checked="checked"{% endif %} data-pos={{ forloop.counter0 }} />


### PR DESCRIPTION
This PR introduces updates to the benefits form from the sponsorship application process. The changes are on the package buttons and on benefits sections as well.

The buttons were updated to look more like as clickable and also the radio input is hidden. Here's how they are looking:

**No selection**
![Screenshot from 2022-01-05 15-09-34](https://user-images.githubusercontent.com/238223/148276811-fd81708c-ee50-4ff9-8aae-6812a0ce0cf5.png)

**Selected**
![Screenshot from 2022-01-05 15-09-47](https://user-images.githubusercontent.com/238223/148276834-47d4608a-3d04-486b-adf8-c1b68eea4405.png)

**On mobile**
![Screenshot from 2022-01-05 15-16-39](https://user-images.githubusercontent.com/238223/148276855-ffbb9fab-a507-4941-8be5-9ef011adccd0.png)

The other change is a new behavior in the form. Since it is a big form, this PR now introduces the option to collapse/expand sections. Here's how they're looking like now:

![Screenshot from 2022-01-05 16-12-31](https://user-images.githubusercontent.com/238223/148277019-028265ab-9b1b-46a0-a636-3af24c7913e8.png)

