### PR TITLE
Fix bug that prevents users from deleting sponsorship applications

### DIFF
--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -831,8 +831,11 @@ class GenericAssetModelAdmin(PolymorphicParentModelAdmin):
         classes = self.get_child_models(*args, **kwargs)
         return self.model.objects.select_related("content_type").instance_of(*classes)
 
-    def has_delete_permission(self, *args, **kwargs):
-        return False
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        if 'delete_selected' in actions:
+            del actions['delete_selected']
+        return actions
 
     def has_add_permission(self, *args, **kwargs):
         return False

--- a/sponsors/models/assets.py
+++ b/sponsors/models/assets.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.fields.files import ImageFieldFile, FileField
+from polymorphic.managers import PolymorphicManager
 from polymorphic.models import PolymorphicModel
 
 
@@ -27,6 +28,8 @@ class GenericAsset(PolymorphicModel):
     """
     Base class used to add required assets to Sponsor or Sponsorship objects
     """
+    polymorphic = PolymorphicManager()
+    non_polymorphic = models.Manager()
 
     # UUID can't be the object ID because Polymorphic expects default django integer ID
     uuid = models.UUIDField(default=uuid.uuid4, editable=False)
@@ -47,6 +50,7 @@ class GenericAsset(PolymorphicModel):
         verbose_name = "Asset"
         verbose_name_plural = "Assets"
         unique_together = ["content_type", "object_id", "internal_name"]
+        base_manager_name = 'non_polymorphic'
 
     @property
     def value(self):

--- a/sponsors/models/assets.py
+++ b/sponsors/models/assets.py
@@ -28,7 +28,7 @@ class GenericAsset(PolymorphicModel):
     """
     Base class used to add required assets to Sponsor or Sponsorship objects
     """
-    polymorphic = PolymorphicManager()
+    objects = PolymorphicManager()
     non_polymorphic = models.Manager()
 
     # UUID can't be the object ID because Polymorphic expects default django integer ID

--- a/sponsors/models/benefits.py
+++ b/sponsors/models/benefits.py
@@ -490,12 +490,14 @@ class BenefitFeature(PolymorphicModel):
     Base class for sponsor benefits features.
     """
     objects = BenefitFeatureQuerySet.as_manager()
+    non_polymorphic = models.Manager()
 
     sponsor_benefit = models.ForeignKey("sponsors.SponsorBenefit", on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = "Benefit Feature"
         verbose_name_plural = "Benefit Features"
+        base_manager_name = 'non_polymorphic'
 
     def display_modifier(self, name, **kwargs):
         return name


### PR DESCRIPTION
Fixes #1977

The cascade deletion was being disabled by [known Django bug](https://code.djangoproject.com/ticket/23076) combined with django-polymorphic. The introduced fix changes the default `base_manager_class` to use a non-polymorphic model manager which ensures cascade deletion as well. This manager is called by the delete process and, thus, now it's possible to delete sponsorships.

Here are screen shots to proof that the deletion operation is working:

![Screenshot from 2022-02-09 20-08-40](https://user-images.githubusercontent.com/238223/153305998-a3770790-9201-4dc4-9cf5-4b0010446772.png)

![Screenshot from 2022-02-09 20-08-50](https://user-images.githubusercontent.com/238223/153305993-13dc516f-7485-4928-871f-d0b05c194e53.png)
