### PR TITLE
Add filters to logo placement API

### DIFF
--- a/sponsors/api.py
+++ b/sponsors/api.py
@@ -14,6 +14,7 @@ class LogoPlacementSerializer(serializers.Serializer):
     publisher = serializers.CharField()
     flight = serializers.CharField()
     sponsor = serializers.CharField()
+    sponsor_slug = serializers.CharField()
     description = serializers.CharField()
     logo = serializers.URLField()
     start_date = serializers.DateField()
@@ -75,6 +76,7 @@ class LogoPlacementeAPIList(APIView):
             sponsor = sponsorship.sponsor
             base_data = {
                 "sponsor": sponsor.name,
+                "sponsor_slug": sponsor.slug,
                 "level_name": sponsorship.level_name,
                 "level_order": sponsorship.package.order,
                 "description": sponsor.description,

--- a/sponsors/api.py
+++ b/sponsors/api.py
@@ -7,6 +7,7 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from sponsors.models import BenefitFeature, LogoPlacement, Sponsorship
+from sponsors.models.enums import PublisherChoices, LogoPlacementChoices
 
 
 class LogoPlacementSerializer(serializers.Serializer):
@@ -20,6 +21,33 @@ class LogoPlacementSerializer(serializers.Serializer):
     sponsor_url = serializers.URLField()
     level_name = serializers.CharField()
     level_order = serializers.IntegerField()
+
+
+class FilterLogoPlacementsSerializer(serializers.Serializer):
+    publisher = serializers.ChoiceField(
+        choices=[(c.value, c.name.replace("_", " ").title()) for c in PublisherChoices],
+        required=False,
+    )
+    flight = serializers.ChoiceField(
+        choices=[(c.value, c.name.replace("_", " ").title()) for c in LogoPlacementChoices],
+        required=False,
+    )
+
+    @property
+    def by_publisher(self):
+        return self.validated_data.get("publisher")
+
+    @property
+    def by_flight(self):
+        return self.validated_data.get("flight")
+
+    def skip_logo(self, logo):
+        if self.by_publisher and self.by_publisher != logo.publisher:
+            return True
+        if self.by_flight and self.by_flight != logo.logo_place:
+            return True
+        else:
+            return False
 
 
 class SponsorPublisherPermission(permissions.BasePermission):
@@ -38,6 +66,9 @@ class LogoPlacementeAPIList(APIView):
 
     def get(self, request, *args, **kwargs):
         placements = []
+        logo_filters = FilterLogoPlacementsSerializer(data=request.GET)
+        if not logo_filters.is_valid():
+            return Response(logo_filters.errors, status=400)
 
         sponsorships = Sponsorship.objects.enabled().with_logo_placement()
         for sponsorship in sponsorships.select_related("sponsor").iterator():
@@ -54,7 +85,8 @@ class LogoPlacementeAPIList(APIView):
             }
 
             benefits = BenefitFeature.objects.filter(sponsor_benefit__sponsorship_id=sponsorship.pk)
-            for logo in benefits.instance_of(LogoPlacement):
+            logos = [l for l in benefits.instance_of(LogoPlacement) if not logo_filters.skip_logo(l)]
+            for logo in logos:
                 placement = base_data.copy()
                 placement["publisher"] = logo.publisher
                 placement["flight"] = logo.logo_place

--- a/sponsors/api.py
+++ b/sponsors/api.py
@@ -33,7 +33,6 @@ class SponsorPublisherPermission(permissions.BasePermission):
 
 
 class LogoPlacementeAPIList(APIView):
-    authentication_classes = [TokenAuthentication]
     permission_classes = [SponsorPublisherPermission]
     serializer_class = LogoPlacementSerializer
 

--- a/sponsors/models/sponsors.py
+++ b/sponsors/models/sponsors.py
@@ -4,6 +4,7 @@ This module holds models related to the Sponsor entity.
 from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.db import models
+from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django_countries.fields import CountryField
 from ordered_model.models import OrderedModel
@@ -101,6 +102,10 @@ class Sponsor(ContentManageable):
             return SponsorContact.objects.get_primary_contact(self)
         except SponsorContact.DoesNotExist:
             return None
+
+    @property
+    def slug(self):
+        return slugify(self.name)
 
     @property
     def admin_url(self):

--- a/sponsors/tests/test_api.py
+++ b/sponsors/tests/test_api.py
@@ -115,6 +115,7 @@ class LogoPlacementeAPIListTests(APITestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(data))
         self.assertEqual(self.sp3.sponsor.name, data[0]["sponsor"])
+        self.assertEqual(self.sp3.sponsor.slug, data[0]["sponsor_slug"])
 
     def test_bad_request_for_invalid_filters(self):
         querystring = urlencode({


### PR DESCRIPTION
This PR adds filter options to `/api/v2/sponsors/logo-placement/`. Now clients can filter by `publisher` and `logo_place` via querystring. Both filters are optional, but if they are being used in a request with invalid values the request will be treated as a bad request.

The filters will be handful for pypi to filter by their logos and use the API data to place sponsors logo. The following request's, for example, will return only the sponsors which should be displayed at Pypi's sponsors page:

`localhost:8000/api/v2/sponsors/logo-placement/?publisher=pypi&logo_place=sponsors`