### PR TITLE
API endpoint to filter assets by internal name

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -47,3 +47,4 @@ num2words==0.5.10
 django-polymorphic==3.0.0
 sorl-thumbnail==12.7.0
 docxtpl==0.12.0
+reportlab==3.6.6

--- a/pydotorg/urls_api.py
+++ b/pydotorg/urls_api.py
@@ -7,7 +7,7 @@ from downloads.api import OSResource, ReleaseResource, ReleaseFileResource
 from downloads.api import OSViewSet, ReleaseViewSet, ReleaseFileViewSet
 from pages.api import PageResource
 from pages.api import PageViewSet
-from sponsors.api import LogoPlacementeAPIList
+from sponsors.api import LogoPlacementeAPIList, SponsorshipAssetsAPIList
 
 v1_api = Api(api_name='v1')
 v1_api.register(PageResource())
@@ -23,4 +23,5 @@ router.register(r'downloads/release_file', ReleaseFileViewSet)
 
 urlpatterns = [
     url(r'sponsors/logo-placement/', LogoPlacementeAPIList.as_view(), name="logo_placement_list"),
+    url(r'sponsors/sponsorship-assets/', SponsorshipAssetsAPIList.as_view(), name="assets_list"),
 ]

--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -828,8 +828,7 @@ class GenericAssetModelAdmin(PolymorphicParentModelAdmin):
         return GenericAsset.all_asset_types()
 
     def get_queryset(self, *args, **kwargs):
-        classes = self.get_child_models(*args, **kwargs)
-        return self.model.objects.select_related("content_type").instance_of(*classes)
+        return GenericAsset.objects.all_assets()
 
     def get_actions(self, request):
         actions = super().get_actions(request)

--- a/sponsors/api.py
+++ b/sponsors/api.py
@@ -2,53 +2,10 @@ from django.utils.text import slugify
 from django.urls import reverse
 
 from rest_framework import permissions
-from rest_framework import serializers
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from sponsors.models import BenefitFeature, LogoPlacement, Sponsorship
-from sponsors.models.enums import PublisherChoices, LogoPlacementChoices
-
-
-class LogoPlacementSerializer(serializers.Serializer):
-    publisher = serializers.CharField()
-    flight = serializers.CharField()
-    sponsor = serializers.CharField()
-    sponsor_slug = serializers.CharField()
-    description = serializers.CharField()
-    logo = serializers.URLField()
-    start_date = serializers.DateField()
-    end_date = serializers.DateField()
-    sponsor_url = serializers.URLField()
-    level_name = serializers.CharField()
-    level_order = serializers.IntegerField()
-
-
-class FilterLogoPlacementsSerializer(serializers.Serializer):
-    publisher = serializers.ChoiceField(
-        choices=[(c.value, c.name.replace("_", " ").title()) for c in PublisherChoices],
-        required=False,
-    )
-    flight = serializers.ChoiceField(
-        choices=[(c.value, c.name.replace("_", " ").title()) for c in LogoPlacementChoices],
-        required=False,
-    )
-
-    @property
-    def by_publisher(self):
-        return self.validated_data.get("publisher")
-
-    @property
-    def by_flight(self):
-        return self.validated_data.get("flight")
-
-    def skip_logo(self, logo):
-        if self.by_publisher and self.by_publisher != logo.publisher:
-            return True
-        if self.by_flight and self.by_flight != logo.logo_place:
-            return True
-        else:
-            return False
+from sponsors.serializers import LogoPlacementSerializer, FilterLogoPlacementsSerializer
 
 
 class SponsorPublisherPermission(permissions.BasePermission):

--- a/sponsors/api.py
+++ b/sponsors/api.py
@@ -68,7 +68,7 @@ class SponsorshipAssetsAPIList(APIView):
 
         assets = GenericAsset.objects.all_assets().filter(
             internal_name=assets_filter.by_internal_name).iterator()
-        assets = (a for a in assets if a.has_value or assets_filter.accept_empty)
+        assets = (a for a in assets if assets_filter.accept_empty or a.has_value)
         serializer = AssetSerializer(assets, many=True)
 
         return Response(serializer.data)

--- a/sponsors/api.py
+++ b/sponsors/api.py
@@ -25,8 +25,7 @@ class LogoPlacementeAPIList(APIView):
     def get(self, request, *args, **kwargs):
         placements = []
         logo_filters = FilterLogoPlacementsSerializer(data=request.GET)
-        if not logo_filters.is_valid():
-            return Response(logo_filters.errors, status=400)
+        logo_filters.is_valid(raise_exception=True)
 
         sponsorships = Sponsorship.objects.enabled().with_logo_placement()
         for sponsorship in sponsorships.select_related("sponsor").iterator():

--- a/sponsors/api.py
+++ b/sponsors/api.py
@@ -57,3 +57,10 @@ class LogoPlacementeAPIList(APIView):
 
         serializer = LogoPlacementSerializer(placements, many=True)
         return Response(serializer.data)
+
+
+class SponsorshipAssetsAPIList(APIView):
+    permission_classes = [SponsorPublisherPermission]
+
+    def get(self, request, *args, **kwargs):
+        return Response("ok")

--- a/sponsors/models/assets.py
+++ b/sponsors/models/assets.py
@@ -13,6 +13,8 @@ from django.db.models.fields.files import ImageFieldFile, FileField
 from polymorphic.managers import PolymorphicManager
 from polymorphic.models import PolymorphicModel
 
+from sponsors.models.managers import GenericAssetQuerySet
+
 
 def generic_asset_path(instance, filename):
     """
@@ -28,7 +30,7 @@ class GenericAsset(PolymorphicModel):
     """
     Base class used to add required assets to Sponsor or Sponsorship objects
     """
-    objects = PolymorphicManager()
+    objects = GenericAssetQuerySet.as_manager()
     non_polymorphic = models.Manager()
 
     # UUID can't be the object ID because Polymorphic expects default django integer ID

--- a/sponsors/models/managers.py
+++ b/sponsors/models/managers.py
@@ -118,3 +118,11 @@ class BenefitFeatureQuerySet(PolymorphicQuerySet):
         from sponsors.models.benefits import ProvidedAssetMixin
         provided_assets_classes = ProvidedAssetMixin.__subclasses__()
         return self.instance_of(*provided_assets_classes).select_related("sponsor_benefit__sponsorship")
+
+
+class GenericAssetQuerySet(PolymorphicQuerySet):
+
+    def all_assets(self):
+        from sponsors.models import GenericAsset
+        classes = GenericAsset.all_asset_types()
+        return self.select_related("content_type").instance_of(*classes)

--- a/sponsors/serializers.py
+++ b/sponsors/serializers.py
@@ -21,10 +21,11 @@ class LogoPlacementSerializer(serializers.Serializer):
 class AssetSerializer(serializers.ModelSerializer):
     content_type = serializers.SerializerMethodField()
     value = serializers.SerializerMethodField()
+    sponsor = serializers.SerializerMethodField()
 
     class Meta:
         model = GenericAsset
-        fields = ["internal_name", "uuid", "value", "content_type"]
+        fields = ["internal_name", "uuid", "value", "content_type", "sponsor"]
 
     def get_content_type(self, asset):
         return asset.content_type.name.title()
@@ -33,6 +34,12 @@ class AssetSerializer(serializers.ModelSerializer):
         if not asset.has_value:
             return ""
         return asset.value if not asset.is_file else asset.value.url
+
+    def get_sponsor(self, asset):
+        if asset.from_sponsorship:
+            return asset.content_object.sponsor.name
+        else:
+            return asset.content_object.name
 
 
 class FilterLogoPlacementsSerializer(serializers.Serializer):

--- a/sponsors/serializers.py
+++ b/sponsors/serializers.py
@@ -1,0 +1,43 @@
+
+from rest_framework import serializers
+from sponsors.models.enums import PublisherChoices, LogoPlacementChoices
+
+class LogoPlacementSerializer(serializers.Serializer):
+    publisher = serializers.CharField()
+    flight = serializers.CharField()
+    sponsor = serializers.CharField()
+    sponsor_slug = serializers.CharField()
+    description = serializers.CharField()
+    logo = serializers.URLField()
+    start_date = serializers.DateField()
+    end_date = serializers.DateField()
+    sponsor_url = serializers.URLField()
+    level_name = serializers.CharField()
+    level_order = serializers.IntegerField()
+
+
+class FilterLogoPlacementsSerializer(serializers.Serializer):
+    publisher = serializers.ChoiceField(
+        choices=[(c.value, c.name.replace("_", " ").title()) for c in PublisherChoices],
+        required=False,
+    )
+    flight = serializers.ChoiceField(
+        choices=[(c.value, c.name.replace("_", " ").title()) for c in LogoPlacementChoices],
+        required=False,
+    )
+
+    @property
+    def by_publisher(self):
+        return self.validated_data.get("publisher")
+
+    @property
+    def by_flight(self):
+        return self.validated_data.get("flight")
+
+    def skip_logo(self, logo):
+        if self.by_publisher and self.by_publisher != logo.publisher:
+            return True
+        if self.by_flight and self.by_flight != logo.logo_place:
+            return True
+        else:
+            return False

--- a/sponsors/serializers.py
+++ b/sponsors/serializers.py
@@ -20,6 +20,7 @@ class LogoPlacementSerializer(serializers.Serializer):
 
 class AssetSerializer(serializers.ModelSerializer):
     content_type = serializers.SerializerMethodField()
+    value = serializers.SerializerMethodField()
 
     class Meta:
         model = GenericAsset
@@ -27,6 +28,11 @@ class AssetSerializer(serializers.ModelSerializer):
 
     def get_content_type(self, asset):
         return asset.content_type.name.title()
+
+    def get_value(self, asset):
+        if not asset.has_value:
+            return ""
+        return asset.value if not asset.is_file else asset.value.url
 
 
 class FilterLogoPlacementsSerializer(serializers.Serializer):

--- a/sponsors/serializers.py
+++ b/sponsors/serializers.py
@@ -1,5 +1,7 @@
 
 from rest_framework import serializers
+
+from sponsors.models import GenericAsset
 from sponsors.models.enums import PublisherChoices, LogoPlacementChoices
 
 class LogoPlacementSerializer(serializers.Serializer):
@@ -14,6 +16,17 @@ class LogoPlacementSerializer(serializers.Serializer):
     sponsor_url = serializers.URLField()
     level_name = serializers.CharField()
     level_order = serializers.IntegerField()
+
+
+class AssetSerializer(serializers.ModelSerializer):
+    content_type = serializers.SerializerMethodField()
+
+    class Meta:
+        model = GenericAsset
+        fields = ["internal_name", "uuid", "value", "content_type"]
+
+    def get_content_type(self, asset):
+        return asset.content_type.name.title()
 
 
 class FilterLogoPlacementsSerializer(serializers.Serializer):
@@ -41,3 +54,16 @@ class FilterLogoPlacementsSerializer(serializers.Serializer):
             return True
         else:
             return False
+
+
+class FilterAssetsSerializer(serializers.Serializer):
+    internal_name = serializers.CharField(max_length=128)
+    list_empty = serializers.BooleanField(required=False, default=False)
+
+    @property
+    def by_internal_name(self):
+        return self.validated_data["internal_name"]
+
+    @property
+    def accept_empty(self):
+        return self.validated_data.get("list_empty", False)

--- a/sponsors/serializers.py
+++ b/sponsors/serializers.py
@@ -22,10 +22,17 @@ class AssetSerializer(serializers.ModelSerializer):
     content_type = serializers.SerializerMethodField()
     value = serializers.SerializerMethodField()
     sponsor = serializers.SerializerMethodField()
+    sponsor_slug = serializers.SerializerMethodField()
 
     class Meta:
         model = GenericAsset
-        fields = ["internal_name", "uuid", "value", "content_type", "sponsor"]
+        fields = ["internal_name", "uuid", "value", "content_type", "sponsor", "sponsor_slug"]
+
+    def _get_sponsor_object(self, asset):
+        if asset.from_sponsorship:
+            return asset.content_object.sponsor
+        else:
+            return asset.content_object
 
     def get_content_type(self, asset):
         return asset.content_type.name.title()
@@ -36,10 +43,10 @@ class AssetSerializer(serializers.ModelSerializer):
         return asset.value if not asset.is_file else asset.value.url
 
     def get_sponsor(self, asset):
-        if asset.from_sponsorship:
-            return asset.content_object.sponsor.name
-        else:
-            return asset.content_object.name
+        return self._get_sponsor_object(asset).name
+
+    def get_sponsor_slug(self, asset):
+        return self._get_sponsor_object(asset).slug
 
 
 class FilterLogoPlacementsSerializer(serializers.Serializer):

--- a/sponsors/tests/test_api.py
+++ b/sponsors/tests/test_api.py
@@ -153,7 +153,7 @@ class SponsorshipAssetsAPIListTests(APITestCase):
         self.img_asset = ImgAsset.objects.create(
             internal_name="img_assets",
             uuid=uuid.uuid4(),
-            content_object=self.sponsorship,
+            content_object=self.sponsor,
         )
 
     def tearDown(self):
@@ -210,6 +210,7 @@ class SponsorshipAssetsAPIListTests(APITestCase):
         self.assertEqual(data[0]["uuid"], str(self.txt_asset.uuid))
         self.assertEqual(data[0]["value"], "Text Content")
         self.assertEqual(data[0]["content_type"], "Sponsorship")
+        self.assertEqual(data[0]["sponsor"], "Sponsor 1")
 
     def test_enable_to_filter_by_assets_with_no_value_via_querystring(self):
         self.url += "&list_empty=true"
@@ -220,6 +221,7 @@ class SponsorshipAssetsAPIListTests(APITestCase):
         self.assertEqual(1, len(data))
         self.assertEqual(data[0]["uuid"], str(self.txt_asset.uuid))
         self.assertEqual(data[0]["value"], "")
+        self.assertEqual(data[0]["sponsor"], "Sponsor 1")
 
     def test_serialize_img_value_as_url_to_image(self):
         self.img_asset.value = SimpleUploadedFile(name='test_image.jpg', content=b"content", content_type='image/jpeg')
@@ -232,3 +234,4 @@ class SponsorshipAssetsAPIListTests(APITestCase):
         self.assertEqual(1, len(data))
         self.assertEqual(data[0]["uuid"], str(self.img_asset.uuid))
         self.assertEqual(data[0]["value"], self.img_asset.value.url)
+        self.assertEqual(data[0]["sponsor"], "Sponsor 2")

--- a/sponsors/tests/test_api.py
+++ b/sponsors/tests/test_api.py
@@ -211,6 +211,7 @@ class SponsorshipAssetsAPIListTests(APITestCase):
         self.assertEqual(data[0]["value"], "Text Content")
         self.assertEqual(data[0]["content_type"], "Sponsorship")
         self.assertEqual(data[0]["sponsor"], "Sponsor 1")
+        self.assertEqual(data[0]["sponsor_slug"], "sponsor-1")
 
     def test_enable_to_filter_by_assets_with_no_value_via_querystring(self):
         self.url += "&list_empty=true"
@@ -222,6 +223,7 @@ class SponsorshipAssetsAPIListTests(APITestCase):
         self.assertEqual(data[0]["uuid"], str(self.txt_asset.uuid))
         self.assertEqual(data[0]["value"], "")
         self.assertEqual(data[0]["sponsor"], "Sponsor 1")
+        self.assertEqual(data[0]["sponsor_slug"], "sponsor-1")
 
     def test_serialize_img_value_as_url_to_image(self):
         self.img_asset.value = SimpleUploadedFile(name='test_image.jpg', content=b"content", content_type='image/jpeg')
@@ -235,3 +237,4 @@ class SponsorshipAssetsAPIListTests(APITestCase):
         self.assertEqual(data[0]["uuid"], str(self.img_asset.uuid))
         self.assertEqual(data[0]["value"], self.img_asset.value.url)
         self.assertEqual(data[0]["sponsor"], "Sponsor 2")
+        self.assertEqual(data[0]["sponsor_slug"], "sponsor-2")


### PR DESCRIPTION
This PR introduces a new endpoint in the sponsors API to filter assets by their `internal_name`. The endpoint URL is `/api/v2/sponsors/sponsorship-assets/` and it always require a `internal_name` to be passed as a query string parameter. If `internal_name` is missing, the response is a bad request.

By default, the endpoint only lists assets which have a value (text or image) associated to it, but it's possible to list every asset by passing `list_empty=true` within the query string.

Here's a response payload example I got from my local database:

```json
[{
  "internal_name": "pycon_logo",
  "uuid": "55f69c46-8d94-4196-9157-76ed6219b120",
  "value": "/media/sponsors-app-assets/55f69c46-8d94-4196-9157-76ed6219b120.jpeg",
  "content_type": "Sponsor",
  "sponsor": "Globe"
}, {
  "internal_name": "pycon_logo",
  "uuid": "2f05d02c-e78a-4976-8b77-5a665612c776",
  "value": "/media/sponsors-app-assets/2f05d02c-e78a-4976-8b77-5a665612c776.jpeg",
  "content_type": "Sponsor",
  "sponsor": "BerinTech"
}]
```
