### PR TITLE
pep 676: don't add trailing slash on redirect

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -269,11 +269,11 @@ http {
                 }
 
                 location ~ ^/dev/peps/?(.*)$ {
-                  return 302 https://peps.python.org/$1/;
+                  return 302 https://peps.python.org/$1;
                 }
 
                 location ~ ^/peps/(.*)\.html$ {
-                  return 302 https://peps.python.org/$1/;
+                  return 302 https://peps.python.org/$1;
                 }
 
                 location ^/(dev/)?peps(/.*)?$ {


### PR DESCRIPTION
followup to #2006 