### PR TITLE
Fix for Can't find Python docker images #2010.

### DIFF
--- a/fixtures/boxes.json
+++ b/fixtures/boxes.json
@@ -332,7 +332,7 @@
 {
     "fields": {
         "label": "download-banner",
-        "content": "<p>Looking for Python with a different OS? Python for <a href=\"/downloads/windows/\">Windows</a>, <a href=\"/downloads/source/\">Linux/UNIX</a>, <a href=\"/downloads/macos/\">macOS</a>, <a href=\"/download/other/\">Other</a></p>\r\n<p style=\"margin-top: 0.35em\">Want to help test development versions of Python?  <a href=\"/download/pre-releases/\">Pre-releases</a></p>\r\n<p style=\"margin-top: 0.35em\">Looking for Python 2.7? See below for specific releases</p>",
+        "content": "<p>Looking for Python with a different OS? Python for <a href=\"/downloads/windows/\">Windows</a>, <a href=\"/downloads/source/\">Linux/UNIX</a>, <a href=\"/downloads/macos/\">macOS</a>, <a href=\"/download/other/\">Other</a></p>\r\n<p style=\"margin-top: 0.35em\">Want to help test development versions of Python?  <a href=\"https://www.python.org/download/pre-releases\">Prereleases,</a><a href=\"https://hub.docker.com/_/python\">Docker images</p>\r\n<p style=\"margin-top: 0.35em\">Looking for Python 2.7? See below for specific releases</p>",
         "content_markup_type": "html"
     }
 },

--- a/fixtures/boxes.json
+++ b/fixtures/boxes.json
@@ -332,7 +332,7 @@
 {
     "fields": {
         "label": "download-banner",
-        "content": "<p>Looking for Python with a different OS? Python for <a href=\"/downloads/windows/\">Windows</a>, <a href=\"/downloads/source/\">Linux/UNIX</a>, <a href=\"/downloads/macos/\">macOS</a>, <a href=\"/download/other/\">Other</a></p>\r\n<p style=\"margin-top: 0.35em\">Want to help test development versions of Python?  <a href=\"https://www.python.org/download/pre-releases\">Prereleases,</a><a href=\"https://hub.docker.com/_/python\">Docker images</p>\r\n<p style=\"margin-top: 0.35em\">Looking for Python 2.7? See below for specific releases</p>",
+        "content": "<p>Looking for Python with a different OS? Python for <a href=\"/downloads/windows/\">Windows</a>, <a href=\"/downloads/source/\">Linux/UNIX</a>, <a href=\"/downloads/macos/\">macOS</a>, <a href=\"/download/other/\">Other</a></p>\r\n<p style=\"margin-top: 0.35em\">Want to help test development versions of Python?  <a href=\"/download/pre-releases/\">Pre-releases,</a><a href=\"https://hub.docker.com/_/python\">Docker images</p>\r\n<p style=\"margin-top: 0.35em\">Looking for Python 2.7? See below for specific releases</p>",
         "content_markup_type": "html"
     }
 },


### PR DESCRIPTION
Fix for Can't find Python docker images https://github.com/python/pythondotorg/issues/2010.