### PR TITLE
add waffle flag to hide sponsorship menu and application

### DIFF
--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -3898,6 +3898,8 @@ span.highlighted {
   #select_sponsorship_benefits_container .submit-row .btn {
     width: 218px;
     height: 47px;
+    font-weight: bold;
+    color: black !important;
     background: #ffd343;
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
     border-radius: 20px;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -2817,6 +2817,8 @@ $breakpoint-desktop: 1200px;
       width: 218px;
       height: 47px;
 
+      font-weight: bold;
+      color: black !important;
       background: $yellow;
       box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
       border-radius: 20px;

--- a/templates/sponsors/sponsorship_benefits_form.html
+++ b/templates/sponsors/sponsorship_benefits_form.html
@@ -1,5 +1,5 @@
 {% extends "psf/full-width.html" %}
-{% load pipeline boxes humanize static sponsors %}
+{% load pipeline boxes humanize static sponsors waffle_tags %}
 
 
 {% block head %}
@@ -9,6 +9,7 @@
 {% block page_title %}Sponsorship Application | {{ SITE_INFO.site_name }}{% endblock %}
 
 {% block content %}
+  {% flag "sponsorship-applications-open" %}
   <article class="text">
     {% box 'sponsorship-application' %}
   </article>
@@ -207,7 +208,7 @@
           <li><p>Submit your contact information</p></li>
         </ol>
         <div>
-          <input class="btn" type="submit" value="Submit">
+          <input class="btn btn-sponsorship-submit" type="submit" value="Submit">
         </div>
         <span></span>
       </div>
@@ -246,14 +247,26 @@
     {% endfor %}
     </div>
   </form>
+  {% else %}
+  <article class="text">
+    {% box 'sponsorship-application-closed' %}
+  </article>
+  {% endflag %}
 
 {% endblock content %}
 
 {% block footer %}
+  {% flag "sponsorship-applications-open" %}
   <div id="thank-you-container">
     <span>If you would like us to walk you through the new program, email sponsors@python.org.</span>
     <h1>Thank you for making a difference in the Python ecosystem!</h1>
   </div>
+  {% else %}
+  <div id="thank-you-container">
+    <span>If you need to submit sooner, or have any questions, email sponsors@python.org.</span>
+    <h1>Thank you for your interest in making a difference in the Python ecosystem!</h1>
+  </div>
+  {% endflag %}
   {{ block.super }}
 {% endblock %}
 


### PR DESCRIPTION
During periods where we are modifying the benefits for a given year, we don't want to display interim states.

This flag will allow us to hide the menu and application form during those periods, while still allowing staff to view/preview that page.

Also addresses the white text in the submit button noted by @loren-c 