### PR TITLE
Change sponsorship admin list view to exclude rejected ones by default

### DIFF
--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -263,6 +263,27 @@ class TargetableEmailBenefitsFilter(admin.SimpleListFilter):
         return queryset.filter(id__in=Subquery(qs))
 
 
+class SponsorshipStatusListFilter(admin.SimpleListFilter):
+    title = "status"
+    parameter_name = "status"
+
+    def lookups(self, request, model_admin):
+        return Sponsorship.STATUS_CHOICES
+
+    def queryset(self, request, queryset):
+        status = self.value()
+        # exclude rejected ones by default
+        if not status:
+            return queryset.exclude(status=Sponsorship.REJECTED)
+        return queryset.filter(status=status)
+
+    def choices(self, changelist):
+        choices = list(super().choices(changelist))
+        # replaces django default "All" text by a custom text
+        choices[0]['display'] = "Applied / Approved / Finalized"
+        return choices
+
+
 @admin.register(Sponsorship)
 class SponsorshipAdmin(admin.ModelAdmin):
     change_form_template = "sponsors/admin/sponsorship_change_form.html"
@@ -278,7 +299,7 @@ class SponsorshipAdmin(admin.ModelAdmin):
         "start_date",
         "end_date",
     ]
-    list_filter = ["status", "package", TargetableEmailBenefitsFilter]
+    list_filter = [SponsorshipStatusListFilter, "package", TargetableEmailBenefitsFilter]
     actions = ["send_notifications"]
     fieldsets = [
         (

--- a/sponsors/tests/test_admin.py
+++ b/sponsors/tests/test_admin.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock
+
+from django.contrib.admin.views.main import ChangeList
+from model_bakery import baker
+
+from django.test import TestCase, RequestFactory
+
+from sponsors.admin import SponsorshipStatusListFilter, SponsorshipAdmin
+from sponsors.models import Sponsorship
+
+class TestCustomSponsorshipStatusListFilter(TestCase):
+
+    def setUp(self):
+        self.request = RequestFactory().get("/")
+        self.model_admin = SponsorshipAdmin
+        self.filter = SponsorshipStatusListFilter(
+            request=self.request,
+            params={},
+            model=Sponsorship,
+            model_admin=self.model_admin
+        )
+
+    def test_basic_configuration(self):
+        self.assertEqual("status", self.filter.title)
+        self.assertEqual("status", self.filter.parameter_name)
+        self.assertIn(SponsorshipStatusListFilter, SponsorshipAdmin.list_filter)
+
+    def test_lookups(self):
+        expected = [
+            ("applied", "Applied"),
+            ("rejected", "Rejected"),
+            ("approved", "Approved"),
+            ("finalized", "Finalized"),
+        ]
+        self.assertEqual(expected, self.filter.lookups(self.request, self.model_admin))
+
+    def test_filter_queryset(self):
+        sponsor = baker.make("sponsors.Sponsor")
+        sponsorships = [
+            baker.make(Sponsorship, status=Sponsorship.REJECTED, sponsor=sponsor),
+            baker.make(Sponsorship, status=Sponsorship.APPLIED, sponsor=sponsor),
+            baker.make(Sponsorship, status=Sponsorship.APPROVED, sponsor=sponsor),
+            baker.make(Sponsorship, status=Sponsorship.FINALIZED, sponsor=sponsor),
+        ]
+
+        # filter by applied, approved and finalized status by default
+        qs = self.filter.queryset(self.request, Sponsorship.objects.all())
+        self.assertEqual(3, qs.count())
+        self.assertNotIn(sponsorships[0], qs)
+
+        for sp in sponsorships:
+            self.filter.used_parameters[self.filter.parameter_name] = sp.status
+            qs = self.filter.queryset(self.request, Sponsorship.objects.all())
+            self.assertEqual(1, qs.count())
+            self.assertIn(sp, qs)
+
+    def test_choices_with_custom_text_for_all(self):
+        lookups = self.filter.lookups(self.request, self.model_admin)
+        changelist = Mock(ChangeList, autospec=True)
+        choices = self.filter.choices(changelist)
+
+        self.assertEqual(len(choices), len(lookups) + 1)
+        self.assertEqual(choices[0]["display"], "Applied / Approved / Finalized")
+        for i, choice in enumerate(choices[1:]):
+            self.assertEqual(choice["display"], lookups[i][1])


### PR DESCRIPTION
This PR updates the `list_filter` attribute from `SponsorsihpAdmin` to have a custom status filter instead of the default one based in the column choices. The reason for that is to hide, by default, rejected applications and, thus, to make the sponsorship applications list cleaner. Here's a print screen with the new filter:

![Screenshot from 2022-07-25 20-05-27](https://user-images.githubusercontent.com/238223/180846010-7315cac5-c917-4d6e-82b2-c4d80aa0a820.png)

**Disclaimer**: the other 2 filters (by package and by targetable email benefit) aren't displayed here because both of them depends on db objects. Since I don't have a valid dump with these tables populated, the filters don't appear.
