### PR TITLE
Remove our custom tastypie django admin bits

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -61,16 +61,3 @@ class MembershipAdmin(admin.ModelAdmin):
     search_fields = ['creator__username']
     list_filter = ['membership_type']
     raw_id_fields = ['creator']
-
-
-class ApiKeyAdmin(admin.ModelAdmin):
-    list_display = ('user', 'created', )
-    date_hierarchy = 'created'
-
-
-try:
-    admin.site.unregister(ApiKey)
-except admin.sites.NotRegistered:
-    pass
-finally:
-    admin.site.register(ApiKey, ApiKeyAdmin)


### PR DESCRIPTION
Tastypie has been in use by python.org for a long time. I'm guessing when it was initially added the Django admin interface for it was either insufficient or nonexistent.

Since then, we've kept fairly up to date with their releases and now that there are robust admin interfaces available, use those.

Closes #2159