### PR TITLE
Update link to devguide

### DIFF
--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -42,7 +42,7 @@
                     {% render_active_banner %}
 
                     <h2 class="widget-title">Active Python Releases</h2>
-                    <p class="success-quote"><a href="https://devguide.python.org/#status-of-python-branches">For more information visit the Python Developer's Guide</a>.</p>
+                    <p class="success-quote"><a href="https://devguide.python.org/versions/#versions">For more information visit the Python Developer's Guide</a>.</p>
 
                     {% box 'downloads-active-releases' %}
                 </div>


### PR DESCRIPTION
The devguide has been reorganised (https://github.com/python/devguide/pull/901), and whilst the old https://devguide.python.org/#status-of-python-branches link still exists, it's just a placeholder to the new https://devguide.python.org/versions/#versions link.

So let's update it.

---

Relatedly, what's needed to add Python 3.11 to the table at https://www.python.org/downloads/?

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/1324225/197763927-0557f807-a239-421f-a993-a7bb02403444.png">
