### PR TITLE
Bump beautifulsoup4 from 4.6.0 to 4.9.3

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -12,7 +12,7 @@ python3-openid==3.1.0
 lxml==4.1.1
 cssselect==0.9.1
 feedparser==5.2.1
-beautifulsoup4==4.6.0
+beautifulsoup4==4.9.3
 icalendar==3.8.4
 chardet2==2.0.3
 # TODO: We may drop 'django-imagekit' completely.


### PR DESCRIPTION
###

Bumps [beautifulsoup4](http://www.crummy.com/software/BeautifulSoup/bs4/) from 4.6.0 to 4.9.3.

signed-off-by: dependabot-preview[bot] <support@dependabot.com>

####