### PR TITLE
Use a custom version of the Github MD formatter

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -30,12 +30,6 @@ from .managers import PageQuerySet
 
 DEFAULT_MARKUP_TYPE = getattr(settings, 'DEFAULT_MARKUP_TYPE', 'restructuredtext')
 
-# Set options for cmarkgfm for "unsafe" renderer, see https://github.com/theacodes/cmarkgfm#advanced-usage
-CMARKGFM_UNSAFE_OPTIONS = (
-    cmarkgfmOptions.CMARK_OPT_UNSAFE |
-    cmarkgfmOptions.CMARK_OPT_GITHUB_PRE_LANG
-)
-
 PAGE_PATH_RE = re.compile(r"""
     ^
     /?                      # We can optionally start with a /
@@ -66,11 +60,12 @@ RENDERERS[markdown_index] = (
     'Markdown'
 )
 
-# Add out own Github style Markdown parser, which doesn't apply the default
+# Add our own Github style Markdown parser, which doesn't apply the default
 # tagfilter used by Github (we can be more liberal, since we know our page
 # editors).
 
 def unsafe_markdown_to_html(text, options=0):
+
     """Render the given GitHub-flavored Makrdown to HTML.
 
     This function is similar to cmarkgfm.github_flavored_markdown_to_html(),
@@ -78,17 +73,22 @@ def unsafe_markdown_to_html(text, options=0):
     using jQuery UI script extensions on pages.
 
     """
+    # Set options for cmarkgfm for "unsafe" renderer, see
+    # https://github.com/theacodes/cmarkgfm#advanced-usage
+    options = options | (
+        cmarkgfmOptions.CMARK_OPT_UNSAFE |
+        cmarkgfmOptions.CMARK_OPT_GITHUB_PRE_LANG
+    )
     return cmarkgfm.markdown_to_html_with_extensions(
-        text, options=options | CMARKGFM_UNSAFE_OPTIONS,
+        text, options=options,
         extensions=[
-            'table', 'autolink', # 'tagfilter',
-            'strikethrough', 'tasklist'
+            'table', 'autolink', 'strikethrough', 'tasklist'
         ])
 
 RENDERERS.append(
     (
         "markdown_unsafe",
-        lambda markdown_text: unsafe_markdown_to_html(markdown_text),
+        unsafe_markdown_to_html,
         "Markdown (unsafe)",
     )
 )


### PR DESCRIPTION
This doesn't filter away the script (and some other) HTML tags.

Fixes #2181.