### PR TITLE
Fixed Issue#2190 | Homepage code syntax error

### DIFF
--- a/codesamples/factories.py
+++ b/codesamples/factories.py
@@ -31,7 +31,7 @@ def initial_data():
             <span class=\"output\">Hello, I'm Python!</span>
 
             <span class=\"comment\"># Input, assignment</span>
-            >>> name = input('What is your name?\\n')
+            >>> name = input('What is your name?\n')
             <span class=\"output\">What is your name?
             Python</span>
             >>> print(f'Hi, {name}.')

--- a/codesamples/factories.py
+++ b/codesamples/factories.py
@@ -27,7 +27,7 @@ def initial_data():
         (
             """\
             <pre><code><span class=\"comment\"># Simple output (with Unicode)</span>
-            >>> print(\"Hello, I'm Python!\")
+            >>> print("Hello, I'm Python!")
             <span class=\"output\">Hello, I'm Python!</span>
 
             <span class=\"comment\"># Input, assignment</span>


### PR DESCRIPTION
Fixed issue #2190. Website home page, in the code example 5(Quick & Easy to Learn) has SyntaxError in first line at https://www.python.org/



