### PR TITLE
update Basic Membership forms

### DIFF
--- a/templates/users/membership_form.html
+++ b/templates/users/membership_form.html
@@ -2,7 +2,7 @@
 {% load boxes %}
 {% load honeypot %}
 
-{% block page_title %}Edit Membership | Our Users &amp; Members | {{ SITE_INFO.site_name }}{% endblock %}
+{% block page_title %}Edit Basic Membership | Our Users &amp; Members | {{ SITE_INFO.site_name }}{% endblock %}
 
 {% block body_attributes %}class="psf signup default-page"{% endblock %}
 
@@ -13,10 +13,14 @@
 
 <article class="text">
     {% if request.user.has_membership %}
-    <h1 class="default-title">Edit your PSF Membership</h1>
+    <h1 class="default-title">Edit your PSF Basic Membership</h1>
     {% else %}
-    <h1 class="default-title">Register to become a PSF Member</h1>
+    <h1 class="default-title">Register to become a PSF Basic Member</h1>
     {% endif %}
+
+    <div class="info">
+      <p>For more information and to sign up for other kinds of PSF membership, visit <a href="https://www.python.org/psf/membership/">Our Membership Page</a>.</p>
+    </div>
 
     {% if form.errors %}
     <div class="user-feedback level-error">
@@ -104,12 +108,7 @@
           class="deletion-form"
           onsubmit="return confirm('Are you sure?');">
         {% csrf_token %}
-        <p>
-            <label for="id_delete_membership">
-                You can delete your PSF membership if you don't want to get emails from the PSF.
-            </label>
-            <button type="submit" id="id_delete_membership">Delete your PSF membership</button>
-        </p>
+        <button type="submit" id="id_delete_membership">Delete your PSF membership</button>
     </form>
     {% endif %}
 

--- a/templates/users/membership_form.html
+++ b/templates/users/membership_form.html
@@ -19,7 +19,7 @@
     {% endif %}
 
     <div class="info">
-      <p>For more information and to sign up for other kinds of PSF membership, visit <a href="https://www.python.org/psf/membership/">Our Membership Page</a>.</p>
+      <p>For more information and to sign up for other kinds of PSF membership, visit our <a href="https://www.python.org/psf/membership/">Membership Page</a>.</p>
     </div>
 
     {% if form.errors %}

--- a/templates/users/membership_form.html
+++ b/templates/users/membership_form.html
@@ -108,7 +108,7 @@
           class="deletion-form"
           onsubmit="return confirm('Are you sure?');">
         {% csrf_token %}
-        <button type="submit" id="id_delete_membership">Delete your PSF membership</button>
+        <button type="submit" id="id_delete_membership">Delete your PSF Basic Membership</button>
     </form>
     {% endif %}
 

--- a/users/forms.py
+++ b/users/forms.py
@@ -68,10 +68,6 @@ class MembershipForm(ModelForm):
         code_of_conduct = self.fields['psf_code_of_conduct']
         code_of_conduct.widget = forms.Select(choices=self.COC_CHOICES)
 
-        announcements = self.fields['psf_announcements']
-        announcements.widget = forms.CheckboxInput()
-        announcements.initial = False
-
     class Meta:
         model = Membership
         fields = [
@@ -83,7 +79,6 @@ class MembershipForm(ModelForm):
             'country',
             'postal_code',
             'psf_code_of_conduct',
-            'psf_announcements',
         ]
 
     def clean_psf_code_of_conduct(self):
@@ -105,4 +100,3 @@ class MembershipUpdateForm(MembershipForm):
         super().__init__(*args, **kwargs)
 
         del(self.fields['psf_code_of_conduct'])
-        del(self.fields['psf_announcements'])


### PR DESCRIPTION
- Removes email related fields/notes since we do not use this membership for any mailing lists.
- Adds note/link regarding other membership types

Signup Form (before):
<img width="1018" alt="basic-reg-before" src="https://user-images.githubusercontent.com/1200832/206537019-61f11692-e347-4909-be30-a658272ef75a.png">

Signup Form (after):
<img width="1018" alt="basic-reg-after" src="https://user-images.githubusercontent.com/1200832/206537086-0c65077e-a523-4f96-babc-ba33f389a703.png">

Edit Form (before):
<img width="1018" alt="basic-edit-before" src="https://user-images.githubusercontent.com/1200832/206537174-1cd023f8-8808-479c-90d2-4a6148c2e18c.png">

Edit Form (after):
<img width="1018" alt="basic-edit-after" src="https://user-images.githubusercontent.com/1200832/206537220-89eb543f-6ab8-421b-8616-96836485e98d.png">
