### PR TITLE
fix(#1988) - This image not being found as `/static/metro-icon-144x144-precomposed.png`

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -54,7 +54,7 @@
     <link rel="apple-touch-icon" href="{{ STATIC_URL }}apple-touch-icon-precomposed.png">
 
     {# Tile icon for Win8 (144x144 + tile color) #}
-    <meta name="msapplication-TileImage" content="{{ STATIC_URL }}metro-icon-144x144-precomposed.png"><!-- white shape -->
+    <meta name="msapplication-TileImage" content="{{ STATIC_URL }}metro-icon-144x144.png"><!-- white shape -->
     <meta name="msapplication-TileColor" content="#3673a5"><!-- python blue -->
     <meta name="msapplication-navbutton-color" content="#3673a5">
 


### PR DESCRIPTION
**Description:**
This PR fixes the issue find on [#1988]
It changes the file name from `metro-icon-144x144-precomposed.png` to `metro-icon-144x144.png`.

Closes #1988


