### PR TITLE
Add a check in CI for missing migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
         run: |
           pip install -U pip setuptools wheel
           pip install -r dev-requirements.txt
+      - name: Check for ungenerated database migrations
+        run: |
+          python manage.py makemigrations --check --dry-run
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/pythonorg
       - name: Run Tests
         run: |
           python -Wd -m coverage run manage.py test -v2


### PR DESCRIPTION
This will cause CI to fail if there are any missing migrations.

Needs https://github.com/python/pythondotorg/pull/2246 first.