### PR TITLE
enable customizing admin theme

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -1,11 +1,14 @@
 dj-database-url==0.5.0
 django-pipeline==2.0.6
 django-sitetree==1.17.0
+django-apptemplates==1.5
+django-admin-interface==0.24.2
+django-translation-aliases==0.1.0
 Django==2.2.24
 docutils==0.12
 Markdown==3.3.4
 cmarkgfm==0.6.0
-Pillow==8.3.1
+Pillow==9.4.0
 psycopg2-binary==2.8.6
 python3-openid==3.2.0
 python-decouple==3.4

--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -94,8 +94,12 @@ TEMPLATES = [
         'DIRS': [
             TEMPLATES_DIR,
         ],
-        'APP_DIRS': True,
         'OPTIONS': {
+            'loaders': [
+                'apptemplates.Loader',
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader',
+            ],
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
@@ -151,10 +155,14 @@ INSTALLED_APPS = [
     'django.contrib.redirects',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.admin',
-    'django.contrib.admindocs',
     'django.contrib.humanize',
 
+    'admin_interface',
+    'colorfield',
+    'django.contrib.admin',
+    'django.contrib.admindocs',
+
+    'django_translation_aliases',
     'pipeline',
     'sitetree',
     'imagekit',
@@ -288,7 +296,8 @@ MESSAGE_TAGS = {
 
 ### SecurityMiddleware
 
-X_FRAME_OPTIONS = 'DENY'
+X_FRAME_OPTIONS = 'SAMEORIGIN'
+SILENCED_SYSTEM_CHECKS = ["security.W019"]
 
 ### django-rest-framework
 

--- a/pydotorg/settings/heroku.py
+++ b/pydotorg/settings/heroku.py
@@ -20,18 +20,6 @@ CACHES = {
     }
 }
 
-HAYSTACK_SEARCHBOX_SSL_URL = config(
-    'SEARCHBOX_SSL_URL'
-)
-
-HAYSTACK_CONNECTIONS = {
-    'default': {
-        'ENGINE': 'haystack.backends.elasticsearch5_backend.Elasticsearch5SearchEngine',
-        'URL': HAYSTACK_SEARCHBOX_SSL_URL,
-        'INDEX_NAME': 'haystack-prod',
-    },
-}
-
 SECRET_KEY = config('SECRET_KEY')
 
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=Csv())

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin_interface:admin/base_site.html" %}
 {% load i18n %}
 
 {% block title %}{{ title }} | {% trans 'python.org' %}{% endblock %}


### PR DESCRIPTION
psf staff spend a lot of time between us.pycon.org and python.org django admin this enables configuration of a different theme for python.org so its easier to differentiate. thanks to @swiencks for pointing out how easy to confuse they are.