### PR TITLE
fix: typo fix for PEP8 convention

### DIFF
--- a/codesamples/factories.py
+++ b/codesamples/factories.py
@@ -125,7 +125,7 @@ def initial_data():
             >>>     a, b = 0, 1
             >>>     while a &lt; n:
             >>>         print(a, end=' ')
-            >>>         a, b = b, a+b
+            >>>         a, b = b, a + b
             >>>     print()
             >>> fib(1000)
             <span class=\"output\">0 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610</span>


### PR DESCRIPTION
https://peps.python.org/pep-0008/#other-recommendations