### PR TITLE
Show membership type on user profile page

### DIFF
--- a/templates/users/user_detail.html
+++ b/templates/users/user_detail.html
@@ -21,7 +21,7 @@
                 <p><span class="profile-label">Name:</span> {% firstof object.get_full_name object %}</p>
             </div>
             <div class="user-profile-membership">
-                <p><span class="profile-label"><span class="icon-python" aria-hidden="true"></span> PSF Member?</span> {{ object.has_membership|yesno|capfirst }}</p>
+                <p><span class="profile-label"><span class="icon-python" aria-hidden="true"></span> PSF Member?</span> {{ object.membership_type|default:"No" }}</p>
             </div>
             {% comment %}
             <div class="user-profile-location">

--- a/users/models.py
+++ b/users/models.py
@@ -58,6 +58,13 @@ class User(AbstractUser):
             return False
 
     @property
+    def membership_type(self):
+        try:
+            return self.membership.get_membership_type_display()
+        except Membership.DoesNotExist:
+            return None
+
+    @property
     def sponsorships(self):
         from sponsors.models import Sponsorship
         return Sponsorship.objects.visible_to(self)


### PR DESCRIPTION
Instead of only showing whether the user is a PSF Member, show what type of member they are on their user profile page.

This (at least partially) resolves https://github.com/python/pythondotorg/issues/398 

I would appreciate this feature because I've self-certified as a contributing member, but I don't know if that self-certification actually applied. 