### PR TITLE
add notes regarding basic membership

### DIFF
--- a/templates/includes/authenticated.html
+++ b/templates/includes/authenticated.html
@@ -7,9 +7,9 @@
                 <li class="tier-2 element-1" role="treeitem"><a href="{% url 'users:user_profile_edit' %}">Edit your user profile</a></li>
                 <li class="tier-2 element-2" role="treeitem"><a href="{% url 'account_change_password' %}">Change your password</a></li>
                 {% if request.user.has_membership %}
-                <li class="tier-2 element-3" role="treeitem"><a href="{% url 'users:user_membership_edit' %}">Edit your PSF membership</a></li>
+                <li class="tier-2 element-3" role="treeitem"><a href="{% url 'users:user_membership_edit' %}">Edit your PSF Basic membership</a></li>
                 {% else %}
-                <li class="tier-2 element-3" role="treeitem"><a href="{% url 'users:user_membership_create' %}">Become a PSF member</a></li>
+                <li class="tier-2 element-3" role="treeitem"><a href="{% url 'users:user_membership_create' %}">Become a PSF Basic member</a></li>
                 {% endif %}
                 {% if request.user.sponsorships %}
                 <li class="tier-2 element-6" role="treeitem"><a href="{% url 'users:user_sponsorships_dashboard' %}">Sponsorships</a>

--- a/templates/users/membership_form.html
+++ b/templates/users/membership_form.html
@@ -19,6 +19,18 @@
     {% endif %}
 
     <div class="info">
+      <p>
+        Basic membership is <b>not a voting membership class</b>.<br>For more information see Article IV
+        of the <a href="https://www.python.org/psf/bylaws/">PSF Bylaws</a>.
+      </p>
+      <p>
+        All other membership classes are recorded on <a href="https://psfmember.org">psfmember.org</a>.<br>
+        Please log in there and review your <a href="https://psfmember.org/user-information/">user profile</a>
+        to see your membership status.<br>
+        If you believe you are a member but do not have an account on psfmember.org, please
+        <a href="https://psfmember.org/wp-login.php?action=register">create an account</a> and verify your
+        email, then email <a href="mailto:psf-donations@python.org">psf-donations@python.org</a> to get your account linked to your membership.
+      </p>
       <p>For more information and to sign up for other kinds of PSF membership, visit our <a href="https://www.python.org/psf/membership/">Membership Page</a>.</p>
     </div>
 

--- a/templates/users/user_detail.html
+++ b/templates/users/user_detail.html
@@ -21,7 +21,23 @@
                 <p><span class="profile-label">Name:</span> {% firstof object.get_full_name object %}</p>
             </div>
             <div class="user-profile-membership">
-                <p><span class="profile-label"><span class="icon-python" aria-hidden="true"></span> PSF Member?</span> {{ object.has_membership|yesno|capfirst }}</p>
+                <p><span class="profile-label"><span class="icon-python" aria-hidden="true"></span>PSF Basic Member?</span> {{ object.has_membership|yesno|capfirst }}</p>
+                {% if object.has_membership %}
+                <div style="margin-left: 1em;">
+                  <p>
+                    Basic membership is <b>not a voting membership class</b>.<br>For more information see Article IV
+                    of the <a href="https://www.python.org/psf/bylaws/">PSF Bylaws</a>.
+                  </p>
+                  <p>
+                    All other membership classes are recorded on <a href="https://psfmember.org">psfmember.org</a>.<br>
+                    Please log in there and review your <a href="https://psfmember.org/user-information/">user profile</a>
+                    to see your membership status.<br>
+                    If you believe you are a member but do not have an account on psfmember.org, please
+                    <a href="https://psfmember.org/wp-login.php?action=register">create an account</a> and verify your
+                    email, then email <a href="mailto:psf-donations@python.org">psf-donations@python.org</a> to get your account linked to your membership.
+                  </p>
+                </div>
+              {% endif %}
             </div>
             {% comment %}
             <div class="user-profile-location">


### PR DESCRIPTION
Updates the form:

<img width="638" alt="form" src="https://github.com/python/pythondotorg/assets/1200832/9109679e-f85d-44f4-9d3d-bb203a5b7464">


And user detail page:

<img width="648" alt="dash" src="https://github.com/python/pythondotorg/assets/1200832/adbe39d8-5f50-4a8f-b37c-421c5732ec8f">


With notes regarding Basic membership and how to verify other membership types.