### PR TITLE
Use "static" templatetag insteadof the deprecated "admin_static"

### DIFF
--- a/templates/sponsors/admin/update_related_sponsorships.html
+++ b/templates/sponsors/admin/update_related_sponsorships.html
@@ -1,5 +1,5 @@
 {% extends 'admin/base_site.html' %}
-{% load i18n admin_static %}
+{% load i18n static %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
 


### PR DESCRIPTION
We should use the `static` template tag in instead of the `admin_static` and `staticfiles` template tags which were marked as deprecated in Django 2.1 and removed from Django in 3.0

https://docs.djangoproject.com/en/4.2/releases/2.1/#features-deprecated-in-2-1
https://docs.djangoproject.com/en/4.2/internals/deprecation/#deprecation-removed-in-3-0

--
### Pull-request sponsored by

[![image](https://s3-us-west-2.amazonaws.com/labcodes.com.br/lab/labcodes-328x120.png)](https://labcodes.com.br/)
[Need a team for your project? Let's talk](https://labcodes.com.br/)

