### PR TITLE
Update job_detail.html

### DIFF
--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -8,7 +8,7 @@
 {% block content_attributes %}with-right-sidebar{% endblock %}
 
 {% block og_title %}Job: {{ object.job_title }} at {{ object.company_name }}{% endblock %}
-{% block og-descript %}{{ object.description|truncatechars:200 }}{% endblock %}
+{% block og-descript %}{{ object.description|escape|truncatechars:200 }}{% endblock %}
 
 {% block content %}
 {% load companies %}


### PR DESCRIPTION
Explicity escape the job description for the meta og:description where the description contains html which can throw off the rendering of the page...

See https://www.python.org/jobs/7314/ for example.