### PR TITLE
Redirect legacy community page

### DIFF
--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
         name='account_change_password'),
     path('accounts/', include('allauth.urls')),
     path('box/', include('boxes.urls')),
+    path('community-landing/', RedirectView.as_view(url='/community/', permanent=True)),
     path('community/', include('community.urls', namespace='community')),
     path('community/microbit/', TemplateView.as_view(template_name="community/microbit.html"), name='microbit'),
     path('events/', include('events.urls', namespace='events')),

--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -54,7 +54,7 @@ urlpatterns = [
         name='account_change_password'),
     path('accounts/', include('allauth.urls')),
     path('box/', include('boxes.urls')),
-    path('community-landing/', RedirectView.as_view(url='/community/', permanent=True)),
+    re_path(r'^community-landing(/.*)?$', RedirectView.as_view(url='/community/', permanent=True)),
     path('community/', include('community.urls', namespace='community')),
     path('community/microbit/', TemplateView.as_view(template_name="community/microbit.html"), name='microbit'),
     path('events/', include('events.urls', namespace='events')),


### PR DESCRIPTION
Permanently redirect legacy community page, /community-landing/, to /community/.

Resolves #2294