### PR TITLE
Add a Mastodon verification link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -106,6 +106,8 @@
     <link rel="search" type="application/opensearchdescription+xml" title="Search for Packages inside the Cheeseshop (PyPI)" href="/search-pycheese.xml">
     <link rel="search" type="application/opensearchdescription+xml" title="Search Archives of the Main Python Mailing List" href="/search-pythonlist.xml">
 
+    <link rel="me" href="https://fosstodon.org/@ThePSF">
+
      * Need to support Twitter cards? Info about that here:
      * https://github.com/h5bp/html5-boilerplate/blob/master/doc/extend.md#twitter-cards
      *


### PR DESCRIPTION
The Python Software Foundation has an official Mastodon account, https://fosstodon.org/@ThePSF. The account is not verified. To improve trust with Mastodon users (and the broader fediverse) that the account really is the official account, the python.org website should include a verification link[1]. This PR adds a link rel=“me” tag to the base.html template.

[1] https://joinmastodon.org/verification