### PR TITLE
Add config file for Read the Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # $ git config --global core.excludesfile ~/.gitignore_global
 
 .sass-cache/
+docs/build
 media/*
 static-root/
 static/stylesheets/mq.css

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,6 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 # Project page: https://readthedocs.org/projects/pythondotorg/
 
-# Required
 version: 2
 
 build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Project page: https://readthedocs.org/projects/pythondotorg/
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+  commands:
+      - python -m pip install -r docs-requirements.txt
+      - make -C docs html JOBS=$(nproc) BUILDDIR=_readthedocs
+      - mv docs/_readthedocs _readthedocs


### PR DESCRIPTION
The Read the Docs builds have started to fail:

> Error
> Problem in your project's configuration. No default configuration file found at repository's root.

https://readthedocs.org/projects/pythondotorg/builds/
https://readthedocs.org/projects/pythondotorg/builds/22548846/

That's because Read the Docs now requires projects to have `.readthedocs.yaml`

https://blog.readthedocs.com/migrate-configuration-v2/

---

Earlier builds included the `readthedocssinglehtmllocalmedia` builder, which created a downloadable zip of the HTML files:

https://readthedocs.org/projects/pythondotorg/builds/21499586/

<img width="246" alt="image" src="https://github.com/python/pythondotorg/assets/1324225/1c7e0335-756e-494d-b42d-66d919c7b827">

I didn't add this back. Do we need it?
