### PR TITLE
Remove broken Twitter widget

### DIFF
--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -2771,10 +2771,6 @@ p.quote-by-organization {
 /*<aside class="main-sidebar | right-sidebar | left-sidebar">*/
 .left-sidebar .sidebar-widget {
   margin-bottom: 0.875em; }
-.left-sidebar .twitter-widget {
-  padding: 0; }
-.left-sidebar .twtr-doc {
-  padding: .75em; }
 
 .jobs-form p {
   padding: 0 0.3125em; }

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1913,9 +1913,6 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
         margin-bottom: rhythm( .5 );
     }
 
-    .twitter-widget { padding: 0; }
-
-    .twtr-doc { padding: .75em; }
 }
 
 .right-sidebar {

--- a/templates/components/tweets-from-psf.html
+++ b/templates/components/tweets-from-psf.html
@@ -1,4 +1,0 @@
-    <div class="twitter-widget sidebar-widget">
-        <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/ThePSF" data-widget-id="434113224703610882">Tweets by @ThePSF</a>
-        <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-    </div>

--- a/templates/pages/default.html
+++ b/templates/pages/default.html
@@ -54,8 +54,6 @@ TODO: should this partially come from sitetree?
 
     {% include "components/navigation-widget.html" %}
     
-    {% include "components/tweets-from-psf.html" %}
-
     <div class="psf-sidebar-widget sidebar-widget">
         {% box 'widget-sidebar-aboutpsf' %}
         

--- a/templates/pages/pep-page.html
+++ b/templates/pages/pep-page.html
@@ -73,8 +73,6 @@ TODO: should this partially come from sitetree?
 
     {% include "components/navigation-widget.html" %}
 
-    {% include "components/tweets-from-psf.html" %}
-
     <div class="psf-sidebar-widget sidebar-widget">
         {% box 'widget-sidebar-aboutpsf' %}
 

--- a/templates/psf/default.html
+++ b/templates/psf/default.html
@@ -68,8 +68,6 @@
 
         </div>
 
-        {% include "components/tweets-from-psf.html" %}
-
     </aside>
 
 {% endblock left_sidebar %}

--- a/templates/python/inner.html
+++ b/templates/python/inner.html
@@ -623,40 +623,9 @@ p q r s t u v w x y z { | } ~</samp></pre>
 
 {% block left_sidebar %}
 <aside class="left-sidebar" role="secondary">
-  
+
     {% include "components/navigation-widget.html" %}
 
-    <div class="twitter-widget sidebar-widget">
-        <script type="text/javascript" src="//widgets.twimg.com/j/2/widget.js"></script>
-        <script type="text/javascript">// <![CDATA[
-        new TWTR.Widget({
-          version: 2,
-          type: 'profile',
-          rpp: 3,
-          interval: 30000,
-          width: 'auto',
-          height: 300,
-          theme: {
-            shell: {
-              background: '#f2f2f2',
-              color: '#666666'
-            },
-            tweets: {
-              background: '#f2f2f2',
-              color: '#666666',
-              links: '#3776ab'
-            }
-          },
-          features: {
-            scrollbar: false,
-            loop: false,
-            live: false,
-            behavior: 'all'
-          }
-        }).render().setUser('ThePSF').start();
-        // ]]></script>
-    </div>
-    
     <div class="psf-sidebar-widget sidebar-widget">
         <h3 class="widget-title">The PSF</h3>
         <p>The Python Software Foundation is the organization behind Python. Become a member of the PSF and help advance the software and our mission. </p>

--- a/templates/successstories/base.html
+++ b/templates/successstories/base.html
@@ -26,7 +26,5 @@
 
     </div>
 
-    {% include "components/tweets-from-psf.html" %}
-
 </aside>
 {% endblock left_sidebar %}

--- a/templates/waitforit.html
+++ b/templates/waitforit.html
@@ -22,37 +22,5 @@
 
 {% block left_sidebar %}
 <aside class="left-sidebar" role="secondary">
-  
-    <div class="twitter-widget sidebar-widget">
-        <script type="text/javascript" src="//widgets.twimg.com/j/2/widget.js"></script>
-        <script type="text/javascript">// <![CDATA[
-        new TWTR.Widget({
-          version: 2,
-          type: 'profile',
-          rpp: 3,
-          interval: 30000,
-          width: 'auto',
-          height: 300,
-          theme: {
-            shell: {
-              background: '#efefef',
-              color: '#666666'
-            },
-            tweets: {
-              background: '#f2f2f2',
-              color: '#666666',
-              links: '#3776ab'
-            }
-          },
-          features: {
-            scrollbar: false,
-            loop: false,
-            live: false,
-            behavior: 'all'
-          }
-        }).render().setUser('ThePSF').start();
-        // ]]></script>
-    </div>
-
 </aside>
 {% endblock left_sidebar %}


### PR DESCRIPTION
Fixes https://github.com/python/pythondotorg/issues/738.

The Twitter widget is broken, let's remove it:

<img width="1582" alt="image" src="https://github.com/python/pythondotorg/assets/1324225/74fb2ef7-f9f2-433e-b469-5634cd6a6613">

https://www.python.org/about/gettingstarted/