### PR TITLE
Update nginx.conf.erb to allow gzip on proxied responses

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -12,6 +12,7 @@ http {
         gzip on;
         gzip_comp_level 2;
         gzip_min_length 512;
+	gzip_proxied any; # Heroku router sends Via header
 
 	server_tokens off;
 


### PR DESCRIPTION
I noticed that the [python.org](https://www.python.org/) website doesn't use any compression for all HTML responses.

Apparently the [sample nginx config for Heroku](https://github.com/heroku/heroku-buildpack-nginx/blob/main/config/nginx.conf.erb) didn't include the `gzip_proxied` setting back in the day, which allows Nginx to apply gzip compression to proxied responses.

This PR updates the nginx config file to allow applying gzip compression on proxied responses. This saves at least 37 kB on the HTML text of the python.org homepage.