### PR TITLE
`download:download_release_detail` view: Display file sizes with human-readable units

### DIFF
--- a/downloads/tests/base.py
+++ b/downloads/tests/base.py
@@ -64,6 +64,7 @@ class BaseDownloadTests(DownloadMixin, TestCase):
             is_source=True,
             description='Gzipped source',
             url='ftp/python/2.7.5/Python-2.7.5.tgz',
+            filesize=12345678,
         )
 
         self.draft_release = Release.objects.create(

--- a/downloads/tests/test_views.py
+++ b/downloads/tests/test_views.py
@@ -40,6 +40,9 @@ class DownloadViewsTests(BaseDownloadTests):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
+        with self.subTest("Release file sizes should be human-readable"):
+            self.assertInHTML("<td>11.8 MB</td>", response.content.decode())
+
         url = reverse('download:download_release_detail', kwargs={'release_slug': 'fake_slug'})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -62,7 +62,7 @@
                 <td>{{ f.os.name }}</td>
                 <td>{{ f.description }}</td>
                 <td>{{ f.md5_sum }}</td>
-                <td>{{ f.filesize }}</td>
+                <td>{{ f.filesize|filesizeformat }}</td>
                 <td>{% if f.gpg_signature_file %}<a href="{{ f.gpg_signature_file }}">SIG</a>{% endif %}</td>
                 {% if release_files|has_sigstore_materials %}
                   {% if f.sigstore_bundle_file %}


### PR DESCRIPTION
When viewing the download files for a given release, their file sizes are displayed in bytes, which can be 8 digits long, making them difficult to read. To remedy this, the [`filesizeformat`](https://docs.djangoproject.com/en/2.2/ref/templates/builtins/#filesizeformat) template filter can be used to reduce the number of digits to a more easily read amount.

## Before

See how the numbers in the **File Size** column are very large and difficult to compare.

![Table of releases where the File Size column is in units of bytes and contains large numbers](https://github.com/python/pythondotorg/assets/5957867/3b2895a7-3aad-4841-8221-6fe1488f8853)

## After

Now see how the values in the **File Size** column can be quickly parsed and compared visually.

![Table of releases where the File Size column is in units of megabytes and contains 2- to 3-digit numbers](https://github.com/python/pythondotorg/assets/5957867/846de5e6-f82b-4089-995b-c85c8c0d9566)

## Unit test

A small [subtest](https://docs.python.org/3.9/library/unittest.html#distinguishing-test-iterations-using-subtests) has been added to enforce this display change without affecting the rest of the testing method:

```shell
docker-compose run --rm web \
./manage.py test -k \
downloads.tests.test_views.DownloadViewsTests.test_download_release_detail
```
