### PR TITLE
Link to SBOM user documentation from release detail page

### DIFF
--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -55,7 +55,7 @@
               <th colspan="2"><a href="https://www.python.org/download/sigstore/">Sigstore</a></th>
               {% endif %}
               {% if release_files|has_sbom %}
-              <th>SBOM</th>
+              <th><a href="https://www.python.org/download/sbom/">SBOM</a></th>
               {% endif %}
             </tr>
           </thead>


### PR DESCRIPTION
Part of https://github.com/python/pythondotorg/issues/2339, this links users to the [SBOM documentation page](https://www.python.org/download/sbom/).