### PR TITLE
fix download redirects to match previous behavior

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -208,19 +208,19 @@ http {
                   return 301 https://www.python.org/download/windows/;
                 }
 
-                location /download/ {
+                location ~ ^/download/$ {
                   return 301 https://www.python.org/downloads/;
                 }
 
-                location /download/source/ {
+                location ~ ^/download/source/$ {
                   return 301 https://www.python.org/downloads/source/;
                 }
 
-                location /download/mac/ {
+                location ~ ^/download/mac/$ {
                   return 301 https://www.python.org/downloads/macos/;
                 }
 
-                location /download/windows/ {
+                location ~ ^/download/windows/$ {
                   return 301 https://www.python.org/downloads/windows/;
                 }
 


### PR DESCRIPTION
fixes #2392

corrects [nginx redirects](https://github.com/python/pythondotorg/commit/95304aa81ba28d638fc0e36ceac203b0e85b68a0#diff-8536d045800ebd99dc58c8e5d9fab522ded64838c446ba361c1c4c6d8ce3b4d4R211-R225) to match the [old django redirects](https://github.com/python/pythondotorg/commit/95304aa81ba28d638fc0e36ceac203b0e85b68a0#diff-f14d8bfd8b7efe397bfe080186cd106bf789b4dab6436a70089bedf47be16a7cL28-L31)