### PR TITLE
Update Django to 2.2.28

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -4,7 +4,7 @@ django-sitetree==1.17.0
 django-apptemplates==1.5
 django-admin-interface==0.24.2
 django-translation-aliases==0.1.0
-Django==2.2.24
+Django==2.2.28
 docutils==0.12
 Markdown==3.3.4
 cmarkgfm==0.6.0


### PR DESCRIPTION
Before we go to Django 3.2 and 4.x after that, the simplest way to get rid of a few CVEs is to upgrade to the last version of 2.2.x. That puts us [on par with 3.2.13 and 4.0.4](https://www.djangoproject.com/weblog/2022/apr/11/security-releases/) security-wise.