### PR TITLE
Redirect Code of Conduct documents to policies.python.org

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -314,6 +314,22 @@ http {
                   return 301 https://python.org/blogs/;
                 }
 
+                location ^/psf/archive/codeofconduct/?$ {
+                    return 302 https://policies.python.org/python.org/code-of-conduct/;
+                }
+                location ^/psf/codeofconduct/?$ {
+                    return 302 https://policies.python.org/python.org/code-of-conduct/;
+                }
+                location ^/psf/conduct/?$ {
+                    return 302 https://policies.python.org/python.org/code-of-conduct/;
+                }
+                location ^/psf/conduct/enforcement/?$ {
+                    return 302 https://policies.python.org/python.org/code-of-conduct/Enforcement-Procedures/;
+                }
+                location ^/psf/conduct/reporting/?$ {
+                    return 302 https://policies.python.org/python.org/code-of-conduct/Procedures-for-Reporting-Incidents/;
+                }
+
                 location /static/ {
                     alias /code/static-root/;
                     add_header Cache-Control "max-age=604800, public";  # 604800 is 7 days


### PR DESCRIPTION
Depends on https://github.com/psf/policies/pull/5