### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,4 +26,4 @@ updates:
       patterns:
         - "*"  # Group all Actions updates into a single larger pull request
   schedule:
-    interval: monthly
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,11 @@ updates:
   - dependency-name: lxml
     versions:
     - 4.6.2
+- package-ecosystem: github-actions
+  directory: /
+  groups:
+    github-actions:
+      patterns:
+        - "*"  # Group all Actions updates into a single larger pull request
+  schedule:
+    interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,10 @@ updates:
     versions:
     - 4.6.2
 - package-ecosystem: github-actions
-  directory: /
+  directory: "/"
   groups:
     github-actions:
       patterns:
         - "*"  # Group all Actions updates into a single larger pull request
   schedule:
-    interval: weekly
+    interval: monthly


### PR DESCRIPTION
Generates pull requests like mymarilyn/clickhouse-driver#423 to fix warnings like at the bottom right of
https://github.com/python/pythondotorg/actions/runs/8235999706

* https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem

Fixes #2424