### PR TITLE
Docs: Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python.org
 
-[![Build Status](https://travis-ci.org/python/pythondotorg.svg?branch=main)](https://travis-ci.org/python/pythondotorg)
+[![CI](https://github.com/python/pythondotorg/actions/workflows/ci.yml/badge.svg)](https://github.com/python/pythondotorg/actions/workflows/ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/pythondotorg/badge/?version=latest)](https://pythondotorg.readthedocs.io/?badge=latest)
 
 ### General information

--- a/docs/source/administration.rst
+++ b/docs/source/administration.rst
@@ -6,7 +6,7 @@ Administration
 Navigation
 ----------
 
-Navigation on the site is managed by the `Sitetree  <https://pypi.org/pypi/django-sitetree>`_ application.  The hierarchy should be fairly obvious.  The biggest gotcha is when defining the URLs.
+Navigation on the site is managed by the `Sitetree  <https://pypi.org/project/django-sitetree/>`_ application.  The hierarchy should be fairly obvious.  The biggest gotcha is when defining the URLs.
 
 Many URLs are defined using `Django's URL system <https://docs.djangoproject.com/en/dev/topics/http/urls/>`_ however many are also simply defined as relative paths.  When editing a particular item in the Sitetree in the *Additional Settings* fieldset there is an option named *URL as pattern*.  If this option is checked the URL pattern is checked against the URLs defined by the Django applications. If it is left unchecked relative and absolute URLs can be entered.
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -11,7 +11,7 @@ already submitted it.
 Code
 ----
 
-The source for python.org is open and licensed under the `Apache 2 license <license>`_.
+The source for python.org is open and licensed under the `Apache 2 license <license_>`_.
 To contribute to either the code or documentation please fork the pythondotorg_
 repository and submit a pull request.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,9 +12,9 @@ General information
 :IRC: ``#pydotorg`` on Freenode
 :Staging site: https://staging.python.org/ (``main`` branch)
 :Production configuration: https://github.com/python/psf-salt
-:Travis:
-  .. image:: https://travis-ci.org/python/pythondotorg.svg?branch=main
-       :target: https://travis-ci.org/python/pythondotorg
+:GitHub Actions:
+  .. image:: https://github.com/python/pythondotorg/actions/workflows/ci.yml/badge.svg
+       :target: https://github.com/python/pythondotorg/actions/workflows/ci.yml
 :License: Apache License
 
 Contents:

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -18,7 +18,7 @@ To get the Pythondotorg source code, [fork](https://docs.github.com/en/pull-requ
 git clone git@github.com:YOUR-USERNAME/pythondotorg.git
 ```
 
-Add a [remote](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork) and [sync](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) regularly to stay current with the repository. 
+Add a [remote](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-repository-for-a-fork) and [sync](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) regularly to stay current with the repository. 
 
 ```
 git remote add upstream https://github.com/python/pythondotorg

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -12,7 +12,7 @@ Docker Compose will be installed by [Docker Mac](https://docs.docker.com/desktop
 Getting started
 ---------------
 
-To get the Pythondotorg source code, [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository on [GitHub](https://github.com/python/pythondotorg) and [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) it to your local machine: 
+To get the Pythondotorg source code, [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) the repository on [GitHub](https://github.com/python/pythondotorg) and [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) it to your local machine: 
 
 ```
 git clone git@github.com:YOUR-USERNAME/pythondotorg.git
@@ -33,7 +33,7 @@ Installing Docker
 Install [Docker Engine](https://docs.docker.com/engine/install/) 
 
 ```{note}
-The best experience for building Pythondotorg on Windows is to use the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/)(WSL) in combination with both [Docker for Windows](https://docs.docker.com/desktop/install/windows-install/) and [Docker for Linux](https://docs.docker.com/engine/install/).
+The best experience for building Pythondotorg on Windows is to use the [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/)(WSL) in combination with both [Docker for Windows](https://docs.docker.com/desktop/install/windows-install/) and [Docker for Linux](https://docs.docker.com/engine/install/).
 ```
 
 Verify that the Docker installation is successful by running: `docker -v`
@@ -197,7 +197,7 @@ Once you have it installed, update the URL value of `HAYSTACK_CONNECTIONS` set
 Generating CSS files automatically
 ----------------------------------
 
-Due to performance issues of [django-pipeline](https://github.com/cyberdelia/django-pipeline/issues/313), we are using a dummy compiler `pydotorg.compilers.DummySASSCompiler` in development mode. To generate CSS files, use `sass` itself in a separate terminal window:
+Due to performance issues of [django-pipeline](https://github.com/jazzband/django-pipeline/issues/313), we are using a dummy compiler `pydotorg.compilers.DummySASSCompiler` in development mode. To generate CSS files, use `sass` itself in a separate terminal window:
 
 ```
 $ cd static

--- a/docs/source/pep_generation.rst
+++ b/docs/source/pep_generation.rst
@@ -31,4 +31,4 @@ This process runs periodically via cron to keep the PEP pages up to date.
    
 See :ref:`management-commands` for all management commands.
 
-.. _PEP Repository: https://github.com/python/peps.git
+.. _PEP Repository: https://github.com/python/peps


### PR DESCRIPTION
At https://pythondotorg.readthedocs.io/contributing.html:

"Apache 2 license" links to the 404 https://pythondotorg.readthedocs.io/license

Fix it to point to https://github.com/python/pythondotorg/blob/main/LICENSE

Also fix a link to GitHub docs, update some redirects, and replace links to Travis CI with GitHub Actions.