### PR TITLE
Upgrade GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install platform dependencies
         run: |
           sudo apt -y update
@@ -29,11 +29,11 @@ jobs:
         run: |
           wget https://github.com/jgm/pandoc/releases/download/2.17.1.1/pandoc-2.17.1.1-1-amd64.deb
           sudo dpkg -i pandoc-2.17.1.1-1-amd64.deb
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9.16
       - name: Cache Python dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: pythondotorg-cache-pip
         with:


### PR DESCRIPTION
To fix the warnings at the bottom right of
https://github.com/python/pythondotorg/actions/runs/8479123182

This could have been automated in
* #2401 

* https://github.com/actions/checkout/releases
* https://github.com/actions/setup-python/releases
* https://github.com/actions/cache/releases