### PR TITLE
Update python3statement URL

### DIFF
--- a/templates/python/documentation.html
+++ b/templates/python/documentation.html
@@ -81,7 +81,7 @@
                         <ul>
                           <li><a href="https://www.python.org/doc/sunset-python-2/">FAQ: Sunsetting Python 2</a></li>
                           <li><a href="https://www.python.org/dev/peps/pep-0373/">Final Python 2.7 Release Schedule</a></li>
-                          <li><a href="https://python3statement.org/">Python 3 Statement</a></li>
+                          <li><a href="https://python3statement.github.io/">Python 3 Statement</a></li>
                           <li>
                             <a href="https://docs.python.org/3/howto/pyporting.html">Porting Python 2 Code to Python 3</a>
                             <ul>


### PR DESCRIPTION
See https://github.com/python3statement/python3statement.github.io/issues/292. 

To avoid having to pay for the domain indefinitely the maintainers are now redirecting to GitHub Pages.