### PR TITLE
Remove unused `django-markupfield-helpers` dependency.

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -35,7 +35,6 @@ requests[security]>=2.26.0
 
 django-honeypot==1.0.1
 django-markupfield==2.0.0
-django-markupfield-helpers==0.1.1
 
 django-allauth==0.50.0
 


### PR DESCRIPTION
`django-markupfield-helpers` was added as a dependency in d155915ec930077fc01e836e957035bb0043f2cc and was used in `sponsors/pdf.py` and `sponsors/tests/test_pdf.py`.  Those files were later removed in b4d22a898957a2c8cbd1c2a2ced4f1d878f0ef01, but the dependency wasn't removed.  This PR removes it.