### PR TITLE
fix(frontend): Improve low constrast of code blocks and links

### DIFF
--- a/static/sass/_base.scss
+++ b/static/sass/_base.scss
@@ -85,7 +85,7 @@ $darkerblue: #1e2933;
 $link-color: $blue;
 $link-hover: $darkerblue;
 
-$code-green: #11a611; 
+$code-green: #0c7d0c;
 $default-border-color: $grey-lighter; /* Set a generic border color here to keep them consistent */
 
 

--- a/static/sass/_base.scss
+++ b/static/sass/_base.scss
@@ -85,7 +85,7 @@ $darkerblue: #1e2933;
 $link-color: $blue;
 $link-hover: $darkerblue;
 
-$code-green: #0c7d0c;
+$code-green: #0d870d;
 $default-border-color: $grey-lighter; /* Set a generic border color here to keep them consistent */
 
 

--- a/static/sass/mq.css
+++ b/static/sass/mq.css
@@ -1651,24 +1651,24 @@ html[xmlns] .slides { display: block; }
     padding-top: 1em; }
 
   .about-banner {
-    background: 120% 0 no-repeat url('../img/landing-about.png?1646853871') transparent;
+    background: 120% 0 no-repeat url('../img/landing-about.png?1767349471') transparent;
     min-height: 345px;
     padding-bottom: 3.5em;
     margin-bottom: -2.5em; }
 
   .download-for-current-os {
-    background: 130% 0 no-repeat url('../img/landing-downloads.png?1646853871') transparent;
+    background: 130% 0 no-repeat url('../img/landing-downloads.png?1767349471') transparent;
     min-height: 345px;
     padding-bottom: 4em;
     margin-bottom: -3em; }
 
   .documentation-banner {
-    background: 130% 0 no-repeat url('../img/landing-docs.png?1646853871') transparent;
+    background: 130% 0 no-repeat url('../img/landing-docs.png?1767349471') transparent;
     padding-bottom: 1em; }
 
   .community-banner {
     text-align: left;
-    background: 110% 0 no-repeat url('../img/landing-community.png?1646853871') transparent;
+    background: 110% 0 no-repeat url('../img/landing-community.png?1767349471') transparent;
     min-height: 345px;
     padding-bottom: 2em;
     margin-bottom: -1.25em; }
@@ -1772,7 +1772,7 @@ html[xmlns] .slides { display: block; }
       right: 1em;
       width: 210px;
       height: 210px;
-      background: top left no-repeat url('../img/python-logo-large.png?1646853871') transparent; }
+      background: top left no-repeat url('../img/python-logo-large.png?1767349471') transparent; }
     .psf-widget .widget-title, .psf-widget p, .python-needs-you-widget .widget-title, .python-needs-you-widget p {
       margin-right: 34.04255%; }
 

--- a/static/sass/no-mq.css
+++ b/static/sass/no-mq.css
@@ -1359,24 +1359,24 @@ a.button {
   padding-top: 1em; }
 
 .about-banner {
-  background: 120% 0 no-repeat url('../img/landing-about.png?1646853871') transparent;
+  background: 120% 0 no-repeat url('../img/landing-about.png?1767349471') transparent;
   min-height: 345px;
   padding-bottom: 3.5em;
   margin-bottom: -2.5em; }
 
 .download-for-current-os {
-  background: 130% 0 no-repeat url('../img/landing-downloads.png?1646853871') transparent;
+  background: 130% 0 no-repeat url('../img/landing-downloads.png?1767349471') transparent;
   min-height: 345px;
   padding-bottom: 4em;
   margin-bottom: -3em; }
 
 .documentation-banner {
-  background: 130% 0 no-repeat url('../img/landing-docs.png?1646853871') transparent;
+  background: 130% 0 no-repeat url('../img/landing-docs.png?1767349471') transparent;
   padding-bottom: 1em; }
 
 .community-banner {
   text-align: left;
-  background: 110% 0 no-repeat url('../img/landing-community.png?1646853871') transparent;
+  background: 110% 0 no-repeat url('../img/landing-community.png?1767349471') transparent;
   min-height: 345px;
   padding-bottom: 2em;
   margin-bottom: -1.25em; }
@@ -1480,7 +1480,7 @@ a.button {
     right: 1em;
     width: 210px;
     height: 210px;
-    background: top left no-repeat url('../img/python-logo-large.png?1646853871') transparent; }
+    background: top left no-repeat url('../img/python-logo-large.png?1767349471') transparent; }
   .psf-widget .widget-title, .psf-widget p, .python-needs-you-widget .widget-title, .python-needs-you-widget p {
     margin-right: 34.04255%; }
 

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -603,7 +603,7 @@ pre {
   /* IE 5.5+ and up */ }
 
 code {
-  color: #11a611; }
+  color: #0d870d; }
 
 var {
   font-style: italic; }
@@ -723,6 +723,9 @@ body, input, textarea, select, button {
 a, a:active, a:visited, a:hover, a:visited:hover {
   color: #3776ab;
   text-decoration: none; }
+
+table tr td a, table tr td a:active, table tr td a:visited, table tr td a:hover, table tr td a:visited:hover {
+  color: #3571a3; }
 
 a:hover, a:focus {
   color: #1e2933; }
@@ -1619,7 +1622,7 @@ input#s,
   padding: 1.25em 1.5em; }
   .slide-code code {
     display: inline-block;
-    color: #11a611; }
+    color: #0d870d; }
     .slide-code code .comment {
       color: #666666; }
     .slide-code code .output {
@@ -1932,8 +1935,7 @@ input#s,
     background-color: #e6e8ea;
     padding: .125em .375em 0;
     margin: 0 .25em; }
-  .text code, .text kbd,
-  .sidebar-widget code,
+  .text kbd,
   .sidebar-widget kbd {
     padding: .125em .375em 0;
     margin: 0 -.0625em;
@@ -1950,7 +1952,7 @@ input#s,
   .text pre,
   .sidebar-widget pre {
     padding: .5em;
-    border-left: 5px solid #11a611;
+    border-left: 5px solid #0d870d;
     background: #e6e8ea;
     -webkit-box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset;
     -moz-box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.1) inset;
@@ -2266,7 +2268,7 @@ table tfoot {
 /* ! ===== Success Stories landing page ===== */
 .featured-success-story {
   padding: 1.3125em 0;
-  background: center -230px no-repeat url('../img/success-glow2.png?1646853871') transparent;
+  background: center -230px no-repeat url('../img/success-glow2.png?1767349471') transparent;
   /*blockquote*/ }
   .featured-success-story img {
     padding: 10px 30px; }
@@ -3276,11 +3278,11 @@ span.highlighted {
     .python .site-headline a:before {
       width: 290px;
       height: 82px;
-      content: url('../img/python-logo_print.png?1646853871'); }
+      content: url('../img/python-logo_print.png?1767349471'); }
     .psf .site-headline a:before {
       width: 334px;
       height: 82px;
-      content: url('../img/psf-logo_print.png?1646853871'); } }
+      content: url('../img/psf-logo_print.png?1767349471'); } }
 /*
  * When we want to review the markup for W3 and similar errors, turn some of these on
  * Uses :not selectors a bunch, so only modern browsers will support them

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -66,6 +66,12 @@ a, a:active, a:visited, a:hover, a:visited:hover {
 	text-decoration: none;
 }
 
+table tr td {
+    a, a:active, a:visited, a:hover, a:visited:hover {
+        color: darken($link-color, 2%);
+    }
+}
+
 a:hover, a:focus { color: $link-hover; }
 
 /*modernizr*/ .touch a[href^="tel:"] { border-bottom: 1px dotted $default-color; }

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -959,7 +959,7 @@ $show-baseline-grid-backgrounds: false;
         margin: 0 .25em;
     }
 
-    code, kbd {
+    kbd {
         padding: .125em .375em 0;
         margin: 0 -.0625em;
         background: $grey-lightest;


### PR DESCRIPTION
Closes #2446 

I changed the code block color for the closest darker green that surpasses `4.5` - Firefox is now reporting it as `4.57`.

I didn't want to change the link color for all links, so I just added a new rule to target links in tables only. Firefox now reports the new value as `4.56`.

Let me know if it's ok like this!