### PR TITLE
give admin user a preview of sponsorship package revenue splits

### DIFF
--- a/sponsors/admin.py
+++ b/sponsors/admin.py
@@ -198,19 +198,13 @@ class SponsorshipPackageAdmin(OrderedModelAdmin):
         return {}
 
     def get_benefit_split(self, obj: SponsorshipPackage) -> str:
-        # colors selected from defined css variables in order to look like they fit in the theme
         colors = [
-            "secondary",  # blue
-            "admin-interface-header-background-color",  # dark green
-            "admin-interface-title-color",  # yellow
-            "admin-interface-header-text-color",  # light green
-            "admin-interface-delete-button-background-hover-color",  # red
-            "admin-interface-save-button-background-hover-color",  # darker green
-            "admin-interface-module-background-selected-color",  # light yellow
-            "admin-interface-generic-link-hover-color",  # medium green
+            "#ffde57",  # Python Gold
+            "#4584b6",  # Python Blue
+            "#646464",  # Python Grey
         ]
         split = obj.get_default_revenue_split()
-        # I hope there's never more than 8 things in the split, but just in case...
+        # rotate colors through our available palette
         if len(split) > len(colors):
             colors = colors * (1 + (len(split) // len(colors)))
         # build some span elements to show the percentages and have the program name in the title (to show on hover)

--- a/sponsors/models/sponsorship.py
+++ b/sponsors/models/sponsorship.py
@@ -121,7 +121,7 @@ class SponsorshipPackage(OrderedModel):
         """
         Give the admin an indication of how revenue for sponsorships in this package will be divvied up
         """
-        values, key = {}, "program__description"
+        values, key = {}, "program__name"
         for benefit in self.benefits.values(key).annotate(amount=Sum("internal_value", default=0)).order_by("-amount"):
             values[benefit[key]] = values.get(benefit[key], 0) + (benefit["amount"] or 0)
         total = sum(values.values())

--- a/sponsors/models/sponsorship.py
+++ b/sponsors/models/sponsorship.py
@@ -117,6 +117,18 @@ class SponsorshipPackage(OrderedModel):
             slug=self.slug, year=year, defaults=defaults
         )
 
+    def get_default_revenue_split(self) -> list[tuple[str, float]]:
+        """
+        Give the admin an indication of how revenue for sponsorships in this package will be divvied up
+        """
+        values, key = {}, "program__description"
+        for benefit in self.benefits.values(key).annotate(amount=Sum("internal_value", default=0)).order_by("-amount"):
+            values[benefit[key]] = values.get(benefit[key], 0) + (benefit["amount"] or 0)
+        total = sum(values.values())
+        if not total:
+            return []  # nothing to split!
+        return [(k, round(v / total * 100, 3)) for k, v in values.items()]
+
 
 class SponsorshipProgram(OrderedModel):
     """

--- a/sponsors/tests/test_models.py
+++ b/sponsors/tests/test_models.py
@@ -433,6 +433,15 @@ class SponsorshipPackageTests(TestCase):
         self.assertFalse(created)
         self.assertEqual(pkg_2023.pk, repeated_pkg_2023.pk)
 
+    def test_get_default_revenue_split(self):
+        for i in range(3):
+            self.package_benefits[i].internal_value = 1000
+            self.package_benefits[i].save()
+        split = self.package.get_default_revenue_split()
+        total = sum((pct for _, pct in split))
+        self.assertEqual(total, 100)
+
+
 class SponsorContactModelTests(TestCase):
     def test_get_primary_contact_for_sponsor(self):
         sponsor = baker.make(Sponsor)


### PR DESCRIPTION
This adds information to the admin screen for Sponsorship Packages about the revenue split for unmodified sponsorships.

![Screenshot from 2024-09-11 08-17-52](https://github.com/user-attachments/assets/ba2e2f36-2a3b-4861-8f8e-ca069eb48e7d)
