### PR TITLE
feat(frontend): Improve highlighting of code samples

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,6 @@ build:
     python: "3"
 
   commands:
-      - python -m pip install '.[docs]'
+      - python -m pip install --group docs .
       - make -C docs html JOBS=$(nproc) BUILDDIR=_readthedocs
       - mv docs/_readthedocs _readthedocs

--- a/apps/codesamples/factories.py
+++ b/apps/codesamples/factories.py
@@ -4,6 +4,9 @@ import textwrap
 
 import factory
 from factory.django import DjangoModelFactory
+from pygments import highlight
+from pygments.formatters import HtmlFormatter
+from pygments.lexers import PythonConsoleLexer
 
 from apps.codesamples.models import CodeSample
 from apps.users.factories import UserFactory
@@ -26,22 +29,28 @@ class CodeSampleFactory(DjangoModelFactory):
     is_published = True
 
 
+def _highlight_python_console(code):
+    """Highlight a Python console code snippet using Pygments."""
+    code = textwrap.dedent(code).strip()
+    html = highlight(code, PythonConsoleLexer(), HtmlFormatter(nowrap=True))
+    return f"<pre><code>{html}</code></pre>"
+
+
 def initial_data():
     """Create the default set of homepage code samples."""
     code_samples = [
         (
-            """\
-            <pre><code><span class=\"comment\"># Simple output (with Unicode)</span>
+            """
+            # Simple output (with Unicode)
             >>> print("Hello, I'm Python!")
-            <span class=\"output\">Hello, I'm Python!</span>
+            Hello, I'm Python!
 
-            <span class=\"comment\"># Input, assignment</span>
-            >>> name = input('What is your name?\n')
-            <span class=\"output\">What is your name?
-            Python</span>
+            # Input, assignment
+            >>> name = input('What is your name?\\n')
             >>> print(f'Hi, {name}.')
-            <span class=\"output\">Hi, Python.</span></code>
-            </pre>
+            What is your name?
+            Python
+            Hi, Python.
             """,
             """\
             <h1>Quick &amp; Easy to Learn</h1>
@@ -53,16 +62,16 @@ def initial_data():
             """,
         ),
         (
-            """\
-            <pre><code><span class=\"comment\"># Simple arithmetic</span>
+            """
+            # Simple arithmetic
             >>> 1 / 2
-            <span class=\"output\">0.5</span>
+            0.5
             >>> 2 ** 3
-            <span class=\"output\">8</span>
-            >>> 17 / 3  <span class=\"comment\"># true division returns a float</span>
-            <span class=\"output\">5.666666666666667</span>
-            >>> 17 // 3  <span class=\"comment\"># floor division</span>
-            <span class=\"output\">5</span></code></pre>
+            8
+            >>> 17 / 3  # true division returns a float
+            5.666666666666667
+            >>> 17 // 3  # floor division
+            5
             """,
             """\
             <h1>Intuitive Interpretation</h1>
@@ -76,16 +85,16 @@ def initial_data():
             """,
         ),
         (
-            """\
-            <pre><code><span class=\"comment\"># List comprehensions</span>
+            """
+            # List comprehensions
             >>> fruits = ['Banana', 'Apple', 'Lime']
             >>> loud_fruits = [fruit.upper() for fruit in fruits]
             >>> print(loud_fruits)
-            <span class=\"output\">['BANANA', 'APPLE', 'LIME']</span>
+            ['BANANA', 'APPLE', 'LIME']
 
-            <span class=\"comment\"># List and the enumerate function</span>
+            # List and the enumerate function
             >>> list(enumerate(fruits))
-            <span class=\"output\">[(0, 'Banana'), (1, 'Apple'), (2, 'Lime')]</span></code></pre>
+            [(0, 'Banana'), (1, 'Apple'), (2, 'Lime')]
             """,
             """\
             <h1>Compound Data Types</h1>
@@ -97,19 +106,15 @@ def initial_data():
             """,
         ),
         (
-            """\
-            <pre>
-            <code>
-            <span class=\"comment\"># For loop on a list</span>
+            """
+            # For loop on a list
             >>> numbers = [2, 4, 6, 8]
             >>> product = 1
             >>> for number in numbers:
             ...     product = product * number
             ...
             >>> print('The product is:', product)
-            <span class=\"output\">The product is: 384</span>
-            </code>
-            </pre>
+            The product is: 384
             """,
             """\
             <h1>All the Flow You&rsquo;d Expect</h1>
@@ -122,21 +127,17 @@ def initial_data():
             """,
         ),
         (
-            """\
-            <pre>
-            <code>
-            <span class=\"comment\"># Write Fibonacci series up to n</span>
+            """
+            # Write Fibonacci series up to n
             >>> def fib(n):
             ...     a, b = 0, 1
-            ...     while a &lt; n:
+            ...     while a < n:
             ...         print(a, end=' ')
             ...         a, b = b, a+b
             ...     print()
             ...
             >>> fib(1000)
-            <span class=\"output\">0 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610</span>
-            </code>
-            </pre>
+            0 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610
             """,
             """\
             <h1>Functions Defined</h1>
@@ -151,7 +152,7 @@ def initial_data():
     return {
         "boxes": [
             CodeSampleFactory(
-                code=textwrap.dedent(code),
+                code=_highlight_python_console(code),
                 copy=textwrap.dedent(copy),
             )
             for code, copy in code_samples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "docutils==0.21.2",
     "Markdown==3.7",
     "cmarkgfm==2024.11.20",
+    "Pygments>=2.17",
     "Pillow==10.4.0",
     "psycopg2-binary==2.9.9",
     "python3-openid==3.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "docutils==0.21.2",
     "Markdown==3.7",
     "cmarkgfm==2024.11.20",
-    "Pygments>=2.17",
+    "Pygments>=2.17,<3",
     "Pillow==10.4.0",
     "psycopg2-binary==2.9.9",
     "python3-openid==3.2.0",

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -1529,18 +1529,14 @@ input#s,
   .slide-code code {
     display: inline-block;
     color: #0d870d; }
-    .slide-code code .k,
-    .slide-code code .ow {
+    .slide-code code .k, .slide-code code .ow {
       color: #6ab825;
       font-weight: bold; }
     .slide-code code .nb {
       color: #24909d; }
     .slide-code code .nf {
       color: #447fcf; }
-    .slide-code code .s1,
-    .slide-code code .s2,
-    .slide-code code .sa,
-    .slide-code code .si {
+    .slide-code code .s1, .slide-code code .s2, .slide-code code .sa, .slide-code code .si {
       color: #ed9d13; }
     .slide-code code .mi {
       color: #3677a9; }
@@ -1550,7 +1546,7 @@ input#s,
       color: #999999;
       font-style: italic; }
     .slide-code code .go {
-      color: #cccccc; }
+      color: #dddddd; }
     .slide-code code .gp {
       color: #c65d09;
       font-weight: bold; }
@@ -2188,7 +2184,7 @@ table .checksum {
 /* ! ===== Success Stories landing page ===== */
 .featured-success-story {
   padding: 1.3125em 0;
-  background: center -230px no-repeat url('../img/success-glow2.png?1694722768') transparent;
+  background: center -230px no-repeat url('../img/success-glow2.png?1726783859') transparent;
   /*blockquote*/ }
   .featured-success-story img {
     padding: 10px 30px; }
@@ -3174,11 +3170,11 @@ span.highlighted {
     .python .site-headline a:before {
       width: 290px;
       height: 82px;
-      content: url('../img/python-logo_print.png?1694722768'); }
+      content: url('../img/python-logo_print.png?1726783859'); }
     .psf .site-headline a:before {
       width: 334px;
       height: 82px;
-      content: url('../img/psf-logo_print.png?1694722768'); } }
+      content: url('../img/psf-logo_print.png?1726783859'); } }
 /*
  * When we want to review the markup for W3 and similar errors, turn some of these on
  * Uses :not selectors a bunch, so only modern browsers will support them

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -1529,10 +1529,13 @@ input#s,
   .slide-code code {
     display: inline-block;
     color: #0d870d; }
-    .slide-code code .comment {
-      color: #666666; }
-    .slide-code code .output {
+    .slide-code code .c1 {
+      color: #666666;
+      font-style: normal; }
+    .slide-code code .go {
       color: #dddddd; }
+    .slide-code code .gp {
+      color: #c65d09; }
 
 .js .launch-shell, .no-js .launch-shell {
   display: none; }

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -2184,7 +2184,7 @@ table .checksum {
 /* ! ===== Success Stories landing page ===== */
 .featured-success-story {
   padding: 1.3125em 0;
-  background: center -230px no-repeat url('../img/success-glow2.png?1726783859') transparent;
+  background: center -230px no-repeat url('../img/success-glow2.png?1694722768') transparent;
   /*blockquote*/ }
   .featured-success-story img {
     padding: 10px 30px; }
@@ -3170,11 +3170,11 @@ span.highlighted {
     .python .site-headline a:before {
       width: 290px;
       height: 82px;
-      content: url('../img/python-logo_print.png?1726783859'); }
+      content: url('../img/python-logo_print.png?1694722768'); }
     .psf .site-headline a:before {
       width: 334px;
       height: 82px;
-      content: url('../img/psf-logo_print.png?1726783859'); } }
+      content: url('../img/psf-logo_print.png?1694722768'); } }
 /*
  * When we want to review the markup for W3 and similar errors, turn some of these on
  * Uses :not selectors a bunch, so only modern browsers will support them

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -1529,13 +1529,31 @@ input#s,
   .slide-code code {
     display: inline-block;
     color: #0d870d; }
+    .slide-code code .k,
+    .slide-code code .ow {
+      color: #6ab825;
+      font-weight: bold; }
+    .slide-code code .nb {
+      color: #24909d; }
+    .slide-code code .nf {
+      color: #447fcf; }
+    .slide-code code .s1,
+    .slide-code code .s2,
+    .slide-code code .sa,
+    .slide-code code .si {
+      color: #ed9d13; }
+    .slide-code code .mi {
+      color: #3677a9; }
+    .slide-code code .o {
+      color: #999999; }
     .slide-code code .c1 {
-      color: #666666;
-      font-style: normal; }
+      color: #999999;
+      font-style: italic; }
     .slide-code code .go {
-      color: #dddddd; }
+      color: #cccccc; }
     .slide-code code .gp {
-      color: #c65d09; }
+      color: #c65d09;
+      font-weight: bold; }
 
 .js .launch-shell, .no-js .launch-shell {
   display: none; }

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -697,9 +697,15 @@ input#s,
             display: inline-block;
             color: $code-green;
 
-            .comment { color: $grey; }
-
-            .output { color: $grey-lighterer; }
+            .k, .ow { color: #6ab825; font-weight: bold; }
+            .nb { color: #24909d; }
+            .nf { color: #447fcf; }
+            .s1, .s2, .sa, .si { color: #ed9d13; }
+            .mi { color: #3677a9; }
+            .o { color: $grey-light; }
+            .c1 { color: $grey-light; font-style: italic; }
+            .go { color: $grey-lighterer; }
+            .gp { color: #c65d09; font-weight: bold; }
         }
     }
 


### PR DESCRIPTION
#### What

- Rebased on the latest `main` from #1517
- Addresses reviewer feedback to use **Pygments** instead of manual regex-based highlighting

#### Changes

- Replace hand-written `<span>` tags and regex `format_html()` with Pygments `PythonConsoleLexer`
- Code samples are now plain Python console text — Pygments generates all syntax highlighting
- Add `Pygments>=2.17` as a dependency
- Update both SCSS source and compiled CSS with Pygments token classes
- Fix Fibonacci example: use `...` continuation lines and plain `<` (Pygments handles HTML escaping)

#### Syntax highlighting colors (dark background)

| Token | Class | Color | Example |
|-------|-------|-------|---------|
| Prompt (`>>>`, `...`) | `.gp` | `#c65d09` (orange, bold) | `>>>` |
| Output | `.go` | `#ddd` (light gray) | `Hello, I'm Python!` |
| Keywords | `.k`, `.ow` | `#6ab825` (bright green, bold) | `def`, `for`, `while` |
| Builtins | `.nb` | `#24909d` (teal) | `print`, `input`, `list` |
| Function names | `.nf` | `#447fcf` (blue) | `fib` |
| Strings | `.s1`, `.s2`, `.sa`, `.si` | `#ed9d13` (gold) | `'Hello'` |
| Numbers | `.mi` | `#3677a9` (blue) | `1000` |
| Operators | `.o` | `#999` (gray) | `=`, `+`, `/` |
| Comments | `.c1` | `#999` (gray, italic) | `# floor division` |
| Default code | inherited | `#0d870d` (green) | variable names, etc. |