### PR TITLE
Pages: Also purge trailing slash

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -137,6 +137,8 @@ def purge_fastly_cache(sender, instance, **kwargs):
     Requires settings.FASTLY_API_KEY being set
     """
     purge_url(f'/{instance.path}')
+    if not instance.path.endswith('/'):
+        purge_url(f'/{instance.path}/')
 
 
 def page_image_path(instance, filename):


### PR DESCRIPTION
Fastly purge requests are sensitive to trailing slash, so to ensure we get the result we want we should also purge that.