### PR TITLE
fix: recreate dictionary each run

### DIFF
--- a/infra/cdn/main.tf
+++ b/infra/cdn/main.tf
@@ -392,8 +392,6 @@ resource "fastly_service_vcl" "python_org" {
       product_enablement,
     ]
   }
-
-  force_destroy = true
 }
 
 output "service_id" {

--- a/infra/cdn/main.tf
+++ b/infra/cdn/main.tf
@@ -347,6 +347,7 @@ resource "fastly_service_vcl" "python_org" {
     for_each = var.activate_ngwaf_service ? [1] : []
     content {
       name = var.edge_security_dictionary
+      force_destroy = true
     }
   }
 
@@ -391,6 +392,8 @@ resource "fastly_service_vcl" "python_org" {
       product_enablement,
     ]
   }
+
+  force_destroy = true
 }
 
 output "service_id" {


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- TF cloud runs fail due to the dictionary not being editable
![image](https://github.com/user-attachments/assets/50eb12eb-a0e1-4b98-ba13-036d5257b240)


