### PR TITLE
add a name for the ngwaf edge dictionary

### DIFF
--- a/infra/cdn/variables.tf
+++ b/infra/cdn/variables.tf
@@ -50,7 +50,7 @@ variable "activate_ngwaf_service" {
 variable "edge_security_dictionary" {
   type        = string
   description = "The dictionary name for the Edge Security product."
-  default     = ""
+  default     = "Edge_Security"
 }
 variable "ngwaf_corp_name" {
   type        = string


### PR DESCRIPTION
#### Description

Fastly requires a name for edge dictionaries.