### PR TITLE
refactor: update `all_day` detection logic

### DIFF
--- a/events/importer.py
+++ b/events/importer.py
@@ -7,9 +7,6 @@ import requests
 from .models import EventLocation, Event, OccurringRule
 from .utils import extract_date_or_datetime
 
-DATE_RESOLUTION = timedelta(1)
-TIME_RESOLUTION = timedelta(0, 0, 1)
-
 logger = logging.getLogger(__name__)
 
 
@@ -31,10 +28,7 @@ class ICSImporter:
             dt_end = dt_start
 
         # Let's mark those occurrences as 'all-day'.
-        all_day = (
-            dt_start.resolution == DATE_RESOLUTION or
-            dt_end.resolution == DATE_RESOLUTION
-        )
+        all_day = dt_end - dt_start >= timedelta(days=1)
 
         defaults = {
             'dt_start': dt_start,

--- a/events/utils.py
+++ b/events/utils.py
@@ -21,7 +21,7 @@ def date_to_datetime(date, tzinfo=None):
 
 
 def extract_date_or_datetime(dt):
-    if isinstance(dt, datetime.datetime):
+    if isinstance(dt, datetime.date):
         return convert_dt_to_aware(dt)
     return dt
 


### PR DESCRIPTION
#### Description

Instead of using a particular resolution on an object, which differs between `datetime.date` and `datetime.datetime` objects, operate on parent class of `datetime` and convert all `dt` to timezone-aware `datetime` values.

This is also in accordance to the model field being a `DateTimeField`, so we should always be passing the correctly-created object, instead of a `datetime.date()`, raising `received a naive datetime` warnings.

Removes unused constants.

#### Closes

Closes #2415

---

Other notes, for fun.

The warnings stem from this little bitty function:

https://github.com/python/pythondotorg/blob/8a02c109590e6e81aa05f8213e7fde7a3d05858f/events/utils.py#L23-L26

Since the ICS importer is often met with a string that looks like a date-only, like this one:
https://github.com/python/pythondotorg/blob/8a02c109590e6e81aa05f8213e7fde7a3d05858f/events/tests/test_importer.py#L39

the returned type is `datetime.date`, not a `datetime.datetime`.

The change in `events/utils.py` drops the warnings, but fails two test cases:

```pycon
======================================================================
FAIL: test_import_event_excludes_ending_day_when_all_day_is_true (events.tests.test_importer.EventsImporterTestCase.test_import_event_excludes_ending_day_when_all_day_is_true)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/events/tests/test_importer.py", line 131, in test_import_event_excludes_ending_day_when_all_day_is_true
    self.assertTrue(all_day_event.next_or_previous_time.all_day)
AssertionError: False is not true

======================================================================
FAIL: test_modified_event (events.tests.test_importer.EventsImporterTestCase.test_modified_event)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/events/tests/test_importer.py", line 63, in test_modified_event
    self.assertTrue(e.next_or_previous_time.all_day)
AssertionError: False is not true
```

These come from the `all_day` calculation over here:

https://github.com/python/pythondotorg/blob/74e659c33077839657bd702a9eb1ddd678ebc5c4/events/importer.py#L33-L37

which has now been updated.