### PR TITLE
Remove major version from /downloads/feed.rss

### DIFF
--- a/downloads/views.py
+++ b/downloads/views.py
@@ -182,8 +182,8 @@ class ReleaseFeed(Feed):
         return item.name
 
     def item_description(self, item: Release) -> str:
-        """Return the release version and release date as the item description."""
-        return f"Version: {item.version}, Release Date: {item.release_date}"
+        """Return the release date as the item description."""
+        return f"Release date: {item.release_date}"
 
     def item_pubdate(self, item: Release) -> datetime | None:
         """Return the release date as the item publication date."""


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

Feed items at https://www.python.org/downloads/feed.rss look like:

```xml
		<item>
			<title>Python 3.12.7</title>
			<link>https://www.python.org/downloads/release/python-3127/</link>
			<description>Version: 3, Release Date: 2024-10-01 04:50:32+00:00</description>
			<pubDate>Tue, 01 Oct 2024 04:50:32 +0000</pubDate>
			<guid>https://www.python.org/downloads/release/python-3127/</guid>
		</item>
		<item>
			<title>Python 3.13.0rc3</title>
			<link>https://www.python.org/downloads/release/python-3130rc3/</link>
			<description>Version: 3, Release Date: 2024-10-01 04:42:14+00:00</description>
			<pubDate>Tue, 01 Oct 2024 04:42:14 +0000</pubDate>
			<guid>https://www.python.org/downloads/release/python-3130rc3/</guid>
		</item>
```

That "Version: 3" isn't really useful: version 2 is long gone and version 4 is unlikely.

Let's remove it.

PS I've hooked up the feed to a Mastodon account: https://mastodon.social/@python_releases@feedsin.space

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
