### PR TITLE
fix: Ensure that Box content is rendered after update

### DIFF
--- a/blogs/parser.py
+++ b/blogs/parser.py
@@ -48,10 +48,12 @@ def update_blog_supernav():
         pass
     else:
         rendered_box = _render_blog_supernav(latest_entry)
-        box, _ = Box.objects.update_or_create(
+        box, created = Box.objects.update_or_create(
             label='supernav-python-blog',
             defaults={
                 'content': rendered_box,
                 'content_markup_type': 'html',
             }
         )
+        if not created:
+            box.save()

--- a/downloads/models.py
+++ b/downloads/models.py
@@ -179,13 +179,15 @@ def update_supernav():
         'last_updated': timezone.now(),
     })
 
-    box, _ = Box.objects.update_or_create(
+    box, created = Box.objects.update_or_create(
         label='supernav-python-downloads',
         defaults={
             'content': content,
             'content_markup_type': 'html',
         }
     )
+    if not created:
+        box.save()
 
 
 def update_download_landing_sources_box():
@@ -208,13 +210,15 @@ def update_download_landing_sources_box():
         return
 
     source_content = render_to_string('downloads/download-sources-box.html', context)
-    source_box, _ = Box.objects.update_or_create(
+    source_box, created = Box.objects.update_or_create(
         label='download-sources',
         defaults={
             'content': source_content,
             'content_markup_type': 'html',
         }
     )
+    if not created:
+        source_box.save()
 
 
 def update_homepage_download_box():
@@ -234,13 +238,15 @@ def update_homepage_download_box():
 
     content = render_to_string('downloads/homepage-downloads-box.html', context)
 
-    box, _ = Box.objects.update_or_create(
+    box, created = Box.objects.update_or_create(
         label='homepage-downloads',
         defaults={
             'content': content,
             'content_markup_type': 'html',
         }
     )
+    if not created:
+        box.save()
 
 
 @receiver(post_save, sender=Release)

--- a/successstories/models.py
+++ b/successstories/models.py
@@ -102,13 +102,15 @@ def update_successstories_supernav(sender, instance, created, **kwargs):
             'story': instance,
         })
 
-        box, _ = Box.objects.update_or_create(
+        box, created = Box.objects.update_or_create(
             label='supernav-python-success-stories',
             defaults={
                 'content': content,
                 'content_markup_type': 'html',
             }
         )
+        if not created:
+            box.save()
 
         # Purge Fastly cache
         purge_url('/box/supernav-python-success-stories/')


### PR DESCRIPTION
This resolves the underlying problem from #2631.

When updated via Django's [`update_or_create`](https://docs.djangoproject.com/en/4.2/ref/models/querysets/#update-or-create), the new `content` for a `Box` is not rendered by django-markupfield's [`pre_save`](https://github.com/jamesturk/django-markupfield/blob/2.0.1/markupfield/fields.py#L163-L179) method unless `save()` is called.

This is due to the fact that [`update`](https://docs.djangoproject.com/en/4.2/ref/models/querysets/#django.db.models.query.QuerySet.update) bypasses calls to `save`, `pre_save`, and `post_save`, from the docs:

> Finally, realize that update() does an update at the SQL level and, thus, does not call any save() methods on your models, nor does it emit the pre_save or post_save signals (which are a consequence of calling Model.save())
