### PR TITLE
Default primary contact field to True for first contact

### DIFF
--- a/sponsors/forms.py
+++ b/sponsors/forms.py
@@ -54,10 +54,6 @@ SponsorContactFormSet = forms.formset_factory(
     max_num=5,
 )
 
-formset = SponsorContactFormSet(
-    initial=[{"primary": True}]
-)
-
 
 class SponsorshipsBenefitsForm(forms.Form):
     """

--- a/sponsors/forms.py
+++ b/sponsors/forms.py
@@ -54,6 +54,10 @@ SponsorContactFormSet = forms.formset_factory(
     max_num=5,
 )
 
+formset = SponsorContactFormSet(
+    initial=[{"primary": True}]
+)
+
 
 class SponsorshipsBenefitsForm(forms.Form):
     """
@@ -285,7 +289,10 @@ class SponsorshipApplicationForm(forms.Form):
         if self.data:
             self.contacts_formset = SponsorContactFormSet(self.data, **formset_kwargs)
         else:
-            self.contacts_formset = SponsorContactFormSet(**formset_kwargs)
+            self.contacts_formset = SponsorContactFormSet(
+                initial=[{"primary": True}],
+                **formset_kwargs
+            )
 
     def clean(self):
         cleaned_data = super().clean()

--- a/sponsors/tests/test_forms.py
+++ b/sponsors/tests/test_forms.py
@@ -534,6 +534,15 @@ class SponsorshipApplicationFormTests(TestCase):
         msg = "You have to mark at least one contact as the primary one."
         self.assertIn(msg, form.errors["__all__"])
 
+    def test_initial_primary_contact(self):
+        form = SponsorshipApplicationForm()
+        formset = form.contacts_formset
+
+        self.assertTrue(
+            formset.forms[0].initial.get("primary"),
+            "The primary field in the first contact form should be initially set to True."
+        )
+
 
 class SponsorContactFormSetTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
Set the initial `primary` contact value to `True` in the form, ensuring only the first contact is marked as primary. All additional contact forms added will default to `False`. Form validation remains unchanged in the event that the `primary` field is unchecked by the user.

Closes #2610


