### PR TITLE
disable logging to datadog by default

### DIFF
--- a/infra/cdn/main.tf
+++ b/infra/cdn/main.tf
@@ -136,6 +136,12 @@ resource "fastly_service_vcl" "python_org" {
     statement = "req.http.host == \"python.org\""
     type      = "REQUEST"
   }
+  condition {
+    name      = "False"
+    priority  = 10
+    statement = "false"
+    type      = "RESPONSE"
+  }
 
   condition {
     name      = "Don't cache 404s for /static"
@@ -262,9 +268,10 @@ resource "fastly_service_vcl" "python_org" {
   }
 
   logging_datadog {
-    name   = "ratelimit-debug"
-    token  = var.datadog_key
-    region = "US"
+    name               = "ratelimit-debug"
+    token              = var.datadog_key
+    region             = "US"
+    response_condition = "False"
   }
 
   logging_s3 {
@@ -361,7 +368,7 @@ resource "fastly_service_vcl" "python_org" {
   dynamic "dictionary" {
     for_each = var.activate_ngwaf_service ? [1] : []
     content {
-      name = var.edge_security_dictionary
+      name          = var.edge_security_dictionary
       force_destroy = true
     }
   }

--- a/infra/cdn/main.tf
+++ b/infra/cdn/main.tf
@@ -137,7 +137,7 @@ resource "fastly_service_vcl" "python_org" {
     type      = "REQUEST"
   }
   condition {
-    name      = "False"
+    name      = "Always False"
     priority  = 10
     statement = "false"
     type      = "RESPONSE"
@@ -271,7 +271,7 @@ resource "fastly_service_vcl" "python_org" {
     name               = "ratelimit-debug"
     token              = var.datadog_key
     region             = "US"
-    response_condition = "False"
+    response_condition = "Always False"
   }
 
   logging_s3 {


### PR DESCRIPTION
Resolves #2651. Determined by downloading the VCL for current service version and the version active before #2519.

I think this is a result of a bit of an inconsistency in how rate limiting is configured in the UI vs terraform. The log statement is [added by default to `vcl_log` routine](https://gist.github.com/ewdurbin/bacc8b9be7cf9a736885549d94c73c21#file-141-154-diff-L53-L71).

This should disable logging by default, and only be called in the rate limit section.