### PR TITLE
Hide GPG column if no GPG signatures in release

### DIFF
--- a/downloads/templatetags/download_tags.py
+++ b/downloads/templatetags/download_tags.py
@@ -9,6 +9,11 @@ def strip_minor_version(version):
 
 
 @register.filter
+def has_gpg(files: list) -> bool:
+    return any(f.gpg_signature_file for f in files)
+
+
+@register.filter
 def has_sigstore_materials(files):
     return any(
         f.sigstore_bundle_file or f.sigstore_cert_file or f.sigstore_signature_file

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load boxes %}
 {% load sitetree %}
+{% load has_gpg from download_tags %}
 {% load has_sigstore_materials from download_tags %}
 {% load has_sbom from download_tags %}
 {% load sort_windows from download_tags %}
@@ -51,7 +52,9 @@
               <th>Description</th>
               <th>MD5 Sum</th>
               <th>File Size</th>
+              {% if release_files|has_gpg %}
               <th>GPG</th>
+              {% endif %}
               {% if release_files|has_sigstore_materials %}
               <th colspan="2"><a href="https://www.python.org/download/sigstore/">Sigstore</a></th>
               {% endif %}
@@ -68,7 +71,9 @@
                 <td>{{ f.description }}</td>
                 <td>{{ f.md5_sum }}</td>
                 <td>{{ f.filesize|filesizeformat }}</td>
+                {% if release_files|has_gpg %}
                 <td>{% if f.gpg_signature_file %}<a href="{{ f.gpg_signature_file }}">SIG</a>{% endif %}</td>
+                {% endif %}
                 {% if release_files|has_sigstore_materials %}
                   {% if f.sigstore_bundle_file %}
                   <td colspan="2">{% if f.sigstore_bundle_file %}<a href="{{ f.sigstore_bundle_file}}">.sigstore</a>{% endif %}</td>


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

[PEP 761](https://peps.python.org/pep-0761/) ("Deprecating PGP signatures for CPython artifacts") has been accepted and means we will no longer provide PGP signatures for Python 3.14 and later. Verifiers are recommended to use Sigstore instead.

Let's hide the GPG column from the download page's files table when there are no such files in the release.

I considered hiding the column when the version `>= (3, 14)`, but went for this approach because it will also hide the column for very old releases which don't have GPG files, such as https://www.python.org/downloads/release/python-201/, which I think is also useful?

cc @sethmlarson 

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

