### PR TITLE
Fix code prompt in Fibonacci example

### DIFF
--- a/codesamples/factories.py
+++ b/codesamples/factories.py
@@ -122,11 +122,12 @@ def initial_data():
             <code>
             <span class=\"comment\"># Write Fibonacci series up to n</span>
             >>> def fib(n):
-            >>>     a, b = 0, 1
-            >>>     while a &lt; n:
-            >>>         print(a, end=' ')
-            >>>         a, b = b, a+b
-            >>>     print()
+            ...     a, b = 0, 1
+            ...     while a &lt; n:
+            ...         print(a, end=' ')
+            ...         a, b = b, a+b
+            ...     print()
+            ...
             >>> fib(1000)
             <span class=\"output\">0 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610</span>
             </code>


### PR DESCRIPTION
The fibonacci example, uses the wrong code prompt for a multiline snippet, it should be `...`.