### PR TITLE
Update `urls.py` for `blogs` app

### DIFF
--- a/blogs/urls.py
+++ b/blogs/urls.py
@@ -1,6 +1,9 @@
 from . import views
-from django.urls import path
+from django.urls import path, re_path
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
     path('', views.BlogHome.as_view(), name='blog'),
+    # Redirect all requests from pythoninsider.blogspot.com to blog.python.org
+    re_path(r'^(?P<path>.*)$', RedirectView.as_view(url='https://blog.python.org/%(path)s', permanent=True)),
 ]


### PR DESCRIPTION
Fixes:  #2662
Redirect pythoninsider.blogspot.com to blog.python.org and other permalinks as well.
