### PR TITLE
feat(dev): emit descriptions for commands in help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,5 @@ test: .state/db-initialized ## Run tests
 
 docker_shell: .state/db-initialized ## Open a bash shell in the web container
 	docker compose run --rm web /bin/bash
+
+.PHONY: help serve migrations migrate manage shell clean test docker_shell

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
-default: 
+help:
 	@echo "Call a specific subcommand:"
 	@echo
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null\
-        | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}'\
-        | sort\
-        | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 	@echo
-	@exit 1
+
+default: help
 
 .state/docker-build-web: Dockerfile dev-requirements.txt base-requirements.txt
 	# Build web container for this project
@@ -29,30 +28,27 @@ default:
 	# Mark the state so we don't rebuild this needlessly.
 	mkdir -p .state && touch .state/db-initialized
 
-serve: .state/db-initialized
+serve: .state/db-initialized ## Start the application
 	docker compose up --remove-orphans
 
-migrations: .state/db-initialized 
-	# Run Django makemigrations
+migrations: .state/db-initialized ## Generate migrations from models
 	docker compose run --rm web ./manage.py makemigrations  
 	
-migrate: .state/docker-build-web
-	# Run Django migrate
+migrate: .state/docker-build-web ## Run Django migrate
 	docker compose run --rm web ./manage.py migrate 
 
-manage: .state/db-initialized
-	# Run Django manage to accept arbitrary arguments
+manage: .state/db-initialized ## Run Django manage to accept arbitrary arguments
 	docker compose run --rm web ./manage.py $(filter-out $@,$(MAKECMDGOALS))
 
-shell: .state/db-initialized 
+shell: .state/db-initialized ## Open Django interactive shell
 	docker compose run --rm web ./manage.py shell
 
-clean:
+clean: ## Clean up the environment
 	docker compose down -v
 	rm -f .state/docker-build-web .state/db-initialized .state/db-migrated 
 
-test: .state/db-initialized
+test: .state/db-initialized ## Run tests
 	docker compose run --rm web ./manage.py test
 
-docker_shell: .state/db-initialized
+docker_shell: .state/db-initialized ## Open a bash shell in the web container
 	docker compose run --rm web /bin/bash


### PR DESCRIPTION
#### Description

Help the developer understand what each target (subcommand) does.

Now looks like:

```shellsession
$ make
Call a specific subcommand:

serve                          Start the application
migrations                     Generate migrations from models
migrate                        Run Django migrate
manage                         Run Django manage to accept arbitrary arguments
shell                          Open Django interactive shell
clean                          Clean up the environment
test                           Run tests
docker_shell                   Open a bash shell in the web container
```