### PR TITLE
fix: return an empty profile page when not found

### DIFF
--- a/templates/users/user_detail.html
+++ b/templates/users/user_detail.html
@@ -1,7 +1,7 @@
 {% extends "users/base.html" %}
 {% load users_tags %}
 
-{% block page_title %}{% firstof object.get_full_name object %} | Our Users &amp; Members | {{ SITE_INFO.site_name }}{% endblock %}
+{% block page_title %}Our Users &amp; Members | {{ SITE_INFO.site_name }}{% endblock %}
 
 {% block body_attributes %}class="psf users default-page"{% endblock %}
 

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -149,15 +149,15 @@ class UsersViewsTestCase(TestCase):
         profile_url = reverse('users:user_detail', kwargs={'slug': 'username'})
         self.assertRedirects(response, profile_url)
 
-        # should return 404 for another user
+        # should return 200 for another user
         another_user_url = reverse('users:user_detail', kwargs={'slug': 'spameggs'})
         response = self.client.get(another_user_url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
 
-        # should return 404 if the user is not logged-in
+        # should return 200 if the user is not logged-in
         self.client.logout()
         response = self.client.get(profile_url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
 
     def test_user_detail(self):
         # Ensure detail page is viewable without login, but that edit URLs
@@ -184,7 +184,7 @@ class UsersViewsTestCase(TestCase):
         self.assertFalse(user.is_active)
         detail_url = reverse('users:user_detail', kwargs={'slug': user.username})
         response = self.client.get(detail_url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
 
     def test_special_usernames(self):
         # Ensure usernames in the forms of:

--- a/users/views.py
+++ b/users/views.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.contrib.auth.models import AnonymousUser
 from django.conf import settings
 from django.core.mail import send_mail
 from django.db.models import Subquery
@@ -126,12 +127,19 @@ class UserUpdate(LoginRequiredMixin, UpdateView):
 
 class UserDetail(DetailView):
     slug_field = 'username'
+    template_name = 'users/user_detail.html'
 
     def get_queryset(self):
         queryset = User.objects.select_related()
         if self.request.user.username == self.kwargs['slug']:
             return queryset
         return queryset.searchable()
+
+    def get_object(self, queryset=None):
+        try:
+            return super().get_object(queryset)
+        except Http404:
+            return AnonymousUser()
 
 
 class HoneypotSignupView(SignupView):


### PR DESCRIPTION
#### Description

Return an identical empty page to prevent user enumeration.
