### PR TITLE
remove google analytics and plausible.io

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,17 +5,7 @@
 <!--[if gt IE 8]><!--><html class="no-js" lang="en" dir="ltr">  <!--<![endif]-->
 {% load pipeline sitetree %}
 <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TF35YF9CVH"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-TF35YF9CVH');
-    </script>
-    <!-- Plausible.io analytics -->
-    <script defer data-domain="python.org" src="https://plausible.io/js/script.js"></script>
-    <script defer data-domain="python.org" src="https://analytics.python.org/js/script.js"></script>
+    <script defer data-domain="python.org" src="https://analytics.python.org/js/script.outbound-links.js"></script>
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
we're going to be migrating to self-hosted plausbile entirely now.

drop plausible.io script, and enable outbound links on analytics.python.org