### PR TITLE
Hide releases from Downloads page when they have no files to download

### DIFF
--- a/templates/downloads/os_list.html
+++ b/templates/downloads/os_list.html
@@ -40,6 +40,7 @@
                 <h2>Stable Releases</h2>
                 <ul>
                     {% for r in releases %}
+                    {% if r.files.all %}
                     <li>
                         <a href="{{ r.get_absolute_url }}">{{ r.name }} - {{ r.release_date|date }}</a>
                         {% if os.slug == 'windows' %}
@@ -63,6 +64,7 @@
                             {% endfor %}
                         </ul>
                     </li>
+                    {% endif %}
                     {% endfor %}
                 </ul>
             </div>
@@ -71,6 +73,7 @@
                 <h2>Pre-releases</h2>
                 <ul>
                     {% for r in pre_releases %}
+                    {% if r.files.all %}
                     <li>
                         <a href="{{ r.get_absolute_url }}">{{ r.name }} - {{ r.release_date|date }}</a>
                         <ul>
@@ -81,6 +84,7 @@
                             {% endfor %}
                         </ul>
                     </li>
+                    {% endif %}
                     {% endfor %}
                 </ul>
             </div>


### PR DESCRIPTION
The problem is most obvious on [the macOS page](https://www.python.org/downloads/macos/), which has a lot of releases listed with no files. For a _downloads_ page, it looks a bit silly.

Most critically, this should hide the Python install manager releases from macOS and Source pages, as it will have no files. An alternative would be to hard-code its ID into the templates, but this way seemed better.

There might be a better way to check if there are no files, I'm not sure. And yes, this makes the `{% empty %}` blocks redundant, but they're also harmless, and if this check is ever changed at least the page will still work.