### PR TITLE
Do not accept nominations for elections before they open

### DIFF
--- a/nominations/views.py
+++ b/nominations/views.py
@@ -89,6 +89,11 @@ class NominationCreate(LoginRequiredMixin, NominationMixin, CreateView):
                 self.request, f"Nominations for {election.name} Election are closed"
             )
             raise Http404(f"Nominations for {election.name} Election are closed")
+        if not election.nominations_open:
+            messages.error(
+                self.request, f"Nominations for {election.name} Election are not open"
+            )
+            raise Http404(f"Nominations for {election.name} Election are not open")
 
         return NominationCreateForm
 


### PR DESCRIPTION
Previously nominations would be open as soon as the election is created an admin this allows, the election to be created and publicized, but not except nominations until the set date