### PR TITLE
fix: inject context for events

### DIFF
--- a/events/tests/test_views.py
+++ b/events/tests/test_views.py
@@ -116,6 +116,8 @@ class EventsViewsTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['object_list']), 6)
+        self.assertIn('upcoming_events', response.context)
+        self.assertEqual(list(response.context['upcoming_events']), list(response.context['object_list']))
 
         url = reverse('events:event_list_past', kwargs={"calendar_slug": 'unexisting'})
         response = self.client.get(url)

--- a/events/views.py
+++ b/events/views.py
@@ -87,6 +87,7 @@ class EventList(EventListBase):
         context['events_today'] = Event.objects.until_datetime(timezone.now()).filter(
             calendar__slug=self.kwargs['calendar_slug'])[:2]
         context['calendar'] = get_object_or_404(Calendar, slug=self.kwargs['calendar_slug'])
+        context['upcoming_events'] = self.get_queryset()
         return context
 
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Injects upcoming events to show for calendars

<details>
<summary>Details</summary>


before
<img width="939" height="345" alt="image" src="https://github.com/user-attachments/assets/01997bba-783a-4d78-a760-bc95a8d80eb1" />

after
<img width="1073" height="568" alt="image" src="https://github.com/user-attachments/assets/1b84ce02-855e-4913-8646-08646deb5fa3" />


</details>

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Closes

- Fixes #2632

