### PR TITLE
Fix OrderedModelManager warnings in Sponsorship models (#2743)

### DIFF
--- a/sponsors/models/sponsorship.py
+++ b/sponsors/models/sponsorship.py
@@ -17,7 +17,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from num2words import num2words
 
-from ordered_model.models import OrderedModel
+from ordered_model.models import OrderedModel, OrderedModelManager
 
 from sponsors.exceptions import SponsorWithExistingApplicationException, InvalidStatusException, \
     SponsorshipInvalidDateRangeException
@@ -37,7 +37,7 @@ class SponsorshipPackage(OrderedModel):
     """
     Represent default packages of benefits (visionary, sustainability etc)
     """
-    objects = SponsorshipPackageQuerySet.as_manager()
+    objects = OrderedModelManager.from_queryset(SponsorshipPackageQuerySet)()
 
     name = models.CharField(max_length=64)
     sponsorship_amount = models.PositiveIntegerField()
@@ -408,7 +408,7 @@ class SponsorshipBenefit(OrderedModel):
     package and program.
     """
 
-    objects = SponsorshipBenefitQuerySet.as_manager()
+    objects = OrderedModelManager.from_queryset(SponsorshipBenefitQuerySet)()
 
     # Public facing
     name = models.CharField(


### PR DESCRIPTION
## Overview

This PR resolves the warning `(ordered_model.W003)` for both `SponsorshipBenefit` and `SponsorshipPackage` models. These models subclass `OrderedModel` but were previously using managers that did not inherit from `OrderedModelManager`.

## Changes Made

- Updated `SponsorshipPackage` to use `OrderedModelManager.from_queryset(SponsorshipPackageQuerySet)()`
- Updated `SponsorshipBenefit` to use `OrderedModelManager.from_queryset(SponsorshipBenefitQuerySet)()`
- Added necessary import for `OrderedModelManager`

## Why This Fixes the Warning

Using `.as_manager()` does not ensure that the resulting manager inherits from `OrderedModelManager`, even if the queryset does. Using `.from_queryset()` ensures the manager inherits from `OrderedModelManager` while preserving custom queryset functionality.

Fixes #2743