### PR TITLE
Add Android release support

### DIFF
--- a/fixtures/sitetree_menus.json
+++ b/fixtures/sitetree_menus.json
@@ -507,7 +507,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": 8,
-        "sort_order": 23,
+        "sort_order": 24,
         "access_permissions": []
     }
 },
@@ -531,7 +531,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": 8,
-        "sort_order": 24,
+        "sort_order": 25,
         "access_permissions": []
     }
 },
@@ -2740,6 +2740,30 @@
         "access_perm_type": 1,
         "parent": 122,
         "sort_order": 123,
+        "access_permissions": []
+    }
+},
+{
+    "model": "sitetree.treeitem",
+    "pk": 124,
+    "fields": {
+        "title": "Android",
+        "hint": "",
+        "url": "/downloads/android/",
+        "urlaspattern": false,
+        "tree": 1,
+        "hidden": false,
+        "alias": null,
+        "description": "",
+        "inmenu": true,
+        "inbreadcrumbs": true,
+        "insitetree": true,
+        "access_loggedin": false,
+        "access_guest": false,
+        "access_restricted": false,
+        "access_perm_type": 1,
+        "parent": 8,
+        "sort_order": 23,
         "access_permissions": []
     }
 }

--- a/templates/downloads/os_list.html
+++ b/templates/downloads/os_list.html
@@ -37,7 +37,7 @@
         </ul>
 
         {% if os.slug == 'android' %}
-        <p>Rather than using these packages directly, in most cases you should use one of the tools recommended in the <a href="https://docs.python.org/3/using/android.html">Python documentation</a>.</p> 
+        <p>Rather than using these packages directly, in most cases you should use one of the tools recommended in the <a href="https://docs.python.org/3/using/android.html">Python documentation</a>.</p>
         {% endif %}
 
         <div class="col-row two-col">

--- a/templates/downloads/os_list.html
+++ b/templates/downloads/os_list.html
@@ -35,6 +35,11 @@
 
             <li><a href="{{ latest_python3.get_absolute_url }}">Latest Python 3 Release - {{ latest_python3.name }}</a></li>
         </ul>
+
+        {% if os.slug == 'android' %}
+        <p>Rather than using these packages directly, in most cases you should use one of the tools recommended in the <a href="https://docs.python.org/3/using/android.html">Python documentation</a>.</p>
+        {% endif %}
+
         <div class="col-row two-col">
             <div class="column">
                 <h2>Stable Releases</h2>

--- a/templates/downloads/os_list.html
+++ b/templates/downloads/os_list.html
@@ -37,7 +37,7 @@
         </ul>
 
         {% if os.slug == 'android' %}
-        <p>Rather than using these packages directly, in most cases you should use one of the tools recommended in the <a href="https://docs.python.org/3/using/android.html">Python documentation</a>.</p>
+        <p>Rather than using these packages directly, in most cases you should use one of the tools recommended in the <a href="https://docs.python.org/3/using/android.html">Python documentation</a>.</p> 
         {% endif %}
 
         <div class="col-row two-col">


### PR DESCRIPTION
See the linked issue for details:
* https://github.com/python/cpython/issues/137242

This PR can be deployed any time before the first release that includes Android binaries. Then, during that release, someone with access to the admin interface will have to make the following changes:

* Under Downloads / Operating Systems, add an entry for Android.
* Under Site Trees, add a Downloads menu item for Android.
* Remove the Android section from Downloads / Other Platforms, since this will now be covered by the paragraph at the top of os_list.html.

For testing purposes, the fixtures have been updated to include the database changes, and to include a copy of the 3.14.0rc1 release with Android added. This was generated with the add_to_pydotorg.py script from https://github.com/python/release-tools/pull/265.

Here's what it looks like:

<img width="638" height="374" alt="Screenshot 2025-08-06 at 23 33 33" src="https://github.com/user-attachments/assets/f13d2054-20e0-4ce9-b359-8098ca0e8bbe" />

<img width="1232" height="718" alt="Screenshot 2025-08-06 at 23 35 04" src="https://github.com/user-attachments/assets/9cde2f91-747f-48b0-b898-75b158007f42" />

<img width="1232" height="1087" alt="Screenshot 2025-08-06 at 23 34 34" src="https://github.com/user-attachments/assets/979eb76f-b119-4d81-b636-4e754c975348" />

