### PR TITLE
Link 'GPG' in downloads table to more info

### DIFF
--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -53,7 +53,7 @@
               <th>MD5 Sum</th>
               <th>File Size</th>
               {% if release_files|has_gpg %}
-              <th>GPG</th>
+              <th><a href="https://www.python.org/downloads/#gpg">GPG</a></th>
               {% endif %}
               {% if release_files|has_sigstore_materials %}
               <th colspan="2"><a href="https://www.python.org/download/sigstore/">Sigstore</a></th>


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

Looking at a page like https://www.python.org/downloads/release/python-3122/ we have links from "Sigstore" and "SBOM" to relevant pages with more info, but nothing for "GPG":

<img width="2368" height="786" alt="image" src="https://github.com/user-attachments/assets/38b7c0f0-48e4-43c2-a8c2-240e1435bf14" />

This PR adds a link from "GPG" to https://www.python.org/downloads/#gpg

I also edited the relevant box of https://www.python.org/downloads/ (it's this one https://www.python.org/admin/boxes/box/57/change/) to add `id="gpg"` to the relevant `<h4>` so we can link directly.

And I also added anchors to the others in that section:

* https://www.python.org/downloads/#sigstore
* https://www.python.org/downloads/#windows
* https://www.python.org/downloads/#macos


<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes python/cpython#4321 or Closes python/cpython#1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Closes

- Fixes https://github.com/python/pythondotorg/issues/2774.

