### PR TITLE
Fixed Language chooser middleware warning during tests

### DIFF
--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -157,7 +157,6 @@ FORM_RENDERER = 'django.forms.renderers.DjangoTemplates'
 
 ROOT_URLCONF = 'pydotorg.urls'
 
-
 # Note that we don't need to activate 'XFrameOptionsMiddleware' and
 # 'SecurityMiddleware' because we set appropriate headers in python/psf-salt.
 MIDDLEWARE = [

--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -157,6 +157,7 @@ FORM_RENDERER = 'django.forms.renderers.DjangoTemplates'
 
 ROOT_URLCONF = 'pydotorg.urls'
 
+
 # Note that we don't need to activate 'XFrameOptionsMiddleware' and
 # 'SecurityMiddleware' because we set appropriate headers in python/psf-salt.
 MIDDLEWARE = [
@@ -172,6 +173,7 @@ MIDDLEWARE = [
     'pages.middleware.PageFallbackMiddleware',
     'django.contrib.redirects.middleware.RedirectFallbackMiddleware',
     'allauth.account.middleware.AccountMiddleware',
+	'django.middleware.locale.LocaleMiddleware'
 ]
 
 AUTH_USER_MODEL = 'users.User'

--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -73,6 +73,9 @@ urlpatterns = [
 
     # storage migration
     re_path(r'^m/(?P<url>.*)/$', views.MediaMigrationView.as_view(prefix='media'), name='media_migration_view'),
+
+    # i18n
+    path('i18n/', include('django.conf.urls.i18n')),
 ]
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description
Resolves the language chooser non-breaking warnings by:
1. Adding missing library to the base MIDDLEWARE.
2. Adding missing url path to root urls file.

fixes #2742  

