### PR TITLE
fix(Frontend): Fixed Issue #1433 "Wrong arrow when select Community" 

### DIFF
--- a/templates/community/post_detail.html
+++ b/templates/community/post_detail.html
@@ -3,7 +3,7 @@
 {% block page_title %}{{ object.title }} | {{ SITE_INFO.site_name }}{% endblock %}
 {% block og_title %}{{ object.title }}{% endblock %}
 
-{% block body_attributes %}class="python community default-page"{% endblock %}
+{% block body_attributes %}class="shop community default-page"{% endblock %}
 
 
 {% block main-nav_attributes %}community-navigation{% endblock main-nav_attributes %}

--- a/templates/community/post_list.html
+++ b/templates/community/post_list.html
@@ -5,7 +5,7 @@
 {% block page_title %}Our Community | {{ SITE_INFO.site_name }}{% endblock %}
 {% block og_title %}Our Community{% endblock %}
 
-{% block body_attributes %}class="python community"{% endblock %}
+{% block body_attributes %}class="shop"{% endblock %}
 
 
 {% block main-nav_attributes %}python-navigation{% endblock main-nav_attributes %}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
This pull request addresses the issue #1433 "Wrong arrow when select Comunity"

#### Issue Raised: 
- Wrong Link is highlighted in the main menu when in the community page.

#### Changes made: 
- Changed the class name of the body element tag in the "post_list.html" file related to the community page

Fixes #1433 

