### PR TITLE
Prioritise Sigstore over GPG in downloads table

### DIFF
--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -52,14 +52,14 @@
               <th>Description</th>
               <th>MD5 Sum</th>
               <th>File Size</th>
-              {% if release_files|has_gpg %}
-              <th><a href="https://www.python.org/downloads/#gpg">GPG</a></th>
-              {% endif %}
               {% if release_files|has_sigstore_materials %}
               <th colspan="2"><a href="https://www.python.org/download/sigstore/">Sigstore</a></th>
               {% endif %}
               {% if release_files|has_sbom %}
               <th><a href="https://www.python.org/download/sbom/">SBOM</a></th>
+              {% endif %}
+              {% if release_files|has_gpg %}
+              <th><a href="https://www.python.org/downloads/#gpg">GPG</a></th>
               {% endif %}
             </tr>
           </thead>
@@ -71,9 +71,6 @@
                 <td>{{ f.description }}</td>
                 <td>{{ f.md5_sum }}</td>
                 <td>{{ f.filesize|filesizeformat }}</td>
-                {% if release_files|has_gpg %}
-                <td>{% if f.gpg_signature_file %}<a href="{{ f.gpg_signature_file }}">SIG</a>{% endif %}</td>
-                {% endif %}
                 {% if release_files|has_sigstore_materials %}
                   {% if f.sigstore_bundle_file %}
                   <td colspan="2">{% if f.sigstore_bundle_file %}<a href="{{ f.sigstore_bundle_file}}">.sigstore</a>{% endif %}</td>
@@ -84,6 +81,9 @@
                 {% endif %}
                 {% if release_files|has_sbom %}
                   <td>{% if f.sbom_spdx2_file %}<a href="{{ f.sbom_spdx2_file }}">SPDX</a>{% endif %}</td>
+                {% endif %}
+                {% if release_files|has_gpg %}
+                <td>{% if f.gpg_signature_file %}<a href="{{ f.gpg_signature_file }}">SIG</a>{% endif %}</td>
                 {% endif %}
               </tr>
             {% endfor %}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Prioritise Sigstore and SBOM over GPG in the downloads table

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Closes https://github.com/python/pythondotorg/issues/2463


