### PR TITLE
remove all feedburner urls, ref #2787

### DIFF
--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -278,7 +278,7 @@ HONEYPOT_FIELD_NAME = 'email_body_text'
 HONEYPOT_VALUE = 'write your message'
 
 ### Blog Feed URL
-PYTHON_BLOG_FEED_URL = "https://feeds.feedburner.com/PythonInsider"
+PYTHON_BLOG_FEED_URL = "https://blog.python.org/feeds/posts/default?alt=rss"
 PYTHON_BLOG_URL = "https://blog.python.org"
 
 ### Registration mailing lists

--- a/templates/base.html
+++ b/templates/base.html
@@ -84,9 +84,9 @@
     <link rel="alternate" type="application/rss+xml" title="Python Job Opportunities"
           href="https://www.python.org/jobs/feed/rss/">
     <link rel="alternate" type="application/rss+xml" title="Python Software Foundation News"
-          href="https://feeds.feedburner.com/PythonSoftwareFoundationNews">
+          href="https://pyfound.blogspot.com/feeds/posts/default?alt=rss">
     <link rel="alternate" type="application/rss+xml" title="Python Insider"
-          href="https://feeds.feedburner.com/PythonInsider">
+          href="https://blog.python.org/feeds/posts/default?alt=rss">
    <link rel="alternate" type="application/rss+xml" title="Python Releases"
          href="https://www.python.org/downloads/feed.rss">
 


### PR DESCRIPTION
See issue, summary is:

> the user who owned/managed the FeedBurner URLs has either been compromised or deleted their account.