### PR TITLE
fix: handle release objects with 'invalid' names

### DIFF
--- a/downloads/models.py
+++ b/downloads/models.py
@@ -128,8 +128,11 @@ class Release(ContentManageable, NameSlugModel):
         return None
 
     def is_version_at_least(self, min_version_tuple):
+        version = self.get_version()
+        if version is None:
+            return False
         v1 = []
-        for b in self.get_version().split('.'):
+        for b in version.split('.'):
             try:
                 v1.append(int(b))
             except ValueError:

--- a/downloads/models.py
+++ b/downloads/models.py
@@ -125,14 +125,11 @@ class Release(ContentManageable, NameSlugModel):
         version = re.match(r'Python\s([\d.]+)', self.name)
         if version is not None:
             return version.group(1)
-        return None
+        return ""
 
     def is_version_at_least(self, min_version_tuple):
-        version = self.get_version()
-        if version is None:
-            return False
         v1 = []
-        for b in version.split('.'):
+        for b in self.get_version().split('.'):
             try:
                 v1.append(int(b))
             except ValueError:
@@ -294,7 +291,7 @@ def purge_fastly_download_pages(sender, instance, **kwargs):
         purge_url('/downloads/source/')
         purge_url('/downloads/windows/')
         purge_url('/ftp/python/')
-        if instance.get_version() is not None:
+        if instance.get_version():
             purge_url(f'/ftp/python/{instance.get_version()}/')
         # See issue #584 for details
         purge_url('/box/supernav-python-downloads/')

--- a/downloads/tests/test_models.py
+++ b/downloads/tests/test_models.py
@@ -74,7 +74,7 @@ class DownloadModelTests(BaseDownloadTests):
             with self.subTest(name=name):
                 release = Release.objects.create(name=name)
                 self.assertEqual(release.name, name)
-                self.assertIsNone(release.get_version())
+                self.assertEqual(release.get_version(), "")
 
     def test_is_version_at_least(self):
         self.assertFalse(self.release_275.is_version_at_least_3_5)

--- a/downloads/tests/test_models.py
+++ b/downloads/tests/test_models.py
@@ -87,3 +87,11 @@ class DownloadModelTests(BaseDownloadTests):
         release_310 = Release.objects.create(name='Python 3.10.0')
         self.assertTrue(release_310.is_version_at_least_3_9)
         self.assertTrue(release_310.is_version_at_least_3_5)
+
+    def test_is_version_at_least_with_invalid_name(self):
+        """Test that is_version_at_least returns False for releases with invalid names"""
+        invalid_release = Release.objects.create(name='Python install manager')
+        # Should return False instead of raising AttributeError
+        self.assertFalse(invalid_release.is_version_at_least_3_5)
+        self.assertFalse(invalid_release.is_version_at_least_3_9)
+        self.assertFalse(invalid_release.is_version_at_least_3_14)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Fixes issue with `/downloads/windows` when trying to parse a non-standard relase object version 