### PR TITLE
Add featured downloads

### DIFF
--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -2113,6 +2113,50 @@ table tfoot {
 .download-widget p:last-child a {
   white-space: nowrap; }
 
+.featured-downloads-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5em;
+  justify-content: center;
+  margin-bottom: 2em; }
+
+.featured-download-box {
+  background-color: #f2f4f6;
+  border: 1px solid #caccce;
+  border-radius: 5px;
+  display: flex;
+  flex: 1 1 300px;
+  flex-direction: column;
+  min-width: 250px;
+  max-width: 400px;
+  padding: 1.25em; }
+  .featured-download-box h3 {
+    margin-top: 0; }
+  .featured-download-box .button {
+    background-color: #ffd343;
+    *zoom: 1;
+    filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFDF76', endColorstr='#FFFFD343');
+    background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffdf76), color-stop(90%, #ffd343));
+    background-image: -webkit-linear-gradient(#ffdf76 10%, #ffd343 90%);
+    background-image: -moz-linear-gradient(#ffdf76 10%, #ffd343 90%);
+    background-image: -o-linear-gradient(#ffdf76 10%, #ffd343 90%);
+    background-image: linear-gradient(#ffdf76 10%, #ffd343 90%);
+    border: 1px solid #dca900;
+    white-space: normal; }
+    .featured-download-box .button:hover, .featured-download-box .button:active {
+      background-color: inherit;
+      background-color: #ffd343;
+      *zoom: 1;
+      filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFEBA9', endColorstr='#FFFFD343');
+      background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(10%, #ffeba9), color-stop(90%, #ffd343));
+      background-image: -webkit-linear-gradient(#ffeba9 10%, #ffd343 90%);
+      background-image: -moz-linear-gradient(#ffeba9 10%, #ffd343 90%);
+      background-image: -o-linear-gradient(#ffeba9 10%, #ffd343 90%);
+      background-image: linear-gradient(#ffeba9 10%, #ffd343 90%); }
+  .featured-download-box .download-buttons {
+    margin-bottom: 0;
+    text-align: center; }
+
 .time-posted {
   display: block;
   font-size: 0.875em;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1098,6 +1098,46 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
     p:last-child a { white-space: nowrap; }
 }
 
+.featured-downloads-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5em;
+    justify-content: center;
+    margin-bottom: 2em;
+}
+
+.featured-download-box {
+    background-color: $grey-lighterest;
+    border: 1px solid $default-border-color;
+    border-radius: 5px;
+    display: flex;
+    flex: 1 1 300px;
+    flex-direction: column;
+    min-width: 250px;
+    max-width: 400px;
+    padding: 1.25em;
+
+    h3 {
+        margin-top: 0;
+    }
+
+    .button {
+        @include vertical-gradient( lighten($yellow, 10%), $yellow );
+        border: 1px solid darken($yellow, 20%);
+        white-space: normal;
+
+        &:hover, &:active {
+            background-color: inherit;
+            @include vertical-gradient( lighten($yellow, 20%), $yellow );
+        }
+    }
+
+    .download-buttons {
+        margin-bottom: 0;
+        text-align: center;
+    }
+}
+
 .documentation-widget { }
 
 .jobs-widget { }

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -50,7 +50,11 @@
             <div class="featured-download-box">
                 <h3>{{ f.os.name }}</h3>
                 <p class="download-buttons">
+                    {% if f.os.slug == 'windows' and latest_pymanager and release.is_version_at_least_3_5 %}
+                    <a class="button" href="https://www.python.org/downloads/latest/pymanager/">Download Python install manager</a>
+                    {% else %}
                     <a class="button" href="{{ f.url }}">Download {{ f.name }}</a>
+                    {% endif %}
                 </p>
             </div>
             {% endfor %}

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -41,8 +41,21 @@
         {% endif %}
 
         <header class="article-header">
-            <h1 class="page-title">Files</h1>
+            <h2 class="page-title">Files</h2>
         </header>
+
+        {% if featured_files %}
+        <div class="featured-downloads-list">
+            {% for f in featured_files %}
+            <div class="featured-download-box">
+                <h3>{{ f.os.name }}</h3>
+                <p class="download-buttons">
+                    <a class="button" href="{{ f.url }}">Download {{ f.name }}</a>
+                </p>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
 
         <table>
           <thead>


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- On download pages such as https://www.python.org/downloads/release/python-3140/, it's not immediately clear what to click in the big table of a dozen files.

- Let's add the most common ones as feature downloads at the top. 

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Closes https://github.com/python/pythondotorg/issues/2419

## Before

<img width="1174" height="551" alt="image" src="https://github.com/user-attachments/assets/1509662d-0b2c-49bb-8bc3-bc60615339bf" />

## After

<img width="1178" height="721" alt="image" src="https://github.com/user-attachments/assets/4aa84ebd-ddf3-4184-9840-d0016e3a7169" />

## Notes

Each "Release" object in the CMS has a number of release files. Some of these have a "Download button" boolean set, max one per OS, which is used for displaying it at https://www.python.org/downloads/:

<img width="304" height="62" alt="image" src="https://github.com/user-attachments/assets/0e64e9e4-5e50-4beb-bbb3-b451ff360a1c" />

Let's also use this flag to decide what to feature here.

(Aside: the flag is set during the release process by `download=True` in https://github.com/python/release-tools/blob/d8077eae1dcea2653775e4b3ba9f51700b354f5e/add_to_pydotorg.py#L105-L190.)

## Windows

However, for Windows, let's use the Python install manager and link to https://www.python.org/downloads/latest/pymanager/ using similar logic for the button at https://www.python.org/downloads/

That page says:

> The install manager can install versions of Python as far back as 3.5, but only supports Windows 10 operating systems (or Windows Server 2022) and later.

Re: "The install manager can install versions of Python as far back as 3.5"

So let's only show the install manager for downloads of 3.5 and later. Older ones can use the file set by the CMS. For example, for 3.4.0:

<img width="1170" height="622" alt="image" src="https://github.com/user-attachments/assets/dc03f7f2-9a5c-42cf-bc0a-ec9df1da0e4f" />

Re: "but only supports Windows 10 operating systems (or Windows Server 2022) and later"

For the purpose of this featured release for 3.5+, it's fine to cater for the common case of new Windows (especially as Win10 is EOL). The full list is right there if you need a file.

@zooba How does this sound?
