### PR TITLE
Generate page of docs by version

### DIFF
--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('getit/', include('downloads.urls', namespace='getit')),
     path('downloads/', include('downloads.urls', namespace='download')),
     path('doc/', views.DocumentationIndexView.as_view(), name='documentation'),
+    path('doc/versions2/', views.DocsByVersionView.as_view(), name='docs-versions'),
     path('blogs/', include('blogs.urls')),
     path('inner/', TemplateView.as_view(template_name="python/inner.html"), name='inner'),
 

--- a/pydotorg/views.py
+++ b/pydotorg/views.py
@@ -1,5 +1,9 @@
+import datetime as dt
 import json
 import os
+import re
+from collections import defaultdict
+
 from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 from django.views.generic.base import RedirectView, TemplateView
@@ -67,3 +71,113 @@ class MediaMigrationView(RedirectView):
             settings.AWS_STORAGE_BUCKET_NAME,
             image_path,
         ])
+
+
+class DocsByVersionView(TemplateView):
+    template_name = "python/versions.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        releases = Release.objects.filter(
+            is_published=True,
+            pre_release=False,
+        ).order_by("-release_date")
+
+        # Some releases have no documentation
+        no_docs = {"2.3.6", "2.3.7", "2.4.5", "2.4.6", "2.5.5", "2.5.6"}
+
+        # We'll group releases by major.minor version
+        version_groups = defaultdict(list)
+
+        for release in releases:
+            # Extract version number from name ("Python 3.14.0" -> "3.14.0")
+            version_match = re.match(r"Python ([\d.]+)", release.name)
+            if version_match:
+                full_version = version_match.group(1)
+
+                if full_version in no_docs:
+                    continue
+
+                # Get major.minor version ("3.14.0" -> "3.14")
+                version_parts = full_version.split(".")
+                major_minor = f"{version_parts[0]}.{version_parts[1]}"
+
+                # For 3.2.0 and earlier, use X.Y instead of X.Y.0
+                if len(version_parts) == 3:
+                    major, minor, patch = map(int, version_parts)
+                    # For versions <= 3.2.0 where patch is 0
+                    if (major, minor, patch) <= (3, 2, 0) and patch == 0:
+                        full_version = major_minor
+
+                release_data = {
+                    "stage": full_version,
+                    "date": release.release_date.replace(tzinfo=None),
+                }
+                version_groups[major_minor].append(release_data)
+
+        # Add legacy releases not in the database
+        legacy_releases_data = {
+            "2.2": [
+                {"stage": "2.2p1", "date": dt.datetime(2002, 3, 29)},
+            ],
+            "2.1": [
+                {"stage": "2.1.2", "date": dt.datetime(2002, 1, 16)},
+                {"stage": "2.1.1", "date": dt.datetime(2001, 7, 20)},
+                {"stage": "2.1", "date": dt.datetime(2001, 4, 15)},
+            ],
+            "2.0": [
+                {"stage": "2.0", "date": dt.datetime(2000, 10, 16)},
+            ],
+            "1.6": [
+                {"stage": "1.6", "date": dt.datetime(2000, 9, 5)},
+            ],
+            "1.5": [
+                {"stage": "1.5.2p2", "date": dt.datetime(2000, 3, 22)},
+                {"stage": "1.5.2p1", "date": dt.datetime(1999, 7, 6)},
+                {"stage": "1.5.2", "date": dt.datetime(1999, 4, 30)},
+                {"stage": "1.5.1p1", "date": dt.datetime(1998, 8, 6)},
+                {"stage": "1.5.1", "date": dt.datetime(1998, 4, 14)},
+                {"stage": "1.5", "date": dt.datetime(1998, 2, 17)},
+            ],
+            "1.4": [
+                {"stage": "1.4", "date": dt.datetime(1996, 10, 25)},
+            ],
+        }
+
+        # Merge legacy releases in
+        for version, items in legacy_releases_data.items():
+            version_groups[version].extend(items)
+
+        # Convert to list for template and sort releases within each version
+        version_list = []
+        for version, releases in version_groups.items():
+            # Sort x.y.z newest first
+            releases = sorted(
+                releases,
+                key=lambda x: x.get("date", dt.datetime.min),
+                reverse=True,
+            )
+            for release in releases:
+                release["date"] = release["date"].strftime("%-d %B %Y")
+
+            version_list.append(
+                {
+                    "version": version,
+                    "releases": releases,
+                }
+            )
+
+        # Sort x.y versions (newest first)
+        version_list.sort(
+            key=lambda x: [
+                int(n) if n.isdigit() else n for n in x["version"].split(".")
+            ],
+            reverse=True,
+        )
+
+        context.update({
+            "version_list": version_list,
+        })
+
+        return context

--- a/templates/python/versions.html
+++ b/templates/python/versions.html
@@ -30,7 +30,7 @@
             {% for release in version_data.releases %}
                 <li>
                     {% if release.stage %}
-                        <a href="https://docs.python.org/release/{{ release.stage|cut:" " }}/">Python {{ release.stage }}</a>{% if release.date %}, documentation released on {{ release.date }}{% endif %}
+                        <a href="https://docs.python.org/release/{{ release.stage|cut:" " }}/">Python {{ release.stage }}</a>{% if release.date %}, released on {{ release.date }}{% endif %}
                     {% endif %}
                 </li>
             {% endfor %}

--- a/templates/python/versions.html
+++ b/templates/python/versions.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% load boxes %}
+{% load sitetree %}
+
+{% block page_title %}Python documentation by version | {{ SITE_INFO.site_name }}{% endblock %}
+
+{% block body_attributes %}class="python pages default-page"{% endblock %}
+
+{% block breadcrumbs %}
+{% sitetree_breadcrumbs from "main" %}
+{% endblock breadcrumbs %}
+
+{% block content_attributes %}with-left-sidebar{% endblock %}
+
+{% block content %}
+    <article class="text">
+        <header class="article-header">
+            <h1 class="page-title">Python documentation by version</h1>
+        </header>
+
+        <p>Some previous versions of the documentation remain available online. Use the list below to select a version to view.</p>
+
+        <p>For unreleased (in development) documentation, see <a href="#in-development-versions">In development versions</a>.</p>
+
+        <h2>Release versions</h2>
+
+        {% for version_data in version_list %}
+            <h3>Python {{ version_data.version }}</h3>
+            <ul>
+            {% for release in version_data.releases %}
+                <li>
+                    {% if release.stage %}
+                        <a href="https://docs.python.org/release/{{ release.stage|cut:" " }}/">Python {{ release.stage }}</a>{% if release.date %}, documentation released on {{ release.date }}{% endif %}
+                    {% endif %}
+                </li>
+            {% endfor %}
+            </ul>
+        {% endfor %}
+
+        <h2 id="in-development-versions">In development versions</h2>
+        <p>The latest, and unreleased, documentation for versions of Python still under development:</p>
+        <ul>
+            <li><a href="https://docs.python.org/dev/">Development version</a></li>
+            <li><a href="https://docs.python.org/3/">Python 3.x</a></li>
+        </ul>
+
+    </article>
+{% endblock content %}
+
+{% block left_sidebar %}
+<aside class="left-sidebar" role="secondary">
+    {% include "components/navigation-widget.html" %}
+
+    <div class="psf-sidebar-widget sidebar-widget">
+        {% box 'widget-sidebar-aboutpsf' %}
+    </div>
+</aside>
+{% endblock left_sidebar %}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

The current "Python documentation by version" page at https://www.python.org/doc/versions/ has a static list of Python docs stored in the CMS.

During each release, the release manager is meant to edit the page and add the new one, but it's often forgotten. The list also sometimes gets out of order, and "February" can be hard to spell (now fixed). 

The CMS also has information about each release, so I propose we generate this page instead.

cc @ned-deily, we've talked about something like this.


---

It mostly follows the same design as the original, but I also grouped the releases by Python feature version. We can keep the current big list if preferred.

Now (left) and new (right):

<img width="1470" height="917" alt="image" src="https://github.com/user-attachments/assets/2dbc062e-bfee-4313-ade6-1704ffd9d71b" />

---

There are a few discrepancies between the old static list and the new one generated from the CMS.

* Some 2.x releases don't have docs. Skip them.

* Some docs don't have releases in the CMS. Hardcode them here, and re-add.

* Some of the "documentation release dates" are not the same as regular release dates from the CMS, especially for older releases. The test CMS data when serving locally only has releases up to 3.10.7/Sept 2022 (178 releases in total), but comparing the generated page with https://www.python.org/doc/versions/ (227 releases), there are 38 with different dates.

  * 25 are just one day out. I'm not bothered about these, it's most likely a UTC vs local time difference and I'm fine with ignoring it.
  * Some are up to 17 days out, which is obviously a bigger gap. Details:


<details>
<summary>Details</summary>

17 days difference:
  2.4.3: local=15 April 2006, prod=29 March 2006

15 days difference:
  3.4.4: local=21 December 2015, prod=06 December 2015
  3.4.7: local=09 August 2017, prod=25 July 2017
  3.8.6: local=08 September 2020, prod=23 September 2020

14 days difference:
  3.5.4: local=08 August 2017, prod=25 July 2017
  3.8.3: local=29 April 2020, prod=13 May 2020

13 days difference:
  3.8.4: local=30 June 2020, prod=13 July 2020

9 days difference:
  3.4.2: local=13 October 2014, prod=04 October 2014

6 days difference:
  3.10.6: local=02 August 2022, prod=08 August 2022
  3.4.9: local=02 August 2018, prod=08 August 2018
  3.5.6: local=02 August 2018, prod=08 August 2018

3 days difference:
  2.7.5: local=12 May 2013, prod=15 May 2013

2 days difference:
  2.7.16: local=04 March 2019, prod=02 March 2019

1 day difference:
  2.4.2: local=27 September 2005, prod=28 September 2005
  2.5.1: local=19 April 2007, prod=18 April 2007
  2.6: local=02 October 2008, prod=01 October 2008
  2.6.4: local=26 October 2009, prod=25 October 2009
  2.6.5: local=18 March 2010, prod=19 March 2010
  2.7: local=03 July 2010, prod=04 July 2010
  2.7.12: local=25 June 2016, prod=26 June 2016
  2.7.15: local=01 May 2018, prod=30 April 2018
  2.7.7: local=01 June 2014, prod=31 May 2014
  2.7.8: local=02 July 2014, prod=01 July 2014
  3.1: local=26 June 2009, prod=27 June 2009
  3.1.2: local=20 March 2010, prod=21 March 2010
  3.2.1: local=09 July 2011, prod=10 July 2011
  3.2.2: local=03 September 2011, prod=04 September 2011
  3.2.4: local=06 April 2013, prod=07 April 2013
  3.2.6: local=12 October 2014, prod=11 October 2014
  3.3.1: local=06 April 2013, prod=07 April 2013
  3.4.0: local=17 March 2014, prod=16 March 2014
  3.4.1: local=19 May 2014, prod=18 May 2014
  3.4.5: local=27 June 2016, prod=26 June 2016
  3.4.8: local=05 February 2018, prod=04 February 2018
  3.5.5: local=05 February 2018, prod=04 February 2018
  3.5.9: local=02 November 2019, prod=01 November 2019
  3.9.1: local=07 December 2020, prod=08 December 2020
  3.9.12: local=23 March 2022, prod=24 March 2022

</details>

How to handle these? Options:

* Don't worry about it, just keep the CMS dates. 
* Don't worry about it, just keep the CMS dates and change "documentation released on" to something like "released on", so that it could refer to the release and not specifically the docs.
* For those more than X days out, keep a hardcoded list of real dates and show those instead of the CMS date.
