### PR TITLE
Redirect `downloads/latest/python3.x` for given 3.x

### DIFF
--- a/downloads/managers.py
+++ b/downloads/managers.py
@@ -48,29 +48,13 @@ class ReleaseQuerySet(QuerySet):
 
 class ReleaseManager(Manager.from_queryset(ReleaseQuerySet)):
     def latest_python2(self):
-        qs = self.get_queryset().latest_python2()
-        if qs:
-            return qs[0]
-        else:
-            return None
+        return self.get_queryset().latest_python2().first()
 
     def latest_python3(self):
-        qs = self.get_queryset().latest_python3()
-        if qs:
-            return qs[0]
-        else:
-            return None
+        return self.get_queryset().latest_python3().first()
 
     def latest_python3x(self, minor_version: int):
-        qs = self.get_queryset().latest_python3x(minor_version)
-        if qs:
-            return qs[0]
-        else:
-            return None
+        return self.get_queryset().latest_python3x(minor_version).first()
 
     def latest_pymanager(self):
-        qs = self.get_queryset().latest_pymanager()
-        if qs:
-            return qs[0]
-        else:
-            return None
+        return self.get_queryset().latest_pymanager().first()

--- a/downloads/managers.py
+++ b/downloads/managers.py
@@ -32,6 +32,10 @@ class ReleaseQuerySet(QuerySet):
     def latest_python3(self):
         return self.python3().filter(is_latest=True)
 
+    def latest_python3x(self, minor_version: int):
+        pattern = rf"^Python 3\.{minor_version}\."
+        return self.python3().filter(name__regex=pattern).order_by("-release_date")
+
     def latest_pymanager(self):
         return self.pymanager().filter(is_latest=True)
 
@@ -52,6 +56,13 @@ class ReleaseManager(Manager.from_queryset(ReleaseQuerySet)):
 
     def latest_python3(self):
         qs = self.get_queryset().latest_python3()
+        if qs:
+            return qs[0]
+        else:
+            return None
+
+    def latest_python3x(self, minor_version: int):
+        qs = self.get_queryset().latest_python3x(minor_version)
         if qs:
             return qs[0]
         else:

--- a/downloads/managers.py
+++ b/downloads/managers.py
@@ -29,10 +29,9 @@ class ReleaseQuerySet(QuerySet):
     def latest_python2(self):
         return self.python2().filter(is_latest=True)
 
-    def latest_python3(self):
-        return self.python3().filter(is_latest=True)
-
-    def latest_python3x(self, minor_version: int):
+    def latest_python3(self, minor_version: int | None = None):
+        if minor_version is None:
+            return self.python3().filter(is_latest=True)
         pattern = rf"^Python 3\.{minor_version}\."
         return self.python3().filter(name__regex=pattern).order_by("-release_date")
 
@@ -50,11 +49,8 @@ class ReleaseManager(Manager.from_queryset(ReleaseQuerySet)):
     def latest_python2(self):
         return self.get_queryset().latest_python2().first()
 
-    def latest_python3(self):
-        return self.get_queryset().latest_python3().first()
-
-    def latest_python3x(self, minor_version: int):
-        return self.get_queryset().latest_python3x(minor_version).first()
+    def latest_python3(self, minor_version: int | None = None):
+        return self.get_queryset().latest_python3(minor_version).first()
 
     def latest_pymanager(self):
         return self.get_queryset().latest_pymanager().first()

--- a/downloads/models.py
+++ b/downloads/models.py
@@ -292,6 +292,12 @@ def purge_fastly_download_pages(sender, instance, **kwargs):
         purge_url('/downloads/feed.rss')
         purge_url('/downloads/latest/python2/')
         purge_url('/downloads/latest/python3/')
+        # Purge minor version specific URLs (like /downloads/latest/python3.14/)
+        version = instance.get_version()
+        if instance.version == Release.PYTHON3 and version:
+            match = re.match(r'^3\.(\d+)', version)
+            if match:
+                purge_url(f'/downloads/latest/python3.{match.group(1)}/')
         purge_url('/downloads/latest/pymanager/')
         purge_url('/downloads/macos/')
         purge_url('/downloads/source/')

--- a/downloads/urls.py
+++ b/downloads/urls.py
@@ -5,6 +5,7 @@ app_name = 'downloads'
 urlpatterns = [
     re_path(r'latest/python2/?$', views.DownloadLatestPython2.as_view(), name='download_latest_python2'),
     re_path(r'latest/python3/?$', views.DownloadLatestPython3.as_view(), name='download_latest_python3'),
+    re_path(r'latest/python3\.(?P<minor>\d+)/?$', views.DownloadLatestPython3x.as_view(), name='download_latest_python3x'),
     re_path(r'latest/pymanager/?$', views.DownloadLatestPyManager.as_view(), name='download_latest_pymanager'),
     re_path(r'latest/?$', views.DownloadLatestPython3.as_view(), name='download_latest_python3'),
     path('operating-systems/', views.DownloadFullOSList.as_view(), name='download_full_os_list'),

--- a/downloads/views.py
+++ b/downloads/views.py
@@ -56,7 +56,7 @@ class DownloadLatestPython3x(RedirectView):
 
         try:
             minor_version_int = int(minor_version)
-            latest_release = Release.objects.latest_python3x(minor_version_int)
+            latest_release = Release.objects.latest_python3(minor_version_int)
         except (ValueError, Release.DoesNotExist):
             latest_release = None
 

--- a/downloads/views.py
+++ b/downloads/views.py
@@ -45,6 +45,27 @@ class DownloadLatestPython3(RedirectView):
             return reverse('download')
 
 
+class DownloadLatestPython3x(RedirectView):
+    """ Redirect to latest Python 3.x release for a specific minor version """
+    permanent = False
+
+    def get_redirect_url(self, **kwargs):
+        minor_version = kwargs.get('minor')
+        if not minor_version:
+            return reverse('downloads:download')
+
+        try:
+            minor_version_int = int(minor_version)
+            latest_release = Release.objects.latest_python3x(minor_version_int)
+        except (ValueError, Release.DoesNotExist):
+            latest_release = None
+
+        if latest_release:
+            return latest_release.get_absolute_url()
+        else:
+            return reverse('downloads:download')
+
+
 class DownloadLatestPyManager(RedirectView):
     """ Redirect to latest Python install manager release """
     permanent = False

--- a/static/sass/_layout.scss
+++ b/static/sass/_layout.scss
@@ -449,6 +449,7 @@
 
     .release-version,
     .release-status,
+    .release-dl,
     .release-start,
     .release-end,
     .release-pep {
@@ -458,10 +459,11 @@
         vertical-align: middle;
     }
 
-    .release-version { width: 15%; }
+    .release-version { width: 10%; }
     .release-status { width: 20%; }
-    .release-start { width: 25%; }
-    .release-end { width: 25%; }
+    .release-dl { width: 15%; }
+    .release-start { width: 20%; }
+    .release-end { width: 20%; }
     .release-pep { width: 15%; }
 
     /* Previous Next pattern */

--- a/static/sass/mq.css
+++ b/static/sass/mq.css
@@ -1505,6 +1505,7 @@ html[xmlns] .slides { display: block; }
 
   .release-version,
   .release-status,
+  .release-dl,
   .release-start,
   .release-end,
   .release-pep {
@@ -1514,16 +1515,19 @@ html[xmlns] .slides { display: block; }
     vertical-align: middle; }
 
   .release-version {
-    width: 15%; }
+    width: 10%; }
 
   .release-status {
     width: 20%; }
 
+  .release-dl {
+    width: 15%; }
+
   .release-start {
-    width: 25%; }
+    width: 20%; }
 
   .release-end {
-    width: 25%; }
+    width: 20%; }
 
   .release-pep {
     width: 15%; }

--- a/static/sass/no-mq.css
+++ b/static/sass/no-mq.css
@@ -1219,6 +1219,7 @@ a.button {
 
 .release-version,
 .release-status,
+.release-dl,
 .release-start,
 .release-end,
 .release-pep {
@@ -1228,16 +1229,19 @@ a.button {
   vertical-align: middle; }
 
 .release-version {
-  width: 15%; }
+  width: 10%; }
 
 .release-status {
   width: 20%; }
 
+.release-dl {
+  width: 15%; }
+
 .release-start {
-  width: 25%; }
+  width: 20%; }
 
 .release-end {
-  width: 25%; }
+  width: 20%; }
 
 .release-pep {
   width: 15%; }


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

Add new redirects for the latest of each 3.x feature release.

We already have (with current redirects):
* https://python.org/downloads/latest/python2 -> https://www.python.org/downloads/release/python-2718/
* https://python.org/downloads/latest/python3 -> https://www.python.org/downloads/release/python-3140/
* https://www.python.org/downloads/latest -> https://www.python.org/downloads/release/python-3140/
* https://www.python.org/downloads/latest/pymanager/ -> https://www.python.org/downloads/release/pymanager-250/

This adds some for 3.x. For example (based on local test CMS data):

* http://0.0.0.0:8000/downloads/latest/python3.10 -> http://0.0.0.0:8000/downloads/release/python-3107/
* http://0.0.0.0:8000/downloads/latest/python3.9 -> http://0.0.0.0:8000/downloads/release/python-3914/

Unknown versions go back to the downloads page:

* http://0.0.0.0:8000/downloads/latest/python3.26 -> http://0.0.0.0:8000/downloads/

(I didn't bother with `downloads/latest/python2.x`, people can use https://python.org/downloads/latest/python2 or  https://www.python.org/downloads/release/python-2718/ or upgrade.)

---

After merge, we can add an extra downloads column to the `downloads-active-releases` box in the CMS, something like:

<details>
<summary>Details</summary>

```html
<div class="list-row-headings">
    <span class="release-version">Python version</span>
    <span class="release-status">Maintenance status</span>
    <span class="release-dl">&nbsp;</span>
    <span class="release-start">First released</span>
    <span class="release-end">End of support</span>
    <span class="release-pep">Release schedule</span>
</div>
<ol class="list-row-container menu">
    <li>
        <span class="release-version">3.15</span>
        <span class="release-status"><a href="https://www.python.org/download/pre-releases/">pre-release</a></span>
        <span class="release-dl"><a href="/downloads/latest/python3.15/"><span aria-hidden="true" class="icon-download"></span>Download</a></span>
        <span class="release-start">2026-10-07 (planned)</span>
        <span class="release-end">2031-10</span>
        <span class="release-pep"><a href="https://peps.python.org/pep-0790/">PEP 790</a></span>
    </li>
    <li>
        <span class="release-version">3.14</span>
        <span class="release-status">bugfix</span>
        <span class="release-dl"><a href="/downloads/latest/python3.14/"><span aria-hidden="true" class="icon-download"></span>Download</a></span>
        <span class="release-start">2025-10-07</span>
        <span class="release-end">2030-10</span>
        <span class="release-pep"><a href="https://peps.python.org/pep-0745/">PEP 745</a></span>
    </li>
    <li>
        <span class="release-version">3.13</span>
        <span class="release-status">bugfix</span>
        <span class="release-dl"><a href="/downloads/latest/python3.13/"><span aria-hidden="true" class="icon-download"></span>Download</a></span>
        <span class="release-start">2024-10-07</span>
        <span class="release-end">2029-10</span>
        <span class="release-pep"><a href="https://peps.python.org/pep-0719/">PEP 719</a></span>
    </li>
    <li>
        <span class="release-version">3.12</span>
        <span class="release-status">security</span>
        <span class="release-dl"><a href="/downloads/latest/python3.12/"><span aria-hidden="true" class="icon-download"></span>Download</a></span>
        <span class="release-start">2023-10-02</span>
        <span class="release-end">2028-10</span>
        <span class="release-pep"><a href="https://peps.python.org/pep-0693/">PEP 693</a></span>
    </li>
    <li>
        <span class="release-version">3.11</span>
        <span class="release-status">security</span>
        <span class="release-dl"><a href="/downloads/latest/python3.11/"><span aria-hidden="true" class="icon-download"></span>Download</a></span>
        <span class="release-start">2022-10-24</span>
        <span class="release-end">2027-10</span>
        <span class="release-pep"><a href="https://peps.python.org/pep-0664/">PEP 664</a></span>
    </li>
    <li>
        <span class="release-version">3.10</span>
        <span class="release-status">security</span>
        <span class="release-dl"><a href="/downloads/latest/python3.10/"><span aria-hidden="true" class="icon-download"></span>Download</a></span>
        <span class="release-start">2021-10-04</span>
        <span class="release-end">2026-10</span>
        <span class="release-pep"><a href="https://peps.python.org/pep-0619/">PEP 619</a></span>
    </li>
    <li>
        <span class="release-version">3.9</span>
        <span class="release-status">end of life, last release was <a href="https://www.python.org/downloads/release/python-3925/">3.9.25</a></span>
        <span class="release-dl"><a href="/downloads/latest/python3.9/"><span aria-hidden="true" class="icon-download"></span>Download</a></span>
        <span class="release-start">2020-10-05</span>
        <span class="release-end">2025-10-31</span>
        <span class="release-pep"><a href="https://peps.python.org/pep-0596/">PEP 596</a></span>
    </li>
</ol>
```

</details>

Before:

<img width="1190" height="934" alt="image" src="https://github.com/user-attachments/assets/75f216ef-08cb-4605-bfef-d8248fb62595" />

After:

<img width="1194" height="939" alt="image" src="https://github.com/user-attachments/assets/973f2e5e-2141-45bf-b8d0-d05811a24f9d" />


(Better yet, we could generate that table as well, but that's for another time.)


<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Closes

- Fixes https://github.com/python/pythondotorg/issues/1693.
- Fixes https://github.com/python/pythondotorg/issues/2701.

