### PR TITLE
Add 'Python 3.X.YaN' placeholder for release name

### DIFF
--- a/downloads/admin.py
+++ b/downloads/admin.py
@@ -25,3 +25,9 @@ class ReleaseAdmin(ContentManageableModelAdmin):
     list_filter = ['version', 'is_published', 'show_on_download_page']
     search_fields = ['name', 'slug']
     ordering = ['-release_date']
+
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        field = super().formfield_for_dbfield(db_field, request, **kwargs)
+        if db_field.name == "name":
+            field.widget.attrs["placeholder"] = "Python 3.X.YaN"
+        return field


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

Add "Python 3.XY.aN" as the placeholder for the name field. Results in this HTML change:

```diff
-<input type="text" name="name" class="vTextField" maxlength="200" required="" id="id_name">
+<input type="text" name="name" class="vTextField" maxlength="200" placeholder="Python 3.X.YaN" required="" id="id_name">
```

This is a useful prompt, as I often have to check the existing releases to check if I need to include Python or write the short or long form of pre-release ("3.15.0a5" or "3.15.0 alpha 5").

Before: https://www.python.org/admin/downloads/release/add/

<img width="477" height="202" alt="image" src="https://github.com/user-attachments/assets/fc41a747-3c9d-4aeb-9953-52fe4222cbf6" />

After: http://0.0.0.0:8000/admin/downloads/release/add/

<img width="478" height="203" alt="image" src="https://github.com/user-attachments/assets/cf52c345-1bfd-49c9-9253-f7ebafbb373f" />

And you type in the real value:

<img width="481" height="210" alt="image" src="https://github.com/user-attachments/assets/515b443c-1d28-41ac-91a4-7ccd7889d0be" />


<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Closes

- Can be done in addition to or instead of https://github.com/python/pythondotorg/pull/2725 / https://github.com/python/pythondotorg/issues/2724.

