### PR TITLE
Rename to /doc/versions

### DIFF
--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
     path('getit/', include('downloads.urls', namespace='getit')),
     path('downloads/', include('downloads.urls', namespace='download')),
     path('doc/', views.DocumentationIndexView.as_view(), name='documentation'),
-    path('doc/versions2/', views.DocsByVersionView.as_view(), name='docs-versions'),
+    path('doc/versions/', views.DocsByVersionView.as_view(), name='docs-versions'),
     path('blogs/', include('blogs.urls')),
     path('inner/', TemplateView.as_view(template_name="python/inner.html"), name='inner'),
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

Follow up to https://github.com/python/pythondotorg/pull/2813. 

The new page at https://www.python.org/doc/versions2/ looks good and has everything, let's rename it to 
https://www.python.org/doc/versions/

I've already renamed the old https://www.python.org/doc/versions/ to https://www.python.org/doc/versions-old/


