### PR TITLE
Add 'superseded by' notice to older Python 3 releases

### DIFF
--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -26,7 +26,11 @@
             <h1 class="page-title">{{ release.name }}</h1>
         </header>
 
-        <p><strong>Release Date:</strong> {{ release.release_date|date }}</p>
+        {% if latest_in_series %}
+        <p><strong>Note:</strong> {{ release.name }} has been superseded by <a href="{{ latest_in_series.get_absolute_url }}">{{ latest_in_series.name }}</a>.</p>
+        {% endif %}
+
+        <p><strong>Release date:</strong> {{ release.release_date|date }}</p>
 
         {% if release.content.raw %}
         {{ release.content.rendered|safe }}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

Automating some more manual RM stuff from [PEP 101](https://peps.python.org/pep-0101/):

> * If this is a final release:
>   * For 3.X.Y, edit all the previous X.Y releases’ page(s) to point to the new release. This includes the content field of the Downloads -> Releases entry for the release:
>    ```
>    Note: Python 3.x.(y-1) has been superseded by
>    `Python 3.x.y </downloads/release/python-3xy/>`_.
>    ```

This tedious manual work isn't often followed, and is perfect for automating over here.

So this adds a note to release pages to link to the latest one in the feature series. The latest one doesn't have the link.

<img width="449" height="167" alt="image" src="https://github.com/user-attachments/assets/33f9a0d9-4e4c-42a6-9290-93e6f5250f3e" />
<img width="325" height="193" alt="image" src="https://github.com/user-attachments/assets/b835ac3c-61fd-43e6-b8bf-1a069137a1f1" />


For example:

* http://0.0.0.0:8000/downloads/release/python-3150a2/ no note
* http://0.0.0.0:8000/downloads/release/python-3150a1/ notes superseded by 3.15.0a2
* http://0.0.0.0:8000/downloads/release/python-3140/ no note
* http://0.0.0.0:8000/downloads/release/python-3140rc3/ notes superseded by 3.14.0
* http://0.0.0.0:8000/downloads/release/python-3139/ no note
* http://0.0.0.0:8000/downloads/release/python-3138/ notes superseded by 3.13.9
* http://0.0.0.0:8000/downloads/release/python-3137/ notes superseded by 3.13.9
* http://0.0.0.0:8000/downloads/release/python-3130/ notes superseded by 3.13.9
* and so on

I didn't bother adding it for Python 2 releases.
