### PR TITLE
Remove unused Requests security extra

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -31,7 +31,7 @@ django-tastypie==0.14.7  # 0.14.6 is first version that supports Django 4.2
 pytz==2021.1
 python-dateutil==2.8.2
 
-requests[security]>=2.26.0
+requests>=2.26.0
 
 django-honeypot==1.0.4  # 1.0.4 is first version that supports Django 4.2
 django-markupfield==2.0.1


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- The `security` extra was made a no-op in Requests 2.26 ([psf/requests#5867](https://github.com/psf/requests/pull/5867)), which is the version we have pinned.

