### PR TITLE
Add EOL banner to EOL downloads

### DIFF
--- a/downloads/tests/test_template_tags.py
+++ b/downloads/tests/test_template_tags.py
@@ -1,0 +1,170 @@
+import unittest.mock as mock
+
+import requests
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from ..templatetags.download_tags import get_eol_info, get_python_releases_data
+from .base import BaseDownloadTests
+
+MOCK_PYTHON_RELEASE = {
+    "metadata": {
+        "2.7": {"status": "end-of-life", "end_of_life": "2020-01-01"},
+        "3.8": {"status": "end-of-life", "end_of_life": "2024-10-07"},
+        "3.10": {"status": "security", "end_of_life": "2026-10-04"},
+    }
+}
+
+
+TEST_CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-cache",
+    }
+}
+
+
+@override_settings(CACHES=TEST_CACHES)
+class GetEOLInfoTests(BaseDownloadTests):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    @mock.patch("downloads.templatetags.download_tags.get_python_releases_data")
+    def test_eol_status(self, mock_get_data):
+        """Test get_eol_info returns correct EOL status."""
+        # Arrange
+        mock_get_data.return_value = MOCK_PYTHON_RELEASE
+        tests = [
+            (self.release_275, True, "2020-01-01"),  # EOL
+            (self.python_3_8_20, True, "2024-10-07"),  # EOL
+            (self.python_3_10_18, False, None),  # security
+        ]
+
+        for release, expected_is_eol, expected_eol_date in tests:
+            with self.subTest(release=release.name):
+                # Act
+                result = get_eol_info(release)
+
+                # Assert
+                self.assertEqual(result["is_eol"], expected_is_eol)
+                self.assertEqual(result["eol_date"], expected_eol_date)
+
+    @mock.patch("downloads.templatetags.download_tags.get_python_releases_data")
+    def test_eol_status_api_failure(self, mock_get_data):
+        """Test that API failure results in not showing EOL warning."""
+        # Arrange
+        mock_get_data.return_value = None
+
+        # Act
+        result = get_eol_info(self.python_3_8_20)
+
+        # Assert
+        self.assertFalse(result["is_eol"])
+        self.assertIsNone(result["eol_date"])
+
+
+@override_settings(CACHES=TEST_CACHES)
+class GetReleaseCycleDataTests(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    @mock.patch("downloads.templatetags.download_tags.requests.get")
+    def test_successful_fetch(self, mock_get):
+        """Test successful API fetch."""
+        # Arrange
+        mock_response = mock.Mock()
+        mock_response.json.return_value = MOCK_PYTHON_RELEASE
+        mock_response.raise_for_status = mock.Mock()
+        mock_get.return_value = mock_response
+
+        # Act
+        result = get_python_releases_data()
+
+        # Assert
+        self.assertEqual(result, MOCK_PYTHON_RELEASE)
+        mock_get.assert_called_once()
+
+    @mock.patch("downloads.templatetags.download_tags.requests.get")
+    def test_caches_result(self, mock_get):
+        """Test that the result is cached."""
+        # Arrange
+        mock_response = mock.Mock()
+        mock_response.json.return_value = MOCK_PYTHON_RELEASE
+        mock_response.raise_for_status = mock.Mock()
+        mock_get.return_value = mock_response
+
+        # Act
+        result1 = get_python_releases_data()
+        result2 = get_python_releases_data()
+
+        # Assert
+        self.assertEqual(result1, result2)
+        mock_get.assert_called_once()
+
+    @mock.patch("downloads.templatetags.download_tags.requests.get")
+    def test_request_exception_returns_none(self, mock_get):
+        """Test that request exceptions return None."""
+        # Arrange
+        mock_get.side_effect = requests.RequestException("Connection error")
+
+        # Act
+        result = get_python_releases_data()
+
+        # Assert
+        self.assertIsNone(result)
+
+    @mock.patch("downloads.templatetags.download_tags.requests.get")
+    def test_json_decode_error_returns_none(self, mock_get):
+        """Test that JSON decode errors return None."""
+        # Arrange
+        mock_response = mock.Mock()
+        mock_response.raise_for_status = mock.Mock()
+        mock_response.json.side_effect = ValueError("Invalid JSON")
+        mock_get.return_value = mock_response
+
+        # Act
+        result = get_python_releases_data()
+
+        # Assert
+        self.assertIsNone(result)
+
+
+@override_settings(CACHES=TEST_CACHES)
+class EOLBannerViewTests(BaseDownloadTests):
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    @mock.patch("downloads.templatetags.download_tags.get_python_releases_data")
+    def test_eol_banner_visibility(self, mock_get_data):
+        """Test EOL banner is shown or hidden correctly."""
+        # Arrange
+        tests = [
+            ("release_275", MOCK_PYTHON_RELEASE, True),
+            ("python_3_8_20", MOCK_PYTHON_RELEASE, True),
+            ("python_3_10_18", MOCK_PYTHON_RELEASE, False),
+            ("python_3_8_20", None, False),
+        ]
+
+        for release_attr, mock_data, expect_banner in tests:
+            with self.subTest(release=release_attr):
+                mock_get_data.return_value = mock_data
+                release = getattr(self, release_attr)
+                url = reverse(
+                    "download:download_release_detail",
+                    kwargs={"release_slug": release.slug},
+                )
+
+                # Act
+                response = self.client.get(url)
+
+                # Assert
+                self.assertEqual(response.status_code, 200)
+                if expect_banner:
+                    self.assertContains(response, "level-error")
+                    self.assertContains(response, "no longer supported")
+                else:
+                    self.assertNotContains(response, "level-error")

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -2652,7 +2652,12 @@ p.quote-by-organization {
   background-color: #ecd4d7;
   border: 2px solid #b55863; }
   .level-error span {
-    color: #b55863; }
+    color: #853b44;
+    font-weight: bold; }
+  .level-error a {
+    color: #2b5b84; }
+    .level-error a:hover, .level-error a:focus {
+      color: #1e415e; }
 
 /* Yeah! It worked correctly */
 .level-success {

--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -2645,7 +2645,8 @@ p.quote-by-organization {
   background-color: #fff7dc;
   border: 2px solid #ffd343; }
   .level-notice span {
-    color: #dca900; }
+    color: #765a00;
+    font-weight: bold; }
 
 /* Something went wrong */
 .level-error {

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1758,7 +1758,10 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
     background-color: lighten( $yellow, 30% );
     border: 2px solid $yellow;
 
-    span { color: darken( $yellow, 20% ); }
+    span {
+        color: darken( $yellow, 40% );
+        font-weight: bold;
+    }
 }
 
 /* Something went wrong */

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1766,7 +1766,14 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
     background-color: lighten( $red, 35% );
     border: 2px solid $red;
 
-    span { color: $red; }
+    span {
+        color: darken( $red, 15% );
+        font-weight: bold;
+    }
+    a {
+        color: darken( $blue, 10% );
+        &:hover, &:focus { color: darken( $blue, 20% ); }
+    }
 }
 
 /* Yeah! It worked correctly */

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -38,7 +38,9 @@
         {% endif %}
 
         {% if latest_in_series %}
-        <p><strong>Note:</strong> {{ release.name }} has been superseded by <a href="{{ latest_in_series.get_absolute_url }}">{{ latest_in_series.name }}</a>.</p>
+        <div class="user-feedback level-notice">
+            <span>Note:</span> {{ release.name }} has been superseded by <a href="{{ latest_in_series.get_absolute_url }}">{{ latest_in_series.name }}</a>.
+        </div>
         {% endif %}
 
         <p><strong>Release date:</strong> {{ release.release_date|date }}</p>

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -5,6 +5,7 @@
 {% load has_sigstore_materials from download_tags %}
 {% load has_sbom from download_tags %}
 {% load sort_windows from download_tags %}
+{% load get_eol_info from download_tags %}
 
 {% block body_attributes %}class="python downloads"{% endblock %}
 
@@ -25,6 +26,16 @@
         <header class="article-header">
             <h1 class="page-title">{{ release.name }}</h1>
         </header>
+
+        {% get_eol_info release as eol_info %}
+        {% if eol_info.is_eol %}
+        <div class="user-feedback level-error">
+            <span>Warning:</span>
+            Python {{ release.get_version|default:release.name }} reached end-of-life{% if eol_info.eol_date %} on {{ eol_info.eol_date }}{% endif %}.
+            It is no longer supported and does not receive security updates.
+            We recommend upgrading to the <a href="{% url 'downloads:download_latest_python3' %}">latest Python release</a>.
+        </div>
+        {% endif %}
 
         {% if latest_in_series %}
         <p><strong>Note:</strong> {{ release.name }} has been superseded by <a href="{{ latest_in_series.get_absolute_url }}">{{ latest_in_series.name }}</a>.</p>


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Add an EOL banner to the relevant releases, similar to https://docs.python.org/3.9/.
- Thanks to @ned-deily for the idea.

We look up the release status and EOL date from https://peps.python.org/api/python-releases.json and cache it.

That API only has data back to 1.6, and we only have releases back to 2.0, so we're covered.

I used the existing red `.user-feedback.level-error` CSS, and adjust the "Warning:" and link colours to meet the WCAG AA guidelines for contrast ratio.

I also switched the superseded-by note added in https://github.com/python/pythondotorg/pull/2827 to use the yellow `.user-feedback.level-notice` and fixed the contrast for "Note:".


Both banners:

<img width="1234" height="480" alt="image" src="https://github.com/user-attachments/assets/d99321a7-b7a8-417e-864a-43ea28730879" />

Only the EOL banner:

<img width="1211" height="347" alt="image" src="https://github.com/user-attachments/assets/4f6a3760-d9a9-4556-8589-d0fce799284f" />

Only the superseded by banner:

<img width="1199" height="394" alt="image" src="https://github.com/user-attachments/assets/5828ade5-ec24-42d4-8da9-2deeffd559c2" />

And this is how the contrast looked before (3.30, 3.45 and 2.02 respectively, now 5.53, 5.10, and 6.06):

<img width="1178" height="250" alt="image" src="https://github.com/user-attachments/assets/e5d0c35f-3e12-46c8-9e3a-d330c84f482a" />

