### PR TITLE
Upgrade three dependencies that trigger pkg_resources removal warning

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -23,7 +23,7 @@ celery[redis]==5.4.0
 django-celery-beat==2.5.0
 # TODO: We may drop 'django-imagekit' completely.
 django-imagekit==5.0  # 5.0 is first version that supports Django 4.2
-django-haystack==3.2.1
+django-haystack==3.3.0
 elasticsearch>=7,<8
 # TODO: 0.14.0 only supports Django 1.8 and 1.11.
 django-tastypie==0.14.7  # 0.14.6 is first version that supports Django 4.2
@@ -44,9 +44,9 @@ djangorestframework==3.14.0  # 3.14.0 is first version that supports Django 4.1,
 django-filter==2.4.0
 django-ordered-model==3.7.4
 django-widget-tweaks==1.5.0
-django-countries==7.2.1
+django-countries==8.2.0
 num2words==0.5.13
-django-polymorphic==3.1.0  # 3.1.0 is first version that supports Django 4.0, unsure if it fully supports 4.2
+django-polymorphic==4.1.0
 sorl-thumbnail==12.11.0
 django-extensions==3.2.3
 django-import-export==2.7.1


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

The old versions of these three packages caused this warning when running the tests:

> UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.

Removal PR: https://github.com/pypa/setuptools/pull/5007. 

Upgrade them.

* django-haystack 3.3.0: "Django versions 3-5 are supported, running on Python 3.8-3.12"
  https://github.com/django-haystack/django-haystack/releases/tag/v3.3.0

* django-countries 8.2.0 supports Django 3.2-5.2, Python 3.8-3.13
  https://pypi.org/project/django-countries/8.2.0/
  The 8.0.0 dropped Python 3.7
  https://github.com/SmileyChris/django-countries/blob/main/CHANGES.md#800-4-november-2025

* django-polymorphic 4.1.0: support Django 3.2-5.0, Python 3.8-3.12
  https://pypi.org/project/django-polymorphic/4.1.0/
  "There were no breaking changes in this major release"
  https://django-polymorphic.readthedocs.io/en/latest/changelog.html#v4-0-0-2025-05-20




<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Closes

- Nothing but helps towards https://github.com/python/pythondotorg/pull/2592 and https://github.com/python/pythondotorg/pull/2741.

