### PR TITLE
Remove duplicate devguide link from footer

### DIFF
--- a/fixtures/sitetree_menus.json
+++ b/fixtures/sitetree_menus.json
@@ -609,30 +609,6 @@
 },
 {
     "model": "sitetree.treeitem",
-    "pk": 28,
-    "fields": {
-        "title": "Developer's Guide",
-        "hint": "",
-        "url": "https://devguide.python.org/",
-        "urlaspattern": false,
-        "tree": 1,
-        "hidden": false,
-        "alias": null,
-        "description": "",
-        "inmenu": true,
-        "inbreadcrumbs": true,
-        "insitetree": true,
-        "access_loggedin": false,
-        "access_guest": false,
-        "access_restricted": false,
-        "access_perm_type": 1,
-        "parent": 9,
-        "sort_order": 28,
-        "access_permissions": []
-    }
-},
-{
-    "model": "sitetree.treeitem",
     "pk": 29,
     "fields": {
         "title": "FAQ",


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- We have two [Developer's Guide](https://devguide.python.org/) links in the footer, the other under Docs, one under Contributing
- The Contributing one makes more sense
- This PR removes is from the test fixtures
- Please can someone with access remove it from the site tree in the CMS? I don't have access. The link is https://www.python.org/admin/sitetree/tree/1/change/

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Closes

- Fixes https://github.com/python/pythondotorg/issues/2727

