### PR TITLE
Fix OrderedModelBase warnings

### DIFF
--- a/sponsors/models/sponsorship.py
+++ b/sponsors/models/sponsorship.py
@@ -17,7 +17,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from num2words import num2words
 
-from ordered_model.models import OrderedModel
+from ordered_model.models import OrderedModel, OrderedModelManager
 
 from sponsors.exceptions import SponsorWithExistingApplicationException, InvalidStatusException, \
     SponsorshipInvalidDateRangeException
@@ -37,7 +37,8 @@ class SponsorshipPackage(OrderedModel):
     """
     Represent default packages of benefits (visionary, sustainability etc)
     """
-    objects = SponsorshipPackageQuerySet.as_manager()
+
+    objects = OrderedModelManager.from_queryset(SponsorshipPackageQuerySet)()
 
     name = models.CharField(max_length=64)
     sponsorship_amount = models.PositiveIntegerField()
@@ -408,7 +409,7 @@ class SponsorshipBenefit(OrderedModel):
     package and program.
     """
 
-    objects = SponsorshipBenefitQuerySet.as_manager()
+    objects = OrderedModelManager.from_queryset(SponsorshipBenefitQuerySet)()
 
     # Public facing
     name = models.CharField(


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Fix these warnings:

```console
❯ make test
docker compose run --rm web ./manage.py test
[+] Creating 2/0
 ✔ Container pythondotorg-redis-1     Running                                                0.0s
 ✔ Container pythondotorg-postgres-1  Running                                                0.0s
/usr/local/lib/python3.12/site-packages/haystack/__init__.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import DistributionNotFound, get_distribution, parse_version
Found 640 test(s).
Creating test database for alias 'default'...
System check identified some issues:

WARNINGS:
SponsorshipBenefit: (ordered_model.W003) OrderedModelBase subclass has a ModelManager that does not inherit from OrderedModelManager. This is not ideal but will work.
SponsorshipPackage: (ordered_model.W003) OrderedModelBase subclass has a ModelManager that does not inherit from OrderedModelManager. This is not ideal but will work.

System check identified 2 issues (0 silenced).
.............................................................
```


<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Closes

- Fixes https://github.com/python/pythondotorg/issues/2743
- Closes https://github.com/python/pythondotorg/pull/2800

