### PR TITLE
Show release cycle charts on downloads page

### DIFF
--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -2588,6 +2588,13 @@ p.quote-by-organization {
   font-size: 0.875em; }
 .active-release-list-widget .list-row-container {
   margin-bottom: .5em; }
+.active-release-list-widget .release-cycle-chart img {
+  display: block;
+  margin: 0 auto;
+  width: 80%; }
+  @media screen and (max-width: 860px) {
+    .active-release-list-widget .release-cycle-chart img {
+      width: 100%; } }
 
 .download-list-widget {
   /*modernizr*/ }

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1690,6 +1690,14 @@ $colors: $blue, $psf, $yellow, $green, $purple, $red;
 
     .list-row-container { margin-bottom: .5em; }
 
+    .release-cycle-chart img {
+        display: block;
+        margin: 0 auto;
+        width: 80%;
+        @media screen and (max-width: 860px) {
+            width: 100%;
+        }
+    }
 }
 
 .download-list-widget {

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -53,6 +53,8 @@
                     <h2 class="widget-title">Active Python releases</h2>
                     <p class="success-quote"><a href="https://devguide.python.org/versions/#versions">For more information visit the Python Developer's Guide</a>.</p>
 
+                    <p class="release-cycle-chart"><img src="https://hugovk-devguide.readthedocs.io/en/standalone-svg/release-cycle.svg" alt="Python release cycle"></p>
+
                     {% box 'downloads-active-releases' %}
                 </div>
 
@@ -89,9 +91,9 @@
                     </div>
                 </div>
 
-        		<div class="row">
+                <div class="row">
 
-        		    <div class="small-widget download-widget1">
+                    <div class="small-widget download-widget1">
                         {% box 'download-widget1' %}
 
                     </div>
@@ -101,7 +103,7 @@
 
                     </div>
 
-        		    <div class="small-widget download-widget3">
+                    <div class="small-widget download-widget3">
                         {% box 'download-widget3' %}
 
                     </div>

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -53,7 +53,7 @@
                     <h2 class="widget-title">Active Python releases</h2>
                     <p class="success-quote"><a href="https://devguide.python.org/versions/#versions">For more information visit the Python Developer's Guide</a>.</p>
 
-                    <p class="release-cycle-chart"><img src="https://hugovk-devguide.readthedocs.io/en/standalone-svg/release-cycle.svg" alt="Python release cycle"></p>
+                    <p class="release-cycle-chart"><img src="https://hugovk-devguide.readthedocs.io/en/standalone-svg/_static/release-cycle.svg" alt="Python release cycle"></p>
 
                     {% box 'downloads-active-releases' %}
                 </div>

--- a/templates/downloads/index.html
+++ b/templates/downloads/index.html
@@ -53,7 +53,7 @@
                     <h2 class="widget-title">Active Python releases</h2>
                     <p class="success-quote"><a href="https://devguide.python.org/versions/#versions">For more information visit the Python Developer's Guide</a>.</p>
 
-                    <p class="release-cycle-chart"><img src="https://hugovk-devguide.readthedocs.io/en/standalone-svg/_static/release-cycle.svg" alt="Python release cycle"></p>
+                    <p class="release-cycle-chart"><img src="https://devguide.python.org/_static/release-cycle.svg" alt="Python release cycle"></p>
 
                     {% box 'downloads-active-releases' %}
                 </div>


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Currently, we only show this in the CPython developer's guide: https://devguide.python.org/versions/
- But best practice is to show it where end users visit, see https://endoflife.date/recommendations#bad---python
- This PR depends first on merging [devguide#1708](https://github.com/python/devguide/pull/1708)

<img width="402" height="832" alt="image" src="https://github.com/user-attachments/assets/e927c4e2-aac5-48b1-b029-cc1afd9f2e8a" />

