### PR TITLE
Improve contrast ratio of H2

### DIFF
--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -781,7 +781,7 @@ h1, .alpha {
   margin-bottom: 0.4375em; }
 
 h2, .beta {
-  color: #999999;
+  color: #222222;
   font-family: SourceSansProRegular, Arial, sans-serif;
   font-size: 1.5em;
   margin-top: 1.3125em;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -96,7 +96,7 @@ h1, .alpha {
 }
 
 h2, .beta {
-    color: $grey-light;
+    color: $grey-darker;
     font-family: $default-font;
     font-size: px2em( $headertwo );
     @include leader(.75);


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Improve accessibility by increasing the contrast ratio to meet WCAG AA guidelines of at least 4.5. Let's use the same colour as the H3.

**Before**

ratio: 2.78

<img width="914" height="436" alt="image" src="https://github.com/user-attachments/assets/91d179ea-26c4-4dc4-9277-2c0b08dc6fbf" />

**After**

ratio 15.37

<img width="920" height="439" alt="image" src="https://github.com/user-attachments/assets/50e767fa-3184-4629-9a87-a61a049eb0e3" />

