### PR TITLE
Fix updating the supernav downloads

### DIFF
--- a/downloads/models.py
+++ b/downloads/models.py
@@ -175,14 +175,11 @@ def update_supernav():
         if latest_pymanager:
             data['pymanager'] = latest_pymanager.download_file_for_os(o.slug)
 
-        python_files.append(data)
+        # Only include OSes that have at least one download file
+        if data['python3'] or data['pymanager']:
+            python_files.append(data)
 
     if not python_files:
-        return
-
-    if not all(f['python3'] or f['pymanager'] for f in python_files):
-        # We have a latest Python release, different OSes, but don't have release
-        # files for the release, so return early.
         return
 
     content = render_to_string('downloads/supernav.html', {


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

The Downloads supernav menu shows Python 3.14.0 instead of 3.14.2.

The supernav box was last updated on 9th October 2025 (when 3.14.0 was released) and hasn't updated since.

This was caused by https://github.com/python/pythondotorg/pull/2793 (merged 10th October) which changed `update_supernav()` to support the Python install manager, but introduced a regression.

The code iterates over each operating system, looking for download files with `download_button=True` (let's call them "featured files") to put in the supernav.

Before, operating systems without featured files were skipped:

```python
release_file = latest_python3.download_file_for_os(o.slug)
if not release_file:
    continue  # Skip this OS
data['python3'] = release_file
```

After, all operating systems are added to the list, even without featured files:

```python
data['python3'] = latest_python3.download_file_for_os(o.slug)
if latest_pymanager:
    data['pymanager'] = latest_pymanager.download_file_for_os(o.slug)

python_files.append(data)  # Always appends, even if no featured files
```

But then a later new check requires every OS to have a featured file:

```python
if not all(f['python3'] or f['pymanager'] for f in python_files):
    return  # Silently return without updating
```

However, Android has no featured files, so for Python 3.14.1 and 3.14.2, the function silently returns without updating the supernav box.

The fix is to restore the skip: only add an OS to `python_files` if it has a featured file. 


<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Closes

- Fixes https://github.com/python/pythondotorg/issues/2839

