### PR TITLE
Add "Edit this release" button to release pages

### DIFF
--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -21,6 +21,9 @@
 
 {% block content %}
     <article class="text">
+        {% if request.user.is_staff %}
+        <a role="button" class="button" href="{% url 'admin:downloads_release_change' release.pk %}">Edit this release</a>
+        {% endif %}
 
         <header class="article-header">
             <h1 class="page-title">{{ release.name }}</h1>


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Many published CMS pages have an "Edit this page" / "Edit this story" button at the top for logged-in users.

- See: https://github.com/search?q=repo%3Apython%2Fpythondotorg%20%22Edit%20this%22&type=code

- Let's also add one to release pages so RMs can easily edit pages such as https://www.python.org/downloads/release/python-3142/ instead of https://www.python.org/admin/ > Releases > and find the one you want.

<img width="406" height="394" alt="image" src="https://github.com/user-attachments/assets/ebbec439-7ee6-485a-846f-874dc15ebc0c" />
