### PR TITLE
Improve accessibility: wrap logo in div not H1

### DIFF
--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -1078,7 +1078,6 @@ h2.not-column {
     text-align: center;
     padding: .75em 1em; }
 
-/*h1*/
 .site-headline {
   color: white;
   margin: 0.15em auto 0.2em; }

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -411,7 +411,7 @@ h2.not-column {
     }
 }
 
-/*h1*/ .site-headline {
+.site-headline {
     color: $white;
     margin: 0.15em auto 0.2em;
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -194,9 +194,9 @@
         <header class="main-header" role="banner">
             <div class="container">
 
-                <h1 class="site-headline">
+                <div class="site-headline">
                     {% block section-logo %}<a href="/"><img class="python-logo" src="{{ STATIC_URL }}img/python-logo.png" alt="python&trade;"></a>{% endblock %}
-                </h1>
+                </div>
 
                 <div class="options-bar-container do-not-print">
                     <a href="https://donate.python.org/" class="donate-button">Donate</a>


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Improve accessibility
- Screen readers often allow to easily jump from heading to heading
- It's preferred to only have a single H1 per page, and to maintain a hierarchy of headers
- The logo doesn't need to be an H1
- We already have other H1s (on [release](https://www.python.org/downloads/release/python-3142/) pages, it's "Python 3.14.2" (some pages have yet other H1s, that's another issue)
- https://www.w3.org/WAI/tutorials/page-structure/headings/
- https://www.a11yproject.com/posts/how-to-accessible-heading-structure/


This does move the logo/menu a couple of pixels up, but I don't think that matters, and better to improve the page semantics.

**Before**

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/a4cf4508-7fc9-4e1b-8501-1a88125c88f2" />

**After**

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/09742c94-434c-4fb0-b449-9a0352b73dd4" />

