### PR TITLE
Use endpoint for release edit button that's only rendered for staff

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -347,6 +347,7 @@ http {
                         proxy_redirect off;
                         add_header Cache-Control "max-age=604800, public";
                         add_header Surrogate-Control "max-age=604800, stale-if-error=3600, stale-while-revalidate=300";
+                        proxy_hide_header Vary;
                         proxy_pass http://app_server/downloads/;
                 }
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -347,7 +347,6 @@ http {
                         proxy_redirect off;
                         add_header Cache-Control "max-age=604800, public";
                         add_header Surrogate-Control "max-age=604800, stale-if-error=3600, stale-while-revalidate=300";
-                        proxy_hide_header Vary;
                         proxy_pass http://app_server/downloads/;
                 }
 

--- a/downloads/views.py
+++ b/downloads/views.py
@@ -267,3 +267,17 @@ class ReleaseFeed(Feed):
                 return timezone.make_aware(item.release_date)
             return item.release_date
         return None
+
+
+class ReleaseEditButton(TemplateView):
+    """Render the release edit button (shown only to staff users).
+
+    This endpoint is not cached, allowing the edit button to appear
+    for staff users even when the release page itself is cached.
+    """
+    template_name = "downloads/release_edit_button.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["release_pk"] = self.kwargs["pk"]
+        return context

--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -8,6 +8,7 @@ from django.views.generic.base import TemplateView
 from django.conf import settings
 
 from cms.views import custom_404
+from downloads.views import ReleaseEditButton
 from users.views import HoneypotSignupView, CustomPasswordChangeView
 
 from . import views, urls_api
@@ -19,6 +20,7 @@ urlpatterns = [
     path('', views.IndexView.as_view(), name='home'),
     re_path(r'^_health/?', views.health, name='health'),
     path('authenticated', views.AuthenticatedView.as_view(), name='authenticated'),
+    path('release-edit-button/<int:pk>', ReleaseEditButton.as_view(), name='release_edit_button'),
     path('humans.txt', TemplateView.as_view(template_name='humans.txt', content_type='text/plain')),
     path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
     path('funding.json', views.serve_funding_json, name='funding_json'),

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -22,9 +22,7 @@
 
 {% block content %}
     <article class="text">
-        {% if request.user.is_staff %}
-        <a role="button" class="button" href="{% url 'admin:downloads_release_change' release.pk %}">Edit this release</a>
-        {% endif %}
+        <span data-html-include="{% url 'release_edit_button' release.pk %}"></span>
 
         <header class="article-header">
             <h1 class="page-title">{{ release.name }}</h1>

--- a/templates/downloads/release_edit_button.html
+++ b/templates/downloads/release_edit_button.html
@@ -1,0 +1,3 @@
+{% if request.user.is_staff %}
+<a role="button" class="button" href="{% url 'admin:downloads_release_change' release_pk %}">Edit this release</a>
+{% endif %}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Follow on from [python/pythondotorg#2843](https://github.com/python/pythondotorg/pull/2843)
- I can see the edit button locally on http://0.0.0.0:8000/downloads/release/python-3142/ but not at https://www.python.org/downloads/release/python-3142/
- I can see the edit button on pages such as https://www.python.org/psf/developersinresidence/ have an edit button
- I think this is because Fastly is caching `/downloads` for all users in the same way, because the Django `Vary` header is being hidden for `/downloads` but not other pages
- This caching was added in [python/pythondotorg#1390](https://github.com/python/pythondotorg/pull/1390) along with other measures, and the [majority](https://analytics.python.org/python.org/pages) of visits are to `/downloads`
- Perhaps it's safe to expose `Vary` and keep the other measures?
