### PR TITLE
Remove fundraiser banner as year 2025 is over

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -34,9 +34,6 @@
             crossorigin="anonymous"
     ></script>
     <script src="{{ STATIC_URL }}js/libs/modernizr.js"></script>
-    <script async
-            src="https://donate.python.org/fundraiser-banner/fundraiser-banner.js"></script>
-
 
     {% stylesheet 'style' %}
     {% stylesheet 'mq' %}


### PR DESCRIPTION
This reverts commit 27aef89cab44c2126d1a934b0da86bfd1f42211d.

The year 2025 is over, the banner has been up for more than 3 weeks (in production).

For discussion see:
- https://discuss.python.org/t/accessibility-issues-in-the-pypi-donation-banner/105383
- https://discuss.python.org/t/feedback-on-year-end-donation-banner-when-will-it-be-removed/105487
