### PR TITLE
Use native Django admin interface to support dark mode

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -1,9 +1,6 @@
 dj-database-url==0.5.0
 django-pipeline==3.1.0  # 3.0.0 is first version that supports Django 4.2
 django-sitetree==1.18.0  # >=1.17.1 is (?) first version that supports Django 4.2
-django-apptemplates==1.5
-django-admin-interface==0.28.9
-django-translation-aliases==0.1.0
 Django==4.2.27
 docutils==0.21.2
 Markdown==3.7

--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -123,15 +123,9 @@ TEMPLATES_DIR = os.path.join(BASE, 'templates')
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            TEMPLATES_DIR,
-        ],
+        'DIRS': [TEMPLATES_DIR],
+        'APP_DIRS': True,
         'OPTIONS': {
-            'loaders': [
-                'apptemplates.Loader',
-                'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader',
-            ],
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
@@ -190,13 +184,10 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.humanize',
 
-    'admin_interface',
-    'colorfield',
     'django.contrib.admin',
     'django.contrib.admindocs',
 
     'django_celery_beat',
-    'django_translation_aliases',
     'pipeline',
     'sitetree',
     'imagekit',

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,10 +1,10 @@
-{% extends "admin_interface:admin/base_site.html" %}
+{% extends "admin/base.html" %}
 {% load i18n %}
 
 {% block title %}{{ title }} | {% trans 'python.org' %}{% endblock %}
 
 {% block branding %}
-<h1 id="site-name">{% trans 'python.org administration' %}</h1>
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{% trans 'python.org administration' %}</a></h1>
 {% endblock %}
 
 {% block nav-global %}{% endblock %}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- I'd like the dark admin theme here, for those late night releases :)

I noticed there's a light/dark/auto theme button in the top right corner:

<img width="556" height="40" alt="image" src="https://github.com/user-attachments/assets/5c12858d-2bd2-427d-851a-aeeca8a3ad77" />

But no matter how many times I click it, it stays on light mode:

<img width="546" height="46" alt="image" src="https://github.com/user-attachments/assets/9cfa6232-9dab-47f6-bc24-8b48918c4fb8" />

<img width="547" height="42" alt="image" src="https://github.com/user-attachments/assets/4459ecee-8cae-42ed-92b4-35991beaf94b" />

Django does natively support dark mode, but we actually have a custom theme that doesn't support it: https://github.com/fabiocaccamo/django-admin-interface/issues/129

This PR reverts back to the native theme.

This was originally changed in https://github.com/python/pythondotorg/pull/2263 because:

> psf staff spend a lot of time between us.pycon.org and python.org django admin this enables configuration of a different theme for python.org so its easier to differentiate. thanks to `@swiencks` for pointing out how easy to confuse they are.

I don't know what us.pycon.org looks like behind the scenes, but perhaps we could apply this other custom theme over there? Or stick some big logos at the top?

Other options involve custom CSS for the custom theme here, but that's a fair chunk of work and extra code to maintain, when it's already been done in Django itself.

## Before

<img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/4a9f4c4f-7bb6-4fb9-95d2-5e39ff714dfe" />

## After

<img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/ee05123c-0460-4f3d-924a-65549871e214" />

<img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/3dfa207b-bfe3-4421-bbe9-55d1d3c10d60" />
