### PR TITLE
Only show MD5 or SHA-256 columns if there's data to show

### DIFF
--- a/downloads/templatetags/download_tags.py
+++ b/downloads/templatetags/download_tags.py
@@ -97,6 +97,16 @@ def has_sbom(files):
 
 
 @register.filter
+def has_md5(files):
+    return any(f.md5_sum for f in files)
+
+
+@register.filter
+def has_sha256(files):
+    return any(f.sha256_sum for f in files)
+
+
+@register.filter
 def sort_windows(files):
     if not files:
         return files

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -99,11 +99,10 @@
               {% if release_files|has_gpg %}
               <th><a href="https://www.python.org/downloads/#gpg">GPG</a></th>
               {% endif %}
-              {% if release_files|has_md5 %}
-              <th>MD5 checksum</th>
-              {% endif %}
               {% if release_files|has_sha256 %}
               <th>SHA-256 checksum</th>
+              {% elif release_files|has_md5 %}
+              <th>MD5 checksum</th>
               {% endif %}
             </tr>
           </thead>
@@ -128,11 +127,10 @@
                 {% if release_files|has_gpg %}
                 <td>{% if f.gpg_signature_file %}<a href="{{ f.gpg_signature_file }}">SIG</a>{% endif %}</td>
                 {% endif %}
-                {% if release_files|has_md5 %}
-                <td>{{ f.md5_sum }}</td>
-                {% endif %}
                 {% if release_files|has_sha256 %}
                 <td>{{ f.sha256_sum }}</td>
+                {% elif release_files|has_md5 %}
+                <td>{{ f.md5_sum }}</td>
                 {% endif %}
               </tr>
             {% endfor %}

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -87,9 +87,9 @@
           <thead>
             <tr>
               <th>Version</th>
-              <th>Operating System</th>
+              <th>Operating system</th>
               <th>Description</th>
-              <th>File Size</th>
+              <th>File size</th>
               {% if release_files|has_sigstore_materials %}
               <th colspan="2"><a href="https://www.python.org/download/sigstore/">Sigstore</a></th>
               {% endif %}
@@ -100,10 +100,10 @@
               <th><a href="https://www.python.org/downloads/#gpg">GPG</a></th>
               {% endif %}
               {% if release_files|has_md5 %}
-              <th>MD5 Checksum</th>
+              <th>MD5 checksum</th>
               {% endif %}
               {% if release_files|has_sha256 %}
-              <th>SHA256 Checksum</th>
+              <th>SHA-256 checksum</th>
               {% endif %}
             </tr>
           </thead>

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -4,6 +4,8 @@
 {% load has_gpg from download_tags %}
 {% load has_sigstore_materials from download_tags %}
 {% load has_sbom from download_tags %}
+{% load has_md5 from download_tags %}
+{% load has_sha256 from download_tags %}
 {% load sort_windows from download_tags %}
 {% load get_eol_info from download_tags %}
 
@@ -87,8 +89,12 @@
               <th>Version</th>
               <th>Operating System</th>
               <th>Description</th>
+              {% if release_files|has_md5 %}
               <th>MD5 Checksum</th>
+              {% endif %}
+              {% if release_files|has_sha256 %}
               <th>SHA256 Checksum</th>
+              {% endif %}
               <th>File Size</th>
               {% if release_files|has_sigstore_materials %}
               <th colspan="2"><a href="https://www.python.org/download/sigstore/">Sigstore</a></th>
@@ -107,8 +113,12 @@
                 <td><a href="{{ f.url }}">{{ f.name }}</a></td>
                 <td>{{ f.os.name }}</td>
                 <td>{{ f.description }}</td>
+                {% if release_files|has_md5 %}
                 <td>{{ f.md5_sum }}</td>
-                <td>{{ f.sha256_sum|default:"n/a" }}</td>
+                {% endif %}
+                {% if release_files|has_sha256 %}
+                <td>{{ f.sha256_sum }}</td>
+                {% endif %}
                 <td>{{ f.filesize|filesizeformat }}</td>
                 {% if release_files|has_sigstore_materials %}
                   {% if f.sigstore_bundle_file %}

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -89,12 +89,6 @@
               <th>Version</th>
               <th>Operating System</th>
               <th>Description</th>
-              {% if release_files|has_md5 %}
-              <th>MD5 Checksum</th>
-              {% endif %}
-              {% if release_files|has_sha256 %}
-              <th>SHA256 Checksum</th>
-              {% endif %}
               <th>File Size</th>
               {% if release_files|has_sigstore_materials %}
               <th colspan="2"><a href="https://www.python.org/download/sigstore/">Sigstore</a></th>
@@ -105,6 +99,12 @@
               {% if release_files|has_gpg %}
               <th><a href="https://www.python.org/downloads/#gpg">GPG</a></th>
               {% endif %}
+              {% if release_files|has_md5 %}
+              <th>MD5 Checksum</th>
+              {% endif %}
+              {% if release_files|has_sha256 %}
+              <th>SHA256 Checksum</th>
+              {% endif %}
             </tr>
           </thead>
           <tbody>
@@ -113,12 +113,6 @@
                 <td><a href="{{ f.url }}">{{ f.name }}</a></td>
                 <td>{{ f.os.name }}</td>
                 <td>{{ f.description }}</td>
-                {% if release_files|has_md5 %}
-                <td>{{ f.md5_sum }}</td>
-                {% endif %}
-                {% if release_files|has_sha256 %}
-                <td>{{ f.sha256_sum }}</td>
-                {% endif %}
                 <td>{{ f.filesize|filesizeformat }}</td>
                 {% if release_files|has_sigstore_materials %}
                   {% if f.sigstore_bundle_file %}
@@ -133,6 +127,12 @@
                 {% endif %}
                 {% if release_files|has_gpg %}
                 <td>{% if f.gpg_signature_file %}<a href="{{ f.gpg_signature_file }}">SIG</a>{% endif %}</td>
+                {% endif %}
+                {% if release_files|has_md5 %}
+                <td>{{ f.md5_sum }}</td>
+                {% endif %}
+                {% if release_files|has_sha256 %}
+                <td>{{ f.sha256_sum }}</td>
                 {% endif %}
               </tr>
             {% endfor %}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

Part of https://github.com/python/pythondotorg/issues/1227.

The table is now very wide with SHA-256 checksums:

<img width="1271" height="809" alt="image" src="https://github.com/user-attachments/assets/79d391cb-54c0-48d0-9638-72acb1d584ea" />


This PR:

* Move checksums to the last columns
* Only show a checksum column if there's checksums available
* If there's both SHA-256 and MD5, only show SHA-256
* Use sentence case for headers and add hyphen to SHA-256
