### PR TITLE
update GHA conditional to allow running on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   migrations:
-    if: github.event_name != 'push' || github.event.repository.fork == true
+    if: github.event_name != 'push' || github.event.repository.fork == true || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -40,7 +40,7 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/pythonorg
 
   test:
-    if: github.event_name != 'push' || github.event.repository.fork == true
+    if: github.event_name != 'push' || github.event.repository.fork == true || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   collectstatic:
-    if: github.event_name != 'push' || github.event.repository.fork == true
+    if: github.event_name != 'push' || github.event.repository.fork == true || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- In https://github.com/python/pythondotorg/pull/2852 it seems it caused some checks to not run on merge on `main` which may or may not affect cabotage deploys