### PR TITLE
Fix tests: Intermittent FK constraint violation on polymorphic_ctype_id

### DIFF
--- a/mailing/tests/test_forms.py
+++ b/mailing/tests/test_forms.py
@@ -1,5 +1,6 @@
 """Tests for mailing app forms."""
 from django.test import TestCase
+from django.contrib.contenttypes.models import ContentType
 
 from mailing.tests.forms import TestBaseEmailTemplateForm
 
@@ -12,6 +13,10 @@ class BaseEmailTemplateFormTests(TestCase):
             "subject": "Hello",
             "internal_name": "notification 01",
         }
+
+    def tearDown(self):
+        super().tearDown()
+        ContentType.objects.clear_cache()
 
     def test_validate_required_fields(self):
         required = set(self.data)

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -63,3 +63,5 @@ CACHES = {
 REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] += (
     'rest_framework.renderers.BrowsableAPIRenderer',
 )
+
+BAKER_CUSTOM_CLASS = "pydotorg.tests.baker.PolymorphicAwareBaker"

--- a/pydotorg/tests/baker.py
+++ b/pydotorg/tests/baker.py
@@ -1,0 +1,17 @@
+from polymorphic.models import PolymorphicModel
+from model_bakery import baker
+
+
+class PolymorphicAwareBaker(baker.Baker):
+    """
+    Our custom model baker ignores the polymorphic_ctype field on all polymorphic
+    models - this allows the base class to set it correctly.
+
+    See https://github.com/python/pythondotorg/issues/2567
+    """
+
+    def get_fields(self):
+        fields = super().get_fields()
+        if issubclass(self.model, PolymorphicModel):
+            fields = {field for field in fields if field.name != "polymorphic_ctype"}
+        return fields


### PR DESCRIPTION
#### Description

#2567 documents intermittent failures on tests involving the polymorphic models in the sponsors directory. The exception is always along the lines of:

```
psycopg2.errors.ForeignKeyViolation: insert or update on table "..." violates foreign key constraint "..."
DETAIL:  Key (polymorphic_ctype_id)=(100) is not present in table "django_content_type".
```

[django-polymorphic](https://pypi.org/project/django-polymorphic) uses the ``polymorphic_ctype`` field to track the concrete instance type on the base table. It sets this field automatically. Whats happening here is that *model bakery is overriding this field and setting it to a random content type*. Most of the time this passed the foreign key constraint - but ``ContentType`` objects are cached and ``mailing/tests/models.py`` created a temporary model (``MockEmailTemplate``) in a transaction that is rolled back after the mailing tests are complete. The cache that model bakery was drawing content types from was not cleared however. You get the fk constraint error when it happened to randomly set the content type of a polymorphic model to ``MockEmailTemplate``.

There are two parts to the fix here:

1. I explicitly clear the ContentType cache after the mailing tests run. This is not strictly necessary because 2 fixes the real problem.
2. I configure the test to [use a custom model baker class](https://model-bakery.readthedocs.io/en/latest/how_bakery_behaves.html#customizing-baker) that detects polymorphic models and ignores the polymorphic_ctype field on them, allowing the base class to set it properly. I think this is the best approach because:
    -    I looked into using recipes but you'd have to specify a recipe for each polymorphic model type and the diff in the   tests would be huge.
    -    This method will also work for any future accidental uses of baker.make(PolymorphicModel).
    -    It is my hope that a future major release of [django-polymorphic](https://pypi.org/project/django-polymorphic) will no longer rely on the contenttypes framework, eliminating the need for special model bakery logic for polymorphic models.

#### Closes

- #2567

