### PR TITLE
Add LocaleMiddleware to fix language chooser warning in tests

### DIFF
--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -161,6 +161,7 @@ ROOT_URLCONF = 'pydotorg.urls'
 # 'SecurityMiddleware' because we set appropriate headers in python/psf-salt.
 MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'pydotorg.middleware.AdminNoCaching',


### PR DESCRIPTION
## Summary
This PR adds `django.middleware.locale.LocaleMiddleware` to the MIDDLEWARE setting to resolve the warning that appears during test runs.

## Changes
- Added `LocaleMiddleware` after `SessionMiddleware` in `pydotorg/settings/base.py`

## Issue
Fixes #2742

## Context
The `admin_interface` package's language chooser feature requires `LocaleMiddleware` to be present in the MIDDLEWARE setting. Without it, a warning is raised:

```
UserWarning: Language chooser requires 'django.middleware.locale.LocaleMiddleware' in your MIDDLEWARE to work.
```

The middleware is placed after `SessionMiddleware` as per [Django's documentation](https://docs.djangoproject.com/en/5.0/topics/i18n/translation/#how-django-discovers-language-preference), which recommends it be positioned early, but after SessionMiddleware.
