### PR TITLE
Improve checksum display

### DIFF
--- a/static/sass/style.css
+++ b/static/sass/style.css
@@ -1899,6 +1899,10 @@ table th, table td {
     border-left: none; }
 table tfoot {
   border-top: 1px solid #dddddd; }
+table .checksum {
+  font-size: 0.85em; }
+  table .checksum .checksum-half {
+    display: inline-block; }
 
 .row-title {
   border-top: 5px solid #d4dbe1;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1012,6 +1012,12 @@ table {
     }
 
     tfoot { border-top: 1px solid $grey-lighterer; }
+
+    .checksum {
+        font-size: 0.85em;
+
+        .checksum-half { display: inline-block; }
+    }
 }
 
 .documentation-help { }

--- a/templates/downloads/release_detail.html
+++ b/templates/downloads/release_detail.html
@@ -8,6 +8,7 @@
 {% load has_sha256 from download_tags %}
 {% load sort_windows from download_tags %}
 {% load get_eol_info from download_tags %}
+{% load wbr_wrap from download_tags %}
 
 {% block body_attributes %}class="python downloads"{% endblock %}
 
@@ -126,9 +127,9 @@
                 <td>{% if f.gpg_signature_file %}<a href="{{ f.gpg_signature_file }}">SIG</a>{% endif %}</td>
                 {% endif %}
                 {% if release_files|has_sha256 %}
-                <td>{{ f.sha256_sum }}</td>
+                <td><code class="checksum">{{ f.sha256_sum|wbr_wrap }}</code></td>
                 {% elif release_files|has_md5 %}
-                <td>{{ f.md5_sum }}</td>
+                <td><code class="checksum">{{ f.md5_sum|wbr_wrap }}</code></td>
                 {% endif %}
               </tr>
             {% endfor %}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

Use `<wbr>` for optional line breaks every 16 characters. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/wbr

That means the 32-char MD5 may be split into two. The 64-char SHA-256 may be split into two or four.

And use spans so the first split is not:

```
d7fe130d0501ae04
7ca318fa92aa642603ab6f217901015a1df6ce650d5470cd
```

But instead:

```
d7fe130d0501ae047ca318fa92aa6426
03ab6f217901015a1df6ce650d5470cd
```

And then:
```
d7fe130d0501ae04
7ca318fa92aa6426
03ab6f217901015a
1df6ce650d5470cd
```

Also put in a `<code>` block for monospace font.

## SHA-256

Fullscreen (MacBook Air laptop)

<img width="1470" height="826" alt="image" src="https://github.com/user-attachments/assets/bacca709-172c-4094-8dc7-2d1ad36f9a0e" />

Narrower:

<img width="867" height="824" alt="image" src="https://github.com/user-attachments/assets/3afebd05-e15c-4eff-b807-fa3ee7265279" />

## MD5

Fullscreen:

<img width="1470" height="620" alt="image" src="https://github.com/user-attachments/assets/adc20b2c-3509-4d59-8cf7-43a1e9451aec" />

Narrower:

<img width="865" height="567" alt="image" src="https://github.com/user-attachments/assets/52d19220-52b6-47d6-8454-640840a57fd7" />




<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#### Related

- https://github.com/python/pythondotorg/issues/1227

