### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Ruff linting and formatting (#2882)
+2cf268f0c3b35973cfb6d5bbcfec5de09954eae7
+
+# Move apps under apps/ namespace and update all imports (#2883)
+31bc7e3698333333397292dc01d88e61e41761ab


### PR DESCRIPTION
## Summary

- Adds `.git-blame-ignore-revs` so `git blame` skips bulk formatting/restructure commits
- Covers ruff formatting (#2882, `2cf268f0`) and app restructure (#2883, `31bc7e36`)
- GitHub automatically respects this file; local users can run:
  ```
  git config blame.ignoreRevsFile .git-blame-ignore-revs
  ```

## Test plan

- [ ] Verify `git blame` on a file touched by both #2882 and #2883 skips those commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)