### PR TITLE
fix: ci and group pkg installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pip-
 
       - name: Install dependencies
-        run: pip install -e '.[dev]'
+        run: pip install --group dev -e .
 
       - name: Check for ungenerated migrations
         run: python manage.py makemigrations --check --dry-run
@@ -82,9 +82,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pip-
 
       - name: Install dependencies
-        run: |
-          pip install -U pip setuptools wheel
-          pip install -e '.[dev]'
+        run: pip install --group dev -e .
 
       - name: Run tests
         run: python -Wd -m coverage run manage.py test -v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ COPY pyproject.toml /code/
 RUN --mount=type=cache,target=/root/.cache/pip \
     set -x \
     && pip --disable-pip-version-check \
-        install \
-        '.[dev]'
+        install --group dev \
+        .
 
 COPY . /code/
 

--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -25,13 +25,19 @@ HAYSTACK_CONNECTIONS = {
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 
-INSTALLED_APPS += [
-    "debug_toolbar",
-]
+try:
+    import debug_toolbar  # noqa: F401
 
-MIDDLEWARE += [
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
-]
+    INSTALLED_APPS += [
+        "debug_toolbar",
+    ]
+
+    MIDDLEWARE += [
+        "debug_toolbar.middleware.DebugToolbarMiddleware",
+    ]
+except ModuleNotFoundError as exc:
+    if exc.name != "debug_toolbar":
+        raise
 
 CACHES = {
     "default": {

--- a/pydotorg/urls.py
+++ b/pydotorg/urls.py
@@ -73,6 +73,7 @@ urlpatterns += staticfiles_urlpatterns()
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-    import debug_toolbar
+    if "debug_toolbar" in settings.INSTALLED_APPS:
+        import debug_toolbar
 
-    urlpatterns = [path("__debug__/", include(debug_toolbar.urls)), *urlpatterns]
+        urlpatterns = [path("__debug__/", include(debug_toolbar.urls)), *urlpatterns]


### PR DESCRIPTION
## Summary
- Use `pip install --group dev` (PEP 735) instead of `pip install '.[dev]'` in CI and Dockerfile
  - Dev deps are under `[dependency-groups]`, not `[project.optional-dependencies]`
  - This was causing all dev deps (coverage, debug_toolbar, factory-boy, etc.) to silently not install
- Guard `import debug_toolbar` in `urls.py` and `local.py` with scoped `ModuleNotFoundError` check
  - Only suppresses when `debug_toolbar` itself is missing; re-raises transitive import failures

## Test plan
- [ ] CI migrations check passes
- [ ] CI test suite runs (coverage, factory-boy, etc. installed)
- [ ] Local `make serve` works with Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)