### PR TITLE
add incorp location to agreement

### DIFF
--- a/apps/sponsors/models/sponsors.py
+++ b/apps/sponsors/models/sponsors.py
@@ -97,6 +97,19 @@ class Sponsor(ContentManageable):
         return f"{self.name}"
 
     @property
+    def incorporation_location(self):
+        """Return the incorporation location for use in contracts.
+
+        For non-US companies, return the country name (preferring country of
+        incorporation over mailing country). For US companies, return the state
+        of incorporation if provided, otherwise the mailing state.
+        """
+        country = self.country_of_incorporation or self.country
+        if country and str(country) != "US":
+            return str(country.name)
+        return self.state_of_incorporation or self.state
+
+    @property
     def full_address(self):
         """Return the full mailing address as a formatted string."""
         addr = self.mailing_address_line_1

--- a/apps/sponsors/templates/sponsors/admin/contracts/sponsorship-agreement.md
+++ b/apps/sponsors/templates/sponsors/admin/contracts/sponsorship-agreement.md
@@ -16,7 +16,7 @@ is entered into and made effective as of the
 by and between the **Python Software Foundation** (the **"PSF"**),
 a Delaware nonprofit corporation,
 and **{{sponsor.name|upper}}** (**"Sponsor"**),
-a {{sponsor.state}} corporation.
+a {{sponsor.incorporation_location}} corporation.
 Each of the PSF and Sponsor are hereinafter sometimes individually
 referred to as a **"Party"** and collectively as the **"Parties"**.
 
@@ -180,7 +180,7 @@ wishes to support the Programs by making a contribution to the PSF.
 
 >    **SPONSOR**:  
 >    **{{sponsor.name|upper}}**,  
->    a {{sponsor.state}} entity
+>    a {{sponsor.incorporation_location}} entity
 
 &nbsp;
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Set incorporation location based on US/Non-US or differing state (but keep defaults)