### PR TITLE
Fix: Display sponsorship benefit descriptions inline (#2091)

### DIFF
--- a/apps/users/templates/users/sponsorship_detail.html
+++ b/apps/users/templates/users/sponsorship_detail.html
@@ -113,9 +113,7 @@
                             <div class="benefit-content">
                                 <span class="benefit-name">{{ benefit.name_for_display }}</span>
                                 {% if benefit.description %}
-                                    <span class="benefit-description" title="{{ benefit.description }}">
-                            <i class="fa fa-info-circle"></i>
-                        </span>
+                                    <span class="benefit-description"> - {{ benefit.description }}</span>
                                 {% endif %}
                                 <span class="benefit-category">{{ benefit.program.name }}</span>
                             </div>


### PR DESCRIPTION
Fixes #2091. This replaces the info-circle tooltip hover on the Sponsorship Dashboard with an inline text description next to the benefit name, making the text easier to view as requested.