### PR TITLE
style: make edit sponsor info link a button

### DIFF
--- a/apps/users/templates/users/sponsorship_detail.html
+++ b/apps/users/templates/users/sponsorship_detail.html
@@ -33,7 +33,7 @@
                     <li><b>State:</b> {{ sponsor.state }}</li>
                     <li><b>Country:</b> {{ sponsor.country }}</li>
                 </ul>
-                <small><a href="{% url 'users:edit_sponsor_info' sponsorship.sponsor.pk %}">Edit sponsor information</a></small>
+                <a href="{% url 'users:edit_sponsor_info' sponsorship.sponsor.pk %}" class="button">Edit sponsor information</a>
             </div>
 
             <div id="application-info" class="card small-column">


### PR DESCRIPTION
## Summary
- changes the "edit sponsor information" link on the sponsorship detail page from a plain `<small><a>` text link to an `<a class="button">` so it actually looks like a clickable button
- uses the existing psf site `button` class for consistency with the rest of the ui
<img width="589" height="580" alt="image" src="https://github.com/user-attachments/assets/e4ccd55a-e530-4fa9-91d6-063483c5a015" />
