### PR TITLE
fix(cdn): use purge by key endpoint

### DIFF
--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -24,5 +24,6 @@ jobs:
       - name: Purge ${{ env.KEY }}
         run: |
           curl -fsS -X POST \
-            "https://api.fastly.com/service/${{ secrets.FASTLY_SERVICE_ID }}/purge/${{ env.KEY }}" \
-            -H "Fastly-Key: ${{ secrets.FASTLY_API_KEY }}"
+            "https://api.fastly.com/service/${{ secrets.FASTLY_SERVICE_ID }}/purge" \
+            -H "Fastly-Key: ${{ secrets.FASTLY_API_KEY }}" \
+            -H "Surrogate-Key: ${{ env.KEY }}"


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- surrogate key purge was hitting the singlw purge endpoint instead of purge-by-key
