### PR TITLE
Handle malformed release versions in docs versions view

### DIFF
--- a/pydotorg/tests/test_views.py
+++ b/pydotorg/tests/test_views.py
@@ -34,3 +34,13 @@ class ViewsTests(TestCase):
         self.assertContains(response, "Browse Python 3.6.0 Documentation")
         self.assertContains(response, "https://docs.python.org/3/whatsnew/3.6.html")
         self.assertContains(response, "What's new in Python 3.6")
+
+    def test_docs_versions_ignores_malformed_release_version(self):
+        Release.objects.create(
+            name="Python 4",
+            is_published=True,
+            pre_release=False,
+        )
+
+        response = self.client.get(reverse("docs-versions"))
+        self.assertEqual(response.status_code, 200)

--- a/pydotorg/views.py
+++ b/pydotorg/views.py
@@ -125,6 +125,8 @@ class DocsByVersionView(TemplateView):
 
                 # Get major.minor version ("3.14.0" -> "3.14")
                 version_parts = full_version.split(".")
+                if len(version_parts) < 2:
+                    continue
                 major_minor = f"{version_parts[0]}.{version_parts[1]}"
 
                 # For 3.2.0 and earlier, use X.Y instead of X.Y.0

--- a/pydotorg/views.py
+++ b/pydotorg/views.py
@@ -125,7 +125,7 @@ class DocsByVersionView(TemplateView):
 
                 # Get major.minor version ("3.14.0" -> "3.14")
                 version_parts = full_version.split(".")
-                if len(version_parts) < 2:
+                if len(version_parts) < SEMANTIC_VERSION_PARTS - 1:
                     continue
                 major_minor = f"{version_parts[0]}.{version_parts[1]}"
 


### PR DESCRIPTION
#### Description

- Skip malformed release versions in `DocsByVersionView` when a release name does not include at least `major.minor` parts.
- Add a regression test to ensure `/doc/versions/` still returns HTTP 200 when such a release exists.

#### Closes

- 
