### PR TITLE
fix: guard validate_unique against unsaved Release in admin add view

### DIFF
--- a/apps/downloads/models.py
+++ b/apps/downloads/models.py
@@ -361,7 +361,7 @@ class ReleaseFile(ContentManageable, NameSlugModel):
 
     def validate_unique(self, exclude=None):
         """Ensure only one release file per OS has the download button enabled."""
-        if self.download_button:
+        if self.download_button and self.release_id:
             qs = ReleaseFile.objects.filter(release=self.release, os=self.os, download_button=True).exclude(pk=self.id)
             if qs.count() > 0:
                 msg = 'Only one Release File per OS can have "Download button" enabled'


### PR DESCRIPTION
## Summary

- Django 5.2 (deployed Feb 6 via #2741) raises `ValueError("Model instances passed to related filters must be saved.")` when unsaved model instances are used in queryset filters
- `ReleaseFile.validate_unique()` filters by `release=self.release`, which fails on the admin **add** view because the parent `Release` hasn't been saved yet (no PK)
- Adding `and self.release_id` skips the uniqueness query for unsaved releases — safe because no conflicting records can exist for a release not yet in the database

## Context

Steve Dower hit this today trying to create the "Python install manager 26.0" release via `/admin/downloads/release/add/` with an inline MSIX release file that had `download_button=True`. Got 500 errors 3 times.

Sentry event: `d05ec42eb5a44cceb69616c057186471`

The `validate_unique` was added in #2137 (Sept 2022) and worked fine until the Django 5.2 upgrade tightened related filter validation.

**Workaround** (until this is deployed): create the release without release files or with `download_button` unchecked, save, then edit to add them.

## Test plan

- [ ] Create a new release via `/admin/downloads/release/add/` with an inline release file that has `download_button=True` — should save successfully
- [ ] Edit an existing release and toggle `download_button` — uniqueness validation should still fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)