### PR TITLE
Use jQuery .getJSON() to avoid type inference

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -174,7 +174,7 @@ $().ready(function() {
     if($('body#homepage').length) {
         var launch_shell = $('#launch-shell');
         launch_shell.toggle();
-        $.get('https://console.python.org/python-dot-org-live-consoles-status', function (data) {
+        $.getJSON('https://console.python.org/python-dot-org-live-consoles-status', function (data) {
             if(data.status == 'OK') {
                 launch_shell.toggle();
             }


### PR DESCRIPTION
`$.get()` does type inference based on content type of response, we only expect JSON here.