### PR TITLE
don't override host, breaks csrf

### DIFF
--- a/infra/cdn/main.tf
+++ b/infra/cdn/main.tf
@@ -32,7 +32,7 @@ resource "fastly_service_vcl" "python_org" {
     connect_timeout       = 1000
     first_byte_timeout    = 30000
     between_bytes_timeout = 10000
-    override_host         = var.backend_address
+    override_host         = var.subdomain == "www.test.python.org" ? "www.python.org" : null
   }
 
   backend {


### PR DESCRIPTION
cabotage is now accepting this host header on the backend so no need to override