### PR TITLE
fix(Sentry:PYDOTORG-PROD-1MQ): duplicate key crash on sponsor appliction form submission

### DIFF
--- a/apps/sponsors/models/benefits.py
+++ b/apps/sponsors/models/benefits.py
@@ -1,7 +1,7 @@
 """Benefit feature and configuration models for the sponsors app."""
 
 from django import forms
-from django.db import models
+from django.db import IntegrityError, models, transaction
 from django.db.models import UniqueConstraint
 from django.urls import reverse
 from polymorphic.models import PolymorphicModel
@@ -155,11 +155,15 @@ class AssetConfigurationMixin:
 
         asset_qs = content_object.assets.filter(internal_name=self.internal_name)
         if not asset_qs.exists():
-            asset = self.ASSET_CLASS(
-                content_object=content_object,
-                internal_name=self.internal_name,
-            )
-            asset.save()
+            try:
+                with transaction.atomic():
+                    asset = self.ASSET_CLASS(
+                        content_object=content_object,
+                        internal_name=self.internal_name,
+                    )
+                    asset.save()
+            except IntegrityError:
+                pass  # asset already exists, created by another benefit config
 
         return benefit_feature
 

--- a/apps/sponsors/models/benefits.py
+++ b/apps/sponsors/models/benefits.py
@@ -163,7 +163,8 @@ class AssetConfigurationMixin:
                     )
                     asset.save()
             except IntegrityError:
-                pass  # asset already exists, created by another benefit config
+                if not content_object.assets.filter(internal_name=self.internal_name).exists():
+                    raise
 
         return benefit_feature
 

--- a/apps/sponsors/tests/test_models.py
+++ b/apps/sponsors/tests/test_models.py
@@ -1127,6 +1127,19 @@ class RequiredTextAssetConfigurationTests(TestCase):
         self.config.create_benefit_feature(self.sponsor_benefit)
         self.assertEqual(1, TextAsset.objects.count())
 
+    def test_create_benefit_feature_with_preexisting_asset_no_crash(self):
+        """Regression: submitting a new sponsorship when the sponsor already
+        has an asset with the same internal_name (from a prior application)
+        should not raise an IntegrityError."""
+        sponsor = self.sponsor_benefit.sponsorship.sponsor
+        TextAsset.objects.create(
+            content_object=sponsor,
+            internal_name=self.config.internal_name,
+        )
+        # should not raise IntegrityError
+        self.config.create_benefit_feature(self.sponsor_benefit)
+        self.assertEqual(1, TextAsset.objects.count())
+
     def test_clone_configuration_for_new_sponsorship_benefit_with_new_due_date(self):
         sp_benefit = baker.make(SponsorshipBenefit, year=2023)
 

--- a/apps/sponsors/tests/test_models.py
+++ b/apps/sponsors/tests/test_models.py
@@ -1140,6 +1140,17 @@ class RequiredTextAssetConfigurationTests(TestCase):
         self.config.create_benefit_feature(self.sponsor_benefit)
         self.assertEqual(1, TextAsset.objects.count())
 
+    def test_integrity_error_reraised_when_asset_missing(self):
+        """An IntegrityError that is NOT a duplicate-asset collision must
+        propagate so it doesn't get silently swallowed."""
+        from unittest.mock import patch
+
+        with (
+            patch.object(TextAsset, "save", side_effect=IntegrityError("unrelated")),
+            self.assertRaises(IntegrityError),
+        ):
+            self.config.create_benefit_feature(self.sponsor_benefit)
+
     def test_clone_configuration_for_new_sponsorship_benefit_with_new_due_date(self):
         sp_benefit = baker.make(SponsorshipBenefit, year=2023)
 


### PR DESCRIPTION

<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->
#### Description

- Fixes https://python-software-foundation.sentry.io/issues/7333468077/?alert_rule_id=70449&alert_type=issue&environment=production&notification_uuid=1939dba5-edd0-43be-9344-5e14df0577dd&project=39935&referrer=slack
