### PR TITLE
fix: remap dead hg.python.org release-notes URLs to GitHub equivalents

### DIFF
--- a/apps/downloads/models.py
+++ b/apps/downloads/models.py
@@ -123,18 +123,29 @@ class Release(ContentManageable, NameSlugModel):
         the "Release notes" links on the downloads page still work for legacy
         releases (3.3.6 and earlier).
 
-        Example::
+        Examples::
 
             http://hg.python.org/cpython/file/v3.3.6/Misc/NEWS
             → https://github.com/python/cpython/blob/v3.3.6/Misc/NEWS
+
+            http://hg.python.org/cpython/raw-file/v2.7.3/Misc/NEWS
+            → https://raw.githubusercontent.com/python/cpython/v2.7.3/Misc/NEWS
         """
         url = self.release_notes_url
         if not url:
             return url
-        match = re.match(r"https?://hg\.python\.org/cpython/file/([^/]+)/(.+)", url)
-        if match:
-            tag, path = match.group(1), match.group(2)
-            return f"https://github.com/python/cpython/blob/{tag}/{path}"
+        for prefix in (
+            "http://hg.python.org/cpython/file/",
+            "https://hg.python.org/cpython/file/",
+        ):
+            if url.startswith(prefix):
+                return "https://github.com/python/cpython/blob/" + url[len(prefix):]
+        for prefix in (
+            "http://hg.python.org/cpython/raw-file/",
+            "https://hg.python.org/cpython/raw-file/",
+        ):
+            if url.startswith(prefix):
+                return "https://raw.githubusercontent.com/python/cpython/" + url[len(prefix):]
         return url
 
     def download_file_for_os(self, os_slug):

--- a/apps/downloads/models.py
+++ b/apps/downloads/models.py
@@ -114,6 +114,29 @@ class Release(ContentManageable, NameSlugModel):
             return self.release_page.get_absolute_url()
         return reverse("download:download_release_detail", kwargs={"release_slug": self.slug})
 
+    @property
+    def corrected_release_notes_url(self):
+        """Return the release notes URL, converting dead hg.python.org links to GitHub.
+
+        Old Mercurial-hosted URLs (hg.python.org) are no longer reachable.
+        This property remaps them to their equivalent paths on GitHub so that
+        the "Release notes" links on the downloads page still work for legacy
+        releases (3.3.6 and earlier).
+
+        Example::
+
+            http://hg.python.org/cpython/file/v3.3.6/Misc/NEWS
+            → https://github.com/python/cpython/blob/v3.3.6/Misc/NEWS
+        """
+        url = self.release_notes_url
+        if not url:
+            return url
+        match = re.match(r"https?://hg\.python\.org/cpython/file/([^/]+)/(.+)", url)
+        if match:
+            tag, path = match.group(1), match.group(2)
+            return f"https://github.com/python/cpython/blob/{tag}/{path}"
+        return url
+
     def download_file_for_os(self, os_slug):
         """Given an OS slug return the appropriate download file."""
         try:
@@ -430,3 +453,4 @@ class ReleaseFile(ContentManageable, NameSlugModel):
                 violation_error_message="All file URLs must begin with 'https://www.python.org/'",
             ),
         ]
+

--- a/apps/downloads/templates/downloads/index.html
+++ b/apps/downloads/templates/downloads/index.html
@@ -76,7 +76,7 @@
                             <span class="release-number"><a href="{{ r.get_absolute_url }}">{{ r.name }}</a></span>
                             <span class="release-date">{{ r.release_date|date }}</span>
                             <span class="release-download"><a href="{{ r.get_absolute_url }}"><span aria-hidden="true" class="icon-download"></span> Download</a></span>
-                            <span class="release-enhancements"><a href="{{ r.release_notes_url }}">Release notes</a></span>
+                            <span class="release-enhancements">{% if r.corrected_release_notes_url %}<a href="{{ r.corrected_release_notes_url }}">Release notes</a>{% else %}Release notes{% endif %}</span>
                         </li>
                         {% endfor %}
                     </ol>
@@ -127,3 +127,4 @@
                     {% box 'download-pgp' %}
                 </div>
 {% endblock content %}
+

--- a/apps/downloads/tests/test_models.py
+++ b/apps/downloads/tests/test_models.py
@@ -311,3 +311,53 @@ class DownloadModelTests(BaseDownloadTests):
                         name="Windows installer draft",
                         **kwargs,
                     )
+
+class ReleaseNotesURLTests(BaseDownloadTests):
+    """Tests for Release.corrected_release_notes_url property."""
+
+    def test_hg_url_converted_to_github(self):
+        """An hg.python.org URL is remapped to its GitHub equivalent."""
+        release = Release.objects.create(
+            version=Release.PYTHON3,
+            name="Python 3.3.6",
+            is_published=True,
+            release_notes_url="http://hg.python.org/cpython/file/v3.3.6/Misc/NEWS",
+        )
+        self.assertEqual(
+            release.corrected_release_notes_url,
+            "https://github.com/python/cpython/blob/v3.3.6/Misc/NEWS",
+        )
+
+    def test_https_hg_url_also_converted(self):
+        """An https hg.python.org URL is also remapped to GitHub."""
+        release = Release.objects.create(
+            version=Release.PYTHON3,
+            name="Python 3.2.6",
+            is_published=True,
+            release_notes_url="https://hg.python.org/cpython/file/v3.2.6/Misc/NEWS",
+        )
+        self.assertEqual(
+            release.corrected_release_notes_url,
+            "https://github.com/python/cpython/blob/v3.2.6/Misc/NEWS",
+        )
+
+    def test_modern_url_returned_unchanged(self):
+        """A non-hg URL (e.g. already on GitHub) is returned unchanged."""
+        url = "https://github.com/python/cpython/blob/v3.12.0/Misc/NEWS.d"
+        release = Release.objects.create(
+            version=Release.PYTHON3,
+            name="Python 3.12.0",
+            is_published=True,
+            release_notes_url=url,
+        )
+        self.assertEqual(release.corrected_release_notes_url, url)
+
+    def test_empty_url_returns_empty(self):
+        """An empty release_notes_url returns an empty string."""
+        release = Release.objects.create(
+            version=Release.PYTHON3,
+            name="Python 3.11.0",
+            is_published=True,
+            release_notes_url="",
+        )
+        self.assertEqual(release.corrected_release_notes_url, "")

--- a/apps/downloads/tests/test_models.py
+++ b/apps/downloads/tests/test_models.py
@@ -361,3 +361,29 @@ class ReleaseNotesURLTests(BaseDownloadTests):
             release_notes_url="",
         )
         self.assertEqual(release.corrected_release_notes_url, "")
+
+    def test_raw_file_hg_url_converted_to_github_raw(self):
+        """A raw-file hg.python.org URL is remapped to raw.githubusercontent.com."""
+        release = Release.objects.create(
+            version=Release.PYTHON2,
+            name="Python 2.7.3",
+            is_published=True,
+            release_notes_url="http://hg.python.org/cpython/raw-file/v2.7.3/Misc/NEWS",
+        )
+        self.assertEqual(
+            release.corrected_release_notes_url,
+            "https://raw.githubusercontent.com/python/cpython/v2.7.3/Misc/NEWS",
+        )
+
+    def test_https_raw_file_hg_url_also_converted(self):
+        """An https raw-file hg.python.org URL is also remapped to raw.githubusercontent.com."""
+        release = Release.objects.create(
+            version=Release.PYTHON2,
+            name="Python 2.6.9",
+            is_published=True,
+            release_notes_url="https://hg.python.org/cpython/raw-file/v2.6.9/Misc/NEWS",
+        )
+        self.assertEqual(
+            release.corrected_release_notes_url,
+            "https://raw.githubusercontent.com/python/cpython/v2.6.9/Misc/NEWS",
+        )


### PR DESCRIPTION
The "Release notes" links on the downloads page for Python 3.3.6 and earlier are broken — they point to hg.python.org which was retired and now returns 404.

Added a `corrected_release_notes_url` property to the `Release` model that checks whether a stored URL points to hg.python.org and, if so, remaps it to the equivalent path on GitHub. For example, `http://hg.python.org/cpython/file/v3.3.6/Misc/NEWS` becomes `https://github.com/python/cpython/blob/v3.3.6/Misc/NEWS`. The database field itself is left untouched so no migration is needed.

Also updated the downloads index template to use the corrected URL, and added a guard so releases with no URL at all render as plain text rather than an empty anchor.

Four tests added to `ReleaseNotesURLTests` covering the http and https hg variants, a modern URL that should pass through unchanged, and an empty URL.

Closes #2865