### PR TITLE
Remove old exclusions, use dependency cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,26 +3,10 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: docutils
-    versions:
-    - "0.16"
-    - "0.17"
-  - dependency-name: responses
-    versions:
-    - 0.12.1
-    - 0.13.0
-    - 0.13.1
-    - 0.13.2
-  - dependency-name: "boto3"
-  - dependency-name: "boto3-stubs"
-  - dependency-name: "botocore"
-  - dependency-name: "botocore-stubs"
-  - dependency-name: lxml
-    versions:
-    - 4.6.2
 - package-ecosystem: github-actions
   directory: "/"
   groups:
@@ -30,4 +14,6 @@ updates:
       patterns:
         - "*"  # Group all Actions updates into a single larger pull request
   schedule:
-    interval: daily
+    interval: weekly
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
Updates `dependabot.yml` config to use dependency cooldowns and removes all the exclusions as we'll be updating weekly instead of daily.