### PR TITLE
fix: prevent sponsor logo from overlapping section header text

### DIFF
--- a/apps/sponsors/templates/sponsors/partials/sponsors-list.html
+++ b/apps/sponsors/templates/sponsors/partials/sponsors-list.html
@@ -51,19 +51,19 @@
 
   {% for package, placement_info in sponsorships_by_package.items %}
   {% if placement_info.sponsorships %}
-  <div title="{{ package }} Sponsors" align="center">
+  <div title="{{ package }} Sponsors" align="center" style="{% if not forloop.last %}margin-bottom: 3rem;{% endif %}">
     {% with dimension=placement_info.logo_dimension %}
 
     <h1 style="font-size: {% if forloop.first %}350%{% else %}300%{% endif %}">{{ placement_info.label }} Sponsors</h1>
 
-    <div style="display: grid; grid-gap: 2em; grid-template-columns: repeat(auto-fit, minmax({{ dimension }}px, 0fr)); grid-template-rows: repeat(1, minmax({{ dimension }}px, 0fr)); align-items: center; justify-content: center;">
+    <div style="display: grid; gap: 2em; grid-template-columns: repeat(auto-fit, minmax({{ dimension }}px, 0fr)); align-items: center; justify-content: center;">
       {% for sponsorship in placement_info.sponsorships %}
         <div id="{{ sponsorship.sponsor.slug }}" data-internal-year={{ sponsorship.year }}>
             <div
                 data-ea-publisher="psf"
                 data-ea-type="psf-image-only"
                 data-ea-force-ad="{{ sponsorship.sponsor.slug }}-psf-sponsors"
-                style="max-width:{{ sponsorship.sponsor.web_logo|ideal_size:dimension }}px;height:auto;width:auto;"
+                style="max-width:{{ sponsorship.sponsor.web_logo|ideal_size:dimension }}px; max-height:{{ dimension }}px; overflow:hidden; height:auto; width:auto;"
             ></div>
             <p>{{ sponsorship.sponsor.name }}</p>
         </div>


### PR DESCRIPTION
Fixes #2887

Sponsor logos on /psf/sponsors/ were colliding with section header text.

Changes:
- Removed rigid `grid-template-rows` constraint allowing sponsor tiers to flow properly
- Added `margin-bottom: 3rem` on tier wrapper to prevent overlap between sections
- Added `max-height` and `overflow: hidden` on EthicalAds container to bound injected ads

