### PR TITLE
Keep 404 legacy links on the legacy host

### DIFF
--- a/apps/cms/tests.py
+++ b/apps/cms/tests.py
@@ -81,6 +81,9 @@ class Test404(TestCase):
     def test_legacy_path(self):
         self.assertEqual(legacy_path("/any/thing"), "http://legacy.python.org/any/thing")
 
+    def test_legacy_path_without_leading_slash(self):
+        self.assertEqual(legacy_path("any/thing"), "http://legacy.python.org/any/thing")
+
     def test_legacy_path_with_encoded_slash(self):
         self.assertEqual(legacy_path("/%2Fevil.test/x"), "http://legacy.python.org/%2Fevil.test/x")
 

--- a/apps/cms/tests.py
+++ b/apps/cms/tests.py
@@ -81,6 +81,12 @@ class Test404(TestCase):
     def test_legacy_path(self):
         self.assertEqual(legacy_path("/any/thing"), "http://legacy.python.org/any/thing")
 
+    def test_legacy_path_with_encoded_slash(self):
+        self.assertEqual(legacy_path("/%2Fevil.test/x"), "http://legacy.python.org/%2Fevil.test/x")
+
+    def test_legacy_path_with_decoded_encoded_slash(self):
+        self.assertEqual(legacy_path("//evil.test/x"), "http://legacy.python.org//evil.test/x")
+
     def test_custom_404(self):
         """Ensure custom 404 is set to 5 minutes"""
         response = self.client.get("/foo-bar/baz/9876")

--- a/apps/cms/views.py
+++ b/apps/cms/views.py
@@ -1,6 +1,6 @@
 """Views for the cms app, including custom error handlers."""
 
-from urllib.parse import urljoin
+from urllib.parse import quote
 
 from django.shortcuts import render
 from django.urls import reverse
@@ -11,7 +11,9 @@ PYPI_URL = "https://pypi.org/"
 
 def legacy_path(path):
     """Build a path to the same path under the legacy.python.org domain."""
-    return urljoin(LEGACY_PYTHON_DOMAIN, path)
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return f"{LEGACY_PYTHON_DOMAIN}{quote(path, safe='/%')}"
 
 
 def custom_404(request, exception, template_name="404.html"):


### PR DESCRIPTION
#### Description

- Build custom 404 legacy-site links by quoting the request path and appending
  it to the fixed `legacy.python.org` origin.
- Add focused regression tests for encoded-slash and decoded leading-slash
  paths.

#### Closes

- Closes #3013

#### Testing

- Focused 404 view/helper regression tests: passed.
- Focused Ruff lint and format checks on touched files: passed.
- Whitespace check: passed.
