### PR TITLE
Add a Content-Security-Policy in Report-Only mode (refs #3041)

### DIFF
--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -152,6 +152,7 @@ ROOT_URLCONF = "pydotorg.urls"
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "csp.middleware.CSPMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "pydotorg.middleware.AdminNoCaching",
     "pydotorg.middleware.GlobalSurrogateKey",
@@ -296,6 +297,25 @@ MESSAGE_TAGS = {
 
 X_FRAME_OPTIONS = "SAMEORIGIN"
 SILENCED_SYSTEM_CHECKS = ["security.W019"]
+
+### django-csp (Content-Security-Policy)
+
+# Report-Only first: collect violations and tune the allowlist before
+# enforcing. Rollout tracked in #3041.
+CONTENT_SECURITY_POLICY_REPORT_ONLY = {
+    "DIRECTIVES": {
+        "default-src": ["'self'"],
+        "script-src": ["'self'"],
+        "style-src": ["'self'"],
+        "img-src": ["'self'", "data:"],
+        "font-src": ["'self'"],
+        "connect-src": ["'self'"],
+        "frame-ancestors": ["'self'"],
+        "base-uri": ["'self'"],
+        "object-src": ["'none'"],
+        "form-action": ["'self'"],
+    },
+}
 
 ### django-rest-framework
 

--- a/pydotorg/settings/base.py
+++ b/pydotorg/settings/base.py
@@ -298,8 +298,10 @@ MESSAGE_TAGS = {
 X_FRAME_OPTIONS = "SAMEORIGIN"
 SILENCED_SYSTEM_CHECKS = ["security.W019"]
 
-### django-csp (Content-Security-Policy)
+### Content Security Policy, via django-csp
 
+# Django 6.0 ships built-in CSP support; drop django-csp and this setting
+# and use the framework's own CSP once we upgrade.
 # Report-Only first: collect violations and tune the allowlist before
 # enforcing. Rollout tracked in #3041.
 CONTENT_SECURITY_POLICY_REPORT_ONLY = {

--- a/pydotorg/tests/test_middleware.py
+++ b/pydotorg/tests/test_middleware.py
@@ -12,6 +12,12 @@ class MiddlewareTests(TestCase):
         self.assertTrue(response.has_header("Cache-Control"))
         self.assertEqual(response["Cache-Control"], "private")
 
+    def test_csp_report_only_header(self):
+        """CSP ships in Report-Only mode; the enforcing header must not be set."""
+        response = self.client.get("/admin/")
+        self.assertTrue(response.has_header("Content-Security-Policy-Report-Only"))
+        self.assertFalse(response.has_header("Content-Security-Policy"))
+
     def test_redirects(self):
         """
         More of a sanity check just in case some other middleware interferes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 requires-python = ">=3.14"
 dependencies = [
     "dj-database-url==0.5.0",
+    "django-csp==4.0",
     "django-pipeline==4.1.0",
     "django-sitetree==1.18.0",
     "django-apptemplates==1.5",

--- a/uv.lock
+++ b/uv.lock
@@ -479,6 +479,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-csp"
+version = "4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/db/23567744dff2169aadb095f726088074476b24dfff5a759ffcf6389cf401/django_csp-4.0.tar.gz", hash = "sha256:b27010bb702eb20a3dad329178df2b61a2b82d338b70fbdc13c3a3bd28712833", size = 20028, upload-time = "2025-04-02T16:41:46.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/a4/736ab90ee527a23e194d1ce7358c6bcced66381ced83c28268b4aea236f7/django_csp-4.0-py3-none-any.whl", hash = "sha256:d5a0a05463a6b75a4f1fc1828c58c89af8db9364d09fc6e12f122b4d7f3d00dc", size = 25689, upload-time = "2025-04-02T16:41:45.689Z" },
+]
+
+[[package]]
 name = "django-debug-toolbar"
 version = "6.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1258,6 +1271,7 @@ dependencies = [
     { name = "django-apptemplates" },
     { name = "django-celery-beat" },
     { name = "django-countries" },
+    { name = "django-csp" },
     { name = "django-extensions" },
     { name = "django-filter" },
     { name = "django-haystack" },
@@ -1337,6 +1351,7 @@ requires-dist = [
     { name = "django-apptemplates", specifier = "==1.5" },
     { name = "django-celery-beat", specifier = "==2.8.1" },
     { name = "django-countries", specifier = "==8.2.0" },
+    { name = "django-csp", specifier = "==4.0" },
     { name = "django-extensions", specifier = "==3.2.3" },
     { name = "django-filter", specifier = "==25.1" },
     { name = "django-haystack", specifier = "==3.3.0" },


### PR DESCRIPTION
Part of #3041 (adds the CSP in Report-Only mode; enforcing and origin tuning to follow).

## What this does

www.python.org currently sends no `Content-Security-Policy` header. This adds one via [`django-csp`](https://github.com/mozilla/django-csp) as defense-in-depth against XSS.

It ships in **Report-Only** mode: responses carry `Content-Security-Policy-Report-Only` and no enforcing `Content-Security-Policy`, so nothing is blocked for users. The point of this first step is to collect violation reports and tune the allowlist before switching to an enforced policy.

## Changes

- `pyproject.toml` / `uv.lock`: add `django-csp==4.0`.
- `pydotorg/settings/base.py`:
  - add `csp.middleware.CSPMiddleware` to `MIDDLEWARE`, alongside the existing `XFrameOptionsMiddleware` (which is how the site already sets a security header from Django).
  - add a `CONTENT_SECURITY_POLICY_REPORT_ONLY` policy with a strict starting set of directives.

## Starting policy

```
default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:;
font-src 'self'; connect-src 'self'; frame-ancestors 'self'; base-uri 'self';
object-src 'none'; form-action 'self'
```

These are intentionally strict so the Report-Only telemetry surfaces every inline script/style and third-party origin that needs a nonce, hash, or allowlist entry. Follow-ups from #3041: add a report endpoint, tune the origins, wire nonces into the base templates, then flip Report-Only to enforcing.

## Verification

Smoke-tested the config against django-csp 4.0 in isolation: it emits the `Content-Security-Policy-Report-Only` header with the directives above and no enforcing `Content-Security-Policy` header, so pages are never blocked.
