### PR TITLE
Fix: Correct broken link to contributing guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Fork the repo, create a branch, and open a pull request. Before submitting:
 CI runs on every PR — it checks for ungenerated migrations and enforces a 75%
 test coverage minimum. PRs that fail CI won't be merged.
 
-See the full [contributing guide](https://pythondotorg.readthedocs.io/en/latest/contributing.html) for details.
+See the full [contributing guide](https://github.com/python/pythondotorg/blob/main/CONTRIBUTING.md) for details.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Fork the repo, create a branch, and open a pull request. Before submitting:
 CI runs on every PR — it checks for ungenerated migrations and enforces a 75%
 test coverage minimum. PRs that fail CI won't be merged.
 
-See the full [contributing guide](https://github.com/python/pythondotorg/blob/main/CONTRIBUTING.md) for details.
+See the full [contributing guide](https://pythondotorg.readthedocs.io/contributing.html) for details.
 
 ### License
 


### PR DESCRIPTION
## Description
Fixed the broken link in README.md that pointed to outdated documentation.

## Changes
- Updated the contributing guide link in README.md to point to the correct documentation

## Related Issue
Fixes #3044
