### PR TITLE
Remove User.api_v2_token property

### DIFF
--- a/apps/downloads/tests/test_views.py
+++ b/apps/downloads/tests/test_views.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
 from apps.downloads.models import (
@@ -179,7 +180,8 @@ class BaseDownloadApiViewsTest(BaseDownloadTests, BaseAPITestCase):
             password="passworduser",
             is_staff=True,
         )
-        self.Authorization = f"Token {self.staff_user.api_v2_token}"
+        token = Token.objects.get(user=self.staff_user)
+        self.Authorization = f"Token {token.key}"
         self.Authorization_invalid = "Token invalid-token"
 
     def get_json(self, response):

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 from markupfield.fields import MarkupField
-from rest_framework.authtoken.models import Token
 from tastypie.models import create_api_key
 
 from apps.users.managers import UserManager
@@ -72,14 +71,6 @@ class User(AbstractUser):
         from apps.sponsors.models import Sponsorship
 
         return Sponsorship.objects.visible_to(self)
-
-    @property
-    def api_v2_token(self):
-        """Return the user's DRF API token key, or empty string if none exists."""
-        try:
-            return Token.objects.get(user=self).key
-        except Token.DoesNotExist:
-            return ""
 
 
 models.signals.post_save.connect(create_api_key, sender=User)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow the [PSF's Code of Conduct](https://www.python.org/psf/conduct/)
-->

#### Description

* Remove the `User.api_v2_token` property that returned the plaintext DRF API token.
* Remove the now-unused `Token` import from the user model.
* Update the download API tests to query the DRF `Token` model explicitly when constructing the authorization header.

This preserves the existing test authentication behavior while removing the plaintext token access path from the general-purpose `User` model.

Testing:

* `docker compose run --rm web uv run python manage.py test apps.downloads.tests.test_views`

  * 78 tests passed.
* `docker compose run --rm web uv run ruff format --check apps/users/models.py apps/downloads/tests/test_views.py`

  * 2 files already formatted.
* `docker compose run --rm web uv run ruff check --ignore EXE002 apps/users/models.py apps/downloads/tests/test_views.py`

  * All checks passed.

<!--
If applicable, please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Closes

* Fixes #3047
