### PR TITLE
Use https for external nav links and correct the Python News hint

### DIFF
--- a/fixtures/sitetree_menus.json
+++ b/fixtures/sitetree_menus.json
@@ -1189,7 +1189,7 @@
     "fields": {
         "title": "PSF Blog",
         "hint": "",
-        "url": "http://pyfound.blogspot.com/",
+        "url": "https://pyfound.blogspot.com/",
         "urlaspattern": false,
         "tree": 1,
         "hidden": false,
@@ -2076,13 +2076,13 @@
     "pk": 96,
     "fields": {
         "title": "Python News",
-        "hint": "Python Insider Blog Posts",
+        "hint": "Python news and blog posts",
         "url": "blog",
         "urlaspattern": true,
         "tree": 1,
         "hidden": false,
         "alias": null,
-        "description": "Python Insider is the blog used by the Python Core Developers to announce news related to the Python programming language.",
+        "description": "News about the Python programming language, including posts from Python Insider, the blog used by the Python Core Developers.",
         "inmenu": true,
         "inbreadcrumbs": true,
         "insitetree": true,
@@ -2101,7 +2101,7 @@
     "fields": {
         "title": "PSF News",
         "hint": "PSF Blog",
-        "url": "http://pyfound.blogspot.com/",
+        "url": "https://pyfound.blogspot.com/",
         "urlaspattern": false,
         "tree": 1,
         "hidden": false,
@@ -2125,7 +2125,7 @@
     "fields": {
         "title": "Community News",
         "hint": "Planet Python",
-        "url": "http://planetpython.org/",
+        "url": "https://planetpython.org/",
         "urlaspattern": false,
         "tree": 1,
         "hidden": false,
@@ -2149,7 +2149,7 @@
     "fields": {
         "title": "PyCon News",
         "hint": "PyCon Blog",
-        "url": "http://pycon.blogspot.com/",
+        "url": "https://pycon.blogspot.com/",
         "urlaspattern": false,
         "tree": 1,
         "hidden": false,
@@ -2389,7 +2389,7 @@
     "fields": {
         "title": "Self-certify as voting member",
         "hint": "",
-        "url": "http://pyfound.blogspot.de/2015/02/enroll-as-psf-voting-member.html",
+        "url": "https://pyfound.blogspot.com/2015/02/enroll-as-psf-voting-member.html",
         "urlaspattern": false,
         "tree": 1,
         "hidden": false,
@@ -2509,7 +2509,7 @@
     "fields": {
         "title": "Python Brochure",
         "hint": "",
-        "url": "http://brochure.getpython.info/",
+        "url": "https://brochure.getpython.info/",
         "urlaspattern": false,
         "tree": 1,
         "hidden": false,

--- a/fixtures/sitetree_menus.json
+++ b/fixtures/sitetree_menus.json
@@ -2097,6 +2097,30 @@
 },
 {
     "model": "sitetree.treeitem",
+    "pk": 126,
+    "fields": {
+        "title": "Python Insider",
+        "hint": "Python Insider Blog",
+        "url": "https://blog.python.org/",
+        "urlaspattern": false,
+        "tree": 1,
+        "hidden": false,
+        "alias": null,
+        "description": "Python Insider is the blog used by the Python Core Developers to announce news related to the Python programming language.",
+        "inmenu": true,
+        "inbreadcrumbs": true,
+        "insitetree": true,
+        "access_loggedin": false,
+        "access_guest": false,
+        "access_restricted": false,
+        "access_perm_type": 1,
+        "parent": 12,
+        "sort_order": 97,
+        "access_permissions": []
+    }
+},
+{
+    "model": "sitetree.treeitem",
     "pk": 97,
     "fields": {
         "title": "PSF News",
@@ -2115,7 +2139,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": 12,
-        "sort_order": 98,
+        "sort_order": 99,
         "access_permissions": []
     }
 },
@@ -2139,7 +2163,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": 12,
-        "sort_order": 97,
+        "sort_order": 98,
         "access_permissions": []
     }
 },
@@ -2163,7 +2187,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": 12,
-        "sort_order": 99,
+        "sort_order": 100,
         "access_permissions": []
     }
 },


### PR DESCRIPTION
Follow-up to an audit of the News dropdown in `fixtures/sitetree_menus.json`.

**Add Python Insider.** The News menu linked to the PSF, community and PyCon blogs, but not to `blog.python.org` itself. New item pk 126, "Python Insider", sits directly under "Python News". Its siblings shift by one sort_order, so the menu reads: Python News, Python Insider, Community News, PSF News, PyCon News.

**Scheme.** Every external navigation link used `http://` and redirected to `https://`. I verified each destination with curl and updated the six of them:

- pk 58 PSF Blog, pk 97 PSF News — `pyfound.blogspot.com`
- pk 98 Community News — `planetpython.org`
- pk 99 PyCon News — `pycon.blogspot.com`
- pk 109 Self-certify as voting member — used the `pyfound.blogspot.de` country domain, which redirects to `pyfound.blogspot.com`; now points straight at the final URL
- pk 114 Python Brochure — scheme only

**Wording.** The Python News item (pk 96) said "Python Insider Blog Posts" and described itself as the Core Developer blog. It points at `/blogs/`, which lists every imported feed, so PSF blog entries appear there as well. The hint and description now describe that. The old wording moves to the new Python Insider item, where it is accurate.

Note: `brochure.getpython.info` returns 503 over both schemes. That is a separate problem with the destination site, so I left the item in place.

These fixtures are seed data. Production navigation lives in the database, so it needs the same edits applied there.