### PR TITLE
Preserve sponsorship renewal on approval forms

### DIFF
--- a/apps/sponsors/tests/test_views_admin.py
+++ b/apps/sponsors/tests/test_views_admin.py
@@ -303,6 +303,9 @@ class ApproveSponsorshipAdminViewTests(TestCase):
         }
 
     def test_display_confirmation_form_on_get(self):
+        self.sponsorship.renewal = True
+        self.sponsorship.save(update_fields=["renewal"])
+
         response = self.client.get(self.url)
         context = response.context
         form = context["form"]
@@ -315,6 +318,7 @@ class ApproveSponsorshipAdminViewTests(TestCase):
         self.assertEqual(form.initial["start_date"], self.sponsorship.start_date)
         self.assertEqual(form.initial["end_date"], self.sponsorship.end_date)
         self.assertEqual(form.initial["sponsorship_fee"], self.sponsorship.sponsorship_fee)
+        self.assertTrue(form.initial["renewal"])
         self.assertNotEqual(self.sponsorship.status, Sponsorship.APPROVED)  # did not update
 
     def test_approve_sponsorship_on_post(self):
@@ -405,6 +409,9 @@ class ApproveSignedSponsorshipAdminViewTests(TestCase):
         }
 
     def test_display_confirmation_form_on_get(self):
+        self.sponsorship.renewal = True
+        self.sponsorship.save(update_fields=["renewal"])
+
         response = self.client.get(self.url)
         context = response.context
         form = context["form"]
@@ -417,6 +424,7 @@ class ApproveSignedSponsorshipAdminViewTests(TestCase):
         self.assertEqual(form.initial["start_date"], self.sponsorship.start_date)
         self.assertEqual(form.initial["end_date"], self.sponsorship.end_date)
         self.assertEqual(form.initial["sponsorship_fee"], self.sponsorship.sponsorship_fee)
+        self.assertTrue(form.initial["renewal"])
         self.assertNotEqual(self.sponsorship.status, Sponsorship.APPROVED)  # did not update
 
     def test_approve_sponsorship_and_execute_contract_on_post(self):

--- a/apps/sponsors/views_admin.py
+++ b/apps/sponsors/views_admin.py
@@ -83,6 +83,7 @@ def approve_sponsorship_view(model_admin, request, pk):
         "start_date": sponsorship.start_date,
         "end_date": sponsorship.end_date,
         "sponsorship_fee": sponsorship.sponsorship_fee,
+        "renewal": sponsorship.renewal,
     }
 
     form = SponsorshipReviewAdminForm(initial=initial, force_required=True)
@@ -119,6 +120,7 @@ def approve_signed_sponsorship_view(model_admin, request, pk):
         "start_date": sponsorship.start_date,
         "end_date": sponsorship.end_date,
         "sponsorship_fee": sponsorship.sponsorship_fee,
+        "renewal": sponsorship.renewal,
     }
 
     form = SignedSponsorshipReviewAdminForm(initial=initial, force_required=True)


### PR DESCRIPTION
#### Description

- Preserve a saved sponsorship renewal selection when opening either contract approval form.
- Add regression coverage for the generated-contract and existing-signed-contract paths.
- Tests: both approval view classes pass (16 tests); Ruff check and format check pass.

#### Closes

- Closes #2358
