### PR TITLE
Fix nominee visibility during open elections

### DIFF
--- a/apps/nominations/models.py
+++ b/apps/nominations/models.py
@@ -245,10 +245,13 @@ class Nominee(models.Model):
         if self.accepted and self.approved and not self.election.nominations_open:
             return True
 
-        if user is None:
+        if user is None or not user.is_authenticated:
             return False
 
-        return bool(user.is_staff or user == self.user)
+        if user.is_staff or user == self.user:
+            return True
+
+        return self.nominations.filter(election=self.election, nominator=user).exists()
 
 
 class Nomination(models.Model):

--- a/apps/nominations/tests/test_views.py
+++ b/apps/nominations/tests/test_views.py
@@ -112,6 +112,62 @@ class UnknownElectionSlugTests(TestCase):
         self.assertEqual(self.client.get(url).status_code, 404)
 
 
+class OpenNomineeVisibilityTests(TestCase):
+    def setUp(self):
+        self.nominator = UserFactory(first_name="Ada", last_name="Lovelace")
+        self.other_user = UserFactory()
+        self.election = open_election("2026 Board Election")
+        self.other_election = open_election("2027 Board Election")
+
+        self.nominated = Nominee.objects.create(
+            user=UserFactory(first_name="Grace", last_name="Hopper"),
+            election=self.election,
+        )
+        Nomination.objects.create(
+            election=self.election,
+            nominator=self.nominator,
+            nominee=self.nominated,
+            name="Grace Hopper",
+            email="grace@example.com",
+            nomination_statement="A strong candidate.",
+        )
+
+        self.own_candidacy = Nominee.objects.create(user=self.nominator, election=self.election)
+        Nomination.objects.create(
+            election=self.election,
+            nominator=self.other_user,
+            nominee=self.own_candidacy,
+            name=self.nominator.get_full_name(),
+            email=self.nominator.email,
+            nomination_statement="Another strong candidate.",
+        )
+
+        self.unrelated = Nominee.objects.create(user=UserFactory(), election=self.election)
+        self.other_election_candidacy = Nominee.objects.create(user=self.nominator, election=self.other_election)
+        self.client.force_login(self.nominator)
+
+    def _list_url(self):
+        return reverse("nominations:nominees_list", kwargs={"election": self.election.slug})
+
+    def test_list_shows_only_nominees_relevant_to_user_in_current_election(self):
+        response = self.client.get(self._list_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertCountEqual(response.context["object_list"], [self.nominated, self.own_candidacy])
+
+    def test_nominator_can_view_their_nominee_while_nominations_are_open(self):
+        response = self.client.get(self.nominated.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_unrelated_user_cannot_view_nominee_while_nominations_are_open(self):
+        self.client.force_login(self.other_user)
+
+        response = self.client.get(self.nominated.get_absolute_url())
+
+        self.assertEqual(response.status_code, 404)
+
+
 class NominationCreateFormSelectionTests(TestCase):
     def setUp(self):
         self.user = UserFactory()

--- a/apps/nominations/views.py
+++ b/apps/nominations/views.py
@@ -2,6 +2,7 @@
 
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.db.models import Q
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
@@ -72,7 +73,12 @@ class NomineeList(NominationMixin, ListView):
             return Nominee.objects.filter(accepted=True, approved=True, election=election).exclude(user=None)
 
         if self.request.user.is_authenticated:
-            return Nominee.objects.filter(user=self.request.user)
+            return (
+                Nominee.objects.filter(election=election)
+                .filter(Q(user=self.request.user) | Q(nominations__nominator=self.request.user))
+                .exclude(user=None)
+                .distinct()
+            )
         return None
 
 


### PR DESCRIPTION
## Summary

- scope the open-election nominee list to the election in the URL
- show both candidates nominated by the signed-in user and the user's own candidacy
- allow nominators to open nominee detail pages during the nomination window
- add regression coverage for election scoping and nominee-detail permissions

## Root cause

The authenticated-user branch in `NomineeList.get_queryset()` filtered only on `Nominee.user` and did not filter by election. This returned nominations *of* the user across election cycles instead of nominations the user had made in the current election. Separately, `Nominee.visible()` did not consider the nominator, so a candidate linked from the corrected list still returned 404.

## Validation

- `DATABASE_URL=sqlite:///:memory: uv run --group dev python manage.py test apps.nominations.tests` — 66 tests passed
- `ruff check apps/nominations/models.py apps/nominations/views.py apps/nominations/tests/test_views.py`
- `ruff format --check apps/nominations/models.py apps/nominations/views.py apps/nominations/tests/test_views.py`

Fixes #3094